### PR TITLE
docs: Add comment style guidelines for non-doc strings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,8 @@ When explicitly instructed to make a pull request, use the Graphite skill to mak
 
 ## Code styling
 
+When writing comments other than documentation strings, do not capitalize the first letter of sentences, and do not write in sentence form
+
 In Rust:
 - Always document every function to give at least a brief explanation of what its purpose is.
     - Prioritize shorter documentation unless more complicated design is invovled.


### PR DESCRIPTION
Added a new code styling guideline for comments. Comments (other than documentation strings) should not capitalize the first letter and should not be written in sentence form. This keeps them consistent with the rest of the codebase and maintains a uniform style.