### PR TITLE
feat: add mock builder scripts

### DIFF
--- a/builders/scripts/mock-daily-close/0.1.0/builder.py
+++ b/builders/scripts/mock-daily-close/0.1.0/builder.py
@@ -1,0 +1,10 @@
+import pandas as pd
+
+
+def build(dependencies: dict[str, dict], timestamp: pd.Timestamp) -> dict:
+    """Extract the close price from the mock-ohlc dependency."""
+    ohlc = dependencies["mock-ohlc"]
+    return {
+        "ticker": ohlc["ticker"],
+        "close": ohlc["close"],
+    }

--- a/builders/scripts/mock-daily-close/0.1.0/config.toml
+++ b/builders/scripts/mock-daily-close/0.1.0/config.toml
@@ -1,0 +1,12 @@
+name = "mock-daily-close"
+version = "0.1.0"
+builder = "builder.py"
+calendar = "NYSE"
+granularity = "1d"
+
+[schema]
+ticker = "str"
+close = "float"
+
+[dependencies]
+mock-ohlc = "0.1.0"

--- a/builders/scripts/mock-ohlc/0.1.0/builder.py
+++ b/builders/scripts/mock-ohlc/0.1.0/builder.py
@@ -1,0 +1,17 @@
+import random
+
+import pandas as pd
+
+
+def build(dependencies: dict[str, dict], timestamp: pd.Timestamp) -> dict:
+    """Generate deterministic mock OHLC data for AAPL based on the timestamp."""
+    random.seed(str(timestamp))
+    base = round(random.uniform(100, 300), 2)
+
+    return {
+        "ticker": "AAPL",
+        "open": base,
+        "high": round(base + random.uniform(0, 50), 2),
+        "low": round(base - random.uniform(0, 30), 2),
+        "close": round(base + random.uniform(-10, 20), 2),
+    }

--- a/builders/scripts/mock-ohlc/0.1.0/config.toml
+++ b/builders/scripts/mock-ohlc/0.1.0/config.toml
@@ -1,0 +1,12 @@
+name = "mock-ohlc"
+version = "0.1.0"
+builder = "builder.py"
+calendar = "NYSE"
+granularity = "1d"
+
+[schema]
+ticker = "str"
+open = "float"
+high = "float"
+low = "float"
+close = "float"


### PR DESCRIPTION
Adds two mock builder scripts for local testing and development:

- **mock-ohlc** (root dataset): generates deterministic random OHLC data for AAPL, seeded by timestamp for reproducibility
- **mock-daily-close** (depends on mock-ohlc): extracts the close price from mock-ohlc, demonstrating the dependency system

Both include `config.toml` with schema definitions and proper granularity/calendar settings.