### PR TITLE
chore: ignore env files in root gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,8 @@ build/
 *~
 
 # Environment
-.env
-.env.local
+/.env
+/.env.local
 
 # OS
 .DS_Store


### PR DESCRIPTION
Scope `.env` and `.env.local` ignores to the repo root (`/.env`, `/.env.local`) so that env files in subdirectories like `infra/.env` aren't accidentally ignored by git.