### PR TITLE
feat: add docker-compose and env config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ build/
 # Environment
 /.env
 /.env.local
+infra/.env
 
 # OS
 .DS_Store

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,27 @@
+services:
+  postgres:
+    build:
+      context: ./postgres
+    env_file: .env
+    ports:
+      - "5432:5432"
+    networks:
+      - internal
+
+  builder:
+    build:
+      context: ..
+      dockerfile: infra/builder/Dockerfile
+    env_file: .env
+    volumes:
+      - ../builders/scripts:/app/scripts
+    ports:
+      - "8000:8000"
+    depends_on:
+      - postgres
+    networks:
+      - internal
+
+networks:
+  internal:
+    driver: bridge


### PR DESCRIPTION
## Summary

- Add `docker-compose.yml` wiring up postgres and builder containers on a shared internal bridge network
- Builder container mounts `builders/scripts/` as a volume so scripts update without image rebuilds
- Add `.env` to `.gitignore` to keep credentials out of version control