### PR TITLE
feat: add postgres container with datasets schema

### DIFF
--- a/infra/postgres/Dockerfile
+++ b/infra/postgres/Dockerfile
@@ -1,0 +1,2 @@
+FROM postgres:16
+COPY init.sql /docker-entrypoint-initdb.d/

--- a/infra/postgres/init.sql
+++ b/infra/postgres/init.sql
@@ -1,0 +1,9 @@
+CREATE TABLE datasets (
+    id          BIGSERIAL PRIMARY KEY,
+    created_at  TIMESTAMP(6) NOT NULL DEFAULT now(),
+    dataset_name    TEXT NOT NULL,
+    dataset_version TEXT NOT NULL,
+    timestamp       TIMESTAMP(6) NOT NULL,
+    data            JSONB NOT NULL,
+    UNIQUE (dataset_name, dataset_version, timestamp)
+);


### PR DESCRIPTION
Adds the Postgres container setup: a Dockerfile that extends postgres:16 and an init.sql that creates the `datasets` table with the timeseries schema (id, created_at, dataset_name, dataset_version, timestamp, data JSONB) and a unique constraint on (name, version, timestamp).