### PR TITLE
feat: add builder container dockerfile

### DIFF
--- a/infra/builder/Dockerfile
+++ b/infra/builder/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+COPY builders/server/pyproject.toml /app/
+RUN uv sync --no-dev
+
+COPY builders/server/ /app/
+
+ENTRYPOINT ["uv", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
Adds the builder server Dockerfile. Uses python:3.12-slim with uv for dependency management, copies the server code, and runs uvicorn on port 8000.