### PR TITLE
feat: add CLI trigger for builder server

### DIFF
--- a/trigger.py
+++ b/trigger.py
@@ -1,0 +1,34 @@
+"""MVP CLI trigger for the builder server.
+
+Usage:
+    python trigger.py <dataset_name> <dataset_version> <start> <end>
+
+Example:
+    python trigger.py mock-ohlc 0.1.0 2024-01-01 2024-01-31
+"""
+
+import sys
+
+import requests
+
+
+def main():
+    if len(sys.argv) != 5:
+        print(f"Usage: {sys.argv[0]} <dataset_name> <dataset_version> <start> <end>")
+        sys.exit(1)
+
+    dataset_name, dataset_version, start, end = sys.argv[1:]
+    url = f"http://localhost:8000/build/{dataset_name}/{dataset_version}"
+
+    print(f"Triggering build: {dataset_name}/{dataset_version} [{start}, {end}]")
+    resp = requests.post(url, params={"start": start, "end": end})
+
+    if resp.ok:
+        print(f"Success: {resp.json()}")
+    else:
+        print(f"Error ({resp.status_code}): {resp.text}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
adds a simple python CLI script to manually trigger the builder server for a given dataset and date range.

useful for local testing and one-off backfills without needing to write curl commands by hand.

**usage:**
```
python trigger.py <dataset_name> <dataset_version> <start> <end>
```