### PR TITLE
feat: add builder server API and mock scripts

### DIFF
--- a/builders/scripts/mock-daily-close/0.1.0/builder.py
+++ b/builders/scripts/mock-daily-close/0.1.0/builder.py
@@ -1,0 +1,10 @@
+import pandas as pd
+
+
+def build(dependencies: dict[str, dict], timestamp: pd.Timestamp) -> dict:
+    """Extract the close price from the mock-ohlc dependency."""
+    ohlc = dependencies["mock-ohlc"]
+    return {
+        "ticker": ohlc["ticker"],
+        "close": ohlc["close"],
+    }

--- a/builders/scripts/mock-daily-close/0.1.0/config.toml
+++ b/builders/scripts/mock-daily-close/0.1.0/config.toml
@@ -1,0 +1,12 @@
+name = "mock-daily-close"
+version = "0.1.0"
+builder = "builder.py"
+calendar = "NYSE"
+granularity = "1d"
+
+[schema]
+ticker = "str"
+close = "float"
+
+[dependencies]
+mock-ohlc = "0.1.0"

--- a/builders/scripts/mock-ohlc/0.1.0/builder.py
+++ b/builders/scripts/mock-ohlc/0.1.0/builder.py
@@ -1,0 +1,17 @@
+import random
+
+import pandas as pd
+
+
+def build(dependencies: dict[str, dict], timestamp: pd.Timestamp) -> dict:
+    """Generate deterministic mock OHLC data for AAPL based on the timestamp."""
+    random.seed(str(timestamp))
+    base = round(random.uniform(100, 300), 2)
+
+    return {
+        "ticker": "AAPL",
+        "open": base,
+        "high": round(base + random.uniform(0, 50), 2),
+        "low": round(base - random.uniform(0, 30), 2),
+        "close": round(base + random.uniform(-10, 20), 2),
+    }

--- a/builders/scripts/mock-ohlc/0.1.0/config.toml
+++ b/builders/scripts/mock-ohlc/0.1.0/config.toml
@@ -1,0 +1,12 @@
+name = "mock-ohlc"
+version = "0.1.0"
+builder = "builder.py"
+calendar = "NYSE"
+granularity = "1d"
+
+[schema]
+ticker = "str"
+open = "float"
+high = "float"
+low = "float"
+close = "float"

--- a/builders/server/main.py
+++ b/builders/server/main.py
@@ -1,0 +1,109 @@
+import logging
+
+import pandas as pd
+from fastapi import FastAPI, HTTPException, Query
+
+import config
+import db
+import loader
+import runner
+import validator
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = FastAPI()
+
+GRANULARITY_MAP = {
+    "1s": "s",
+    "1m": "min",
+    "1h": "h",
+    "1d": "D",
+}
+
+
+def generate_timestamps(start: pd.Timestamp, end: pd.Timestamp, granularity: str) -> list[pd.Timestamp]:
+    """Generate all timestamps in [start, end] for the given granularity."""
+    freq = GRANULARITY_MAP.get(granularity)
+    if freq is None:
+        raise ValueError(f"Unsupported granularity: {granularity}")
+    return list(pd.date_range(start=start, end=end, freq=freq))
+
+
+@app.post("/build/{dataset_name}/{dataset_version}")
+def build(
+    dataset_name: str,
+    dataset_version: str,
+    start: str = Query(...),
+    end: str = Query(...),
+):
+    """Build missing data for a dataset in the given time range."""
+    try:
+        start_ts = pd.Timestamp(start)
+        end_ts = pd.Timestamp(end)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid start/end timestamp")
+
+    try:
+        _build_dataset(dataset_name, dataset_version, start_ts, end_ts)
+    except Exception as e:
+        logger.exception(f"Build failed for {dataset_name}/{dataset_version}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+    return {"status": "ok"}
+
+
+def _build_dataset(
+    dataset_name: str,
+    dataset_version: str,
+    start: pd.Timestamp,
+    end: pd.Timestamp,
+) -> None:
+    """Core build logic: resolve dependencies, build missing timestamps, insert rows."""
+    cfg = config.load_config(dataset_name, dataset_version)
+    dependencies = cfg.get("dependencies", {})
+    schema = cfg.get("schema", {})
+    granularity = cfg.get("granularity", "1d")
+
+    # Recursively build dependencies first
+    for dep_name, dep_version in dependencies.items():
+        _build_dataset(dep_name, dep_version, start, end)
+
+    # Determine which timestamps are missing
+    all_timestamps = generate_timestamps(start, end, granularity)
+    existing = set(db.get_existing_timestamps(dataset_name, dataset_version, start, end))
+    missing = [ts for ts in all_timestamps if ts not in existing]
+
+    if not missing:
+        logger.info(f"{dataset_name}/{dataset_version}: all timestamps present, skipping")
+        return
+
+    logger.info(f"{dataset_name}/{dataset_version}: building {len(missing)} missing timestamps")
+
+    # Load the builder function
+    build_fn = loader.load_builder(dataset_name, dataset_version)
+
+    # Build each missing timestamp
+    rows = []
+    for ts in missing:
+        # Fetch dependency data for this timestamp
+        dep_data = {}
+        for dep_name, dep_version in dependencies.items():
+            dep_rows = db.get_rows(dep_name, dep_version, [ts])
+            if ts not in dep_rows:
+                raise RuntimeError(
+                    f"Dependency '{dep_name}/{dep_version}' missing data for timestamp {ts}"
+                )
+            dep_data[dep_name] = dep_rows[ts]
+
+        # Run builder in subprocess
+        result = runner.run_builder(build_fn, dep_data, ts)
+
+        # Validate output against schema
+        validator.validate(result, schema)
+
+        rows.append((ts, result))
+
+    # Bulk insert all rows
+    db.insert_rows(dataset_name, dataset_version, rows)
+    logger.info(f"{dataset_name}/{dataset_version}: inserted {len(rows)} rows")


### PR DESCRIPTION
Adds the FastAPI server (main.py) with the POST /build endpoint that ties together config loading, dependency resolution, builder execution, validation, and DB insertion. Also adds two mock builder scripts (mock-ohlc and mock-daily-close) for testing the pipeline.