### PR TITLE
chore: format python files with ruff

### DIFF
--- a/builders/server/config.py
+++ b/builders/server/config.py
@@ -9,9 +9,13 @@ def validate_config(config: dict, dataset_name: str, dataset_version: str) -> No
 
     # TODO (bryan): validate the existence of other fields in the config toml such as builder, calender, granularity, schema
     if "name" not in config:
-        raise ValueError(f"config.toml for {dataset_name}/{dataset_version} is missing 'name' field")
+        raise ValueError(
+            f"config.toml for {dataset_name}/{dataset_version} is missing 'name' field"
+        )
     if "version" not in config:
-        raise ValueError(f"config.toml for {dataset_name}/{dataset_version} is missing 'version' field")
+        raise ValueError(
+            f"config.toml for {dataset_name}/{dataset_version} is missing 'version' field"
+        )
 
     if config["name"] != dataset_name:
         raise ValueError(

--- a/builders/server/db.py
+++ b/builders/server/db.py
@@ -55,7 +55,12 @@ def insert_rows(
             VALUES %s
             """,
             [
-                (dataset_name, dataset_version, ts.to_pydatetime(), psycopg2.extras.Json(data))
+                (
+                    dataset_name,
+                    dataset_version,
+                    ts.to_pydatetime(),
+                    psycopg2.extras.Json(data),
+                )
                 for ts, data in rows
             ],
         )

--- a/builders/server/main.py
+++ b/builders/server/main.py
@@ -22,7 +22,9 @@ GRANULARITY_MAP = {
 }
 
 
-def generate_timestamps(start: pd.Timestamp, end: pd.Timestamp, granularity: str) -> list[pd.Timestamp]:
+def generate_timestamps(
+    start: pd.Timestamp, end: pd.Timestamp, granularity: str
+) -> list[pd.Timestamp]:
     """Generate all timestamps in [start, end] for the given granularity."""
     freq = GRANULARITY_MAP.get(granularity)
     if freq is None:
@@ -71,14 +73,20 @@ def _build_dataset(
 
     # Determine which timestamps are missing
     all_timestamps = generate_timestamps(start, end, granularity)
-    existing = set(db.get_existing_timestamps(dataset_name, dataset_version, start, end))
+    existing = set(
+        db.get_existing_timestamps(dataset_name, dataset_version, start, end)
+    )
     missing = [ts for ts in all_timestamps if ts not in existing]
 
     if not missing:
-        logger.info(f"{dataset_name}/{dataset_version}: all timestamps present, skipping")
+        logger.info(
+            f"{dataset_name}/{dataset_version}: all timestamps present, skipping"
+        )
         return
 
-    logger.info(f"{dataset_name}/{dataset_version}: building {len(missing)} missing timestamps")
+    logger.info(
+        f"{dataset_name}/{dataset_version}: building {len(missing)} missing timestamps"
+    )
 
     # Load the builder function
     build_fn = loader.load_builder(dataset_name, dataset_version)

--- a/builders/server/runner.py
+++ b/builders/server/runner.py
@@ -9,7 +9,12 @@ STATUS_OK = "ok"
 STATUS_ERROR = "error"
 
 
-def _worker(build_fn: Callable, dependencies: dict, timestamp: pd.Timestamp, queue: multiprocessing.Queue):
+def _worker(
+    build_fn: Callable,
+    dependencies: dict,
+    timestamp: pd.Timestamp,
+    queue: multiprocessing.Queue,
+):
     """Subprocess target that runs the builder and puts the result in the queue."""
     try:
         result = build_fn(dependencies, timestamp)
@@ -18,23 +23,31 @@ def _worker(build_fn: Callable, dependencies: dict, timestamp: pd.Timestamp, que
         queue.put((STATUS_ERROR, str(e)))
 
 
-def run_builder(build_fn: Callable, dependencies: dict, timestamp: pd.Timestamp) -> dict:
+def run_builder(
+    build_fn: Callable, dependencies: dict, timestamp: pd.Timestamp
+) -> dict:
     """Run a builder function in an isolated subprocess and return its result."""
 
     # note: there is a performance overhead of using a multiprocessing queue as data has
     # to be serialized when passed between processes
     queue = multiprocessing.Queue()
-    proc = multiprocessing.Process(target=_worker, args=(build_fn, dependencies, timestamp, queue))
+    proc = multiprocessing.Process(
+        target=_worker, args=(build_fn, dependencies, timestamp, queue)
+    )
     proc.start()
     proc.join(timeout=TIMEOUT_SECONDS)
 
     if proc.is_alive():
         proc.kill()
         proc.join()
-        raise RuntimeError(f"Builder timed out after {TIMEOUT_SECONDS}s for timestamp {timestamp}")
+        raise RuntimeError(
+            f"Builder timed out after {TIMEOUT_SECONDS}s for timestamp {timestamp}"
+        )
 
     if queue.empty():
-        raise RuntimeError(f"Builder subprocess crashed without returning a result for timestamp {timestamp}")
+        raise RuntimeError(
+            f"Builder subprocess crashed without returning a result for timestamp {timestamp}"
+        )
 
     status, payload = queue.get()
     if status == STATUS_ERROR:

--- a/builders/server/tests/conftest.py
+++ b/builders/server/tests/conftest.py
@@ -10,6 +10,7 @@ def mock_scripts_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     scripts.mkdir()
     import config
     import loader
+
     monkeypatch.setattr(config, "SCRIPTS_DIR", scripts)
     monkeypatch.setattr(loader, "SCRIPTS_DIR", scripts)
     return scripts
@@ -18,20 +19,28 @@ def mock_scripts_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 @pytest.fixture
 def write_config(tmp_path: Path) -> Callable[[Path, str, str, str], Path]:
     """Factory fixture to write config.toml files under the scripts dir."""
-    def _write(scripts_dir: Path, dataset_name: str, dataset_version: str, content: str) -> Path:
+
+    def _write(
+        scripts_dir: Path, dataset_name: str, dataset_version: str, content: str
+    ) -> Path:
         d = scripts_dir / dataset_name / dataset_version
         d.mkdir(parents=True, exist_ok=True)
         (d / "config.toml").write_text(content)
         return d
+
     return _write
 
 
 @pytest.fixture
 def write_builder(tmp_path: Path) -> Callable[[Path, str, str, str], Path]:
     """Factory fixture to write builder.py files under the scripts dir."""
-    def _write(scripts_dir: Path, dataset_name: str, dataset_version: str, content: str) -> Path:
+
+    def _write(
+        scripts_dir: Path, dataset_name: str, dataset_version: str, content: str
+    ) -> Path:
         d = scripts_dir / dataset_name / dataset_version
         d.mkdir(parents=True, exist_ok=True)
         (d / "builder.py").write_text(content)
         return d
+
     return _write

--- a/builders/server/tests/test_config.py
+++ b/builders/server/tests/test_config.py
@@ -7,12 +7,17 @@ import config
 
 def test_load_valid_config(mock_scripts_dir: Path, write_config: Callable) -> None:
     """Valid config.toml returns correct dict."""
-    write_config(mock_scripts_dir, "my-dataset", "0.1.0", """
+    write_config(
+        mock_scripts_dir,
+        "my-dataset",
+        "0.1.0",
+        """
 name = "my-dataset"
 version = "0.1.0"
 builder = "builder.py"
 granularity = "1d"
-""")
+""",
+    )
     cfg = config.load_config("my-dataset", "0.1.0")
     assert cfg["name"] == "my-dataset"
     assert cfg["version"] == "0.1.0"
@@ -25,67 +30,109 @@ def test_load_config_missing_file_raises(mock_scripts_dir: Path) -> None:
         config.load_config("nonexistent", "0.0.1")
 
 
-def test_load_config_missing_name_field(mock_scripts_dir: Path, write_config: Callable) -> None:
+def test_load_config_missing_name_field(
+    mock_scripts_dir: Path, write_config: Callable
+) -> None:
     """Config without name raises ValueError."""
-    write_config(mock_scripts_dir, "ds", "0.1.0", """
+    write_config(
+        mock_scripts_dir,
+        "ds",
+        "0.1.0",
+        """
 version = "0.1.0"
-""")
+""",
+    )
     with pytest.raises(ValueError, match="missing 'name' field"):
         config.load_config("ds", "0.1.0")
 
 
-def test_load_config_missing_version_field(mock_scripts_dir: Path, write_config: Callable) -> None:
+def test_load_config_missing_version_field(
+    mock_scripts_dir: Path, write_config: Callable
+) -> None:
     """Config without version raises ValueError."""
-    write_config(mock_scripts_dir, "ds", "0.1.0", """
+    write_config(
+        mock_scripts_dir,
+        "ds",
+        "0.1.0",
+        """
 name = "ds"
-""")
+""",
+    )
     with pytest.raises(ValueError, match="missing 'version' field"):
         config.load_config("ds", "0.1.0")
 
 
-def test_load_config_name_mismatch(mock_scripts_dir: Path, write_config: Callable) -> None:
+def test_load_config_name_mismatch(
+    mock_scripts_dir: Path, write_config: Callable
+) -> None:
     """Name doesn't match dir raises ValueError."""
-    write_config(mock_scripts_dir, "ds", "0.1.0", """
+    write_config(
+        mock_scripts_dir,
+        "ds",
+        "0.1.0",
+        """
 name = "wrong-name"
 version = "0.1.0"
-""")
+""",
+    )
     with pytest.raises(ValueError, match="does not match"):
         config.load_config("ds", "0.1.0")
 
 
-def test_load_config_version_mismatch(mock_scripts_dir: Path, write_config: Callable) -> None:
+def test_load_config_version_mismatch(
+    mock_scripts_dir: Path, write_config: Callable
+) -> None:
     """Version doesn't match dir raises ValueError."""
-    write_config(mock_scripts_dir, "ds", "0.1.0", """
+    write_config(
+        mock_scripts_dir,
+        "ds",
+        "0.1.0",
+        """
 name = "ds"
 version = "9.9.9"
-""")
+""",
+    )
     with pytest.raises(ValueError, match="does not match"):
         config.load_config("ds", "0.1.0")
 
 
-def test_load_config_with_dependencies(mock_scripts_dir: Path, write_config: Callable) -> None:
+def test_load_config_with_dependencies(
+    mock_scripts_dir: Path, write_config: Callable
+) -> None:
     """Dependencies section parsed correctly."""
-    write_config(mock_scripts_dir, "ds", "0.1.0", """
+    write_config(
+        mock_scripts_dir,
+        "ds",
+        "0.1.0",
+        """
 name = "ds"
 version = "0.1.0"
 
 [dependencies]
 dep-a = "0.0.2"
 dep-b = "1.0.0"
-""")
+""",
+    )
     cfg = config.load_config("ds", "0.1.0")
     assert cfg["dependencies"] == {"dep-a": "0.0.2", "dep-b": "1.0.0"}
 
 
-def test_load_config_with_schema(mock_scripts_dir: Path, write_config: Callable) -> None:
+def test_load_config_with_schema(
+    mock_scripts_dir: Path, write_config: Callable
+) -> None:
     """Schema section parsed correctly."""
-    write_config(mock_scripts_dir, "ds", "0.1.0", """
+    write_config(
+        mock_scripts_dir,
+        "ds",
+        "0.1.0",
+        """
 name = "ds"
 version = "0.1.0"
 
 [schema]
 ticker = "str"
 price = "int"
-""")
+""",
+    )
     cfg = config.load_config("ds", "0.1.0")
     assert cfg["schema"] == {"ticker": "str", "price": "int"}

--- a/builders/server/tests/test_db.py
+++ b/builders/server/tests/test_db.py
@@ -15,7 +15,9 @@ def reset_pool() -> Generator[None, None, None]:
 
 
 @patch("db.psycopg2.connect")
-def test_get_conn_reads_database_url(mock_connect: MagicMock, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_conn_reads_database_url(
+    mock_connect: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Connects using DATABASE_URL env var."""
     monkeypatch.setenv("DATABASE_URL", "postgresql://test:test@localhost/test")
     mock_conn = MagicMock()
@@ -28,7 +30,9 @@ def test_get_conn_reads_database_url(mock_connect: MagicMock, monkeypatch: pytes
 
 
 @patch("db.psycopg2.connect")
-def test_get_conn_reuses_connection(mock_connect: MagicMock, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_conn_reuses_connection(
+    mock_connect: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Second call reuses existing connection."""
     monkeypatch.setenv("DATABASE_URL", "postgresql://test:test@localhost/test")
     mock_conn = MagicMock()
@@ -41,7 +45,9 @@ def test_get_conn_reuses_connection(mock_connect: MagicMock, monkeypatch: pytest
 
 
 @patch("db.psycopg2.connect")
-def test_get_conn_reconnects_when_closed(mock_connect: MagicMock, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_conn_reconnects_when_closed(
+    mock_connect: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Reconnects if connection is closed."""
     monkeypatch.setenv("DATABASE_URL", "postgresql://test:test@localhost/test")
     mock_conn1 = MagicMock()
@@ -71,7 +77,9 @@ def test_get_existing_timestamps(mock_get_conn: MagicMock) -> None:
     mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
     mock_get_conn.return_value = mock_conn
 
-    result = db.get_existing_timestamps("ds", "0.1.0", pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-31"))
+    result = db.get_existing_timestamps(
+        "ds", "0.1.0", pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-31")
+    )
     assert len(result) == 2
     assert result[0] == pd.Timestamp("2024-01-01")
     assert result[1] == pd.Timestamp("2024-01-02")
@@ -87,7 +95,9 @@ def test_get_existing_timestamps_empty(mock_get_conn: MagicMock) -> None:
     mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
     mock_get_conn.return_value = mock_conn
 
-    result = db.get_existing_timestamps("ds", "0.1.0", pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-31"))
+    result = db.get_existing_timestamps(
+        "ds", "0.1.0", pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-31")
+    )
     assert result == []
 
 
@@ -100,7 +110,9 @@ def test_insert_rows_empty_returns_early(mock_get_conn: MagicMock) -> None:
 
 @patch("db.execute_values")
 @patch("db.get_conn")
-def test_insert_rows_calls_execute_values(mock_get_conn: MagicMock, mock_exec_values: MagicMock) -> None:
+def test_insert_rows_calls_execute_values(
+    mock_get_conn: MagicMock, mock_exec_values: MagicMock
+) -> None:
     """Verify execute_values is called with correct SQL and args."""
     mock_cursor = MagicMock()
     mock_conn = MagicMock()

--- a/builders/server/tests/test_loader.py
+++ b/builders/server/tests/test_loader.py
@@ -6,33 +6,54 @@ import pytest
 import loader
 
 
-def test_load_builder_returns_callable(mock_scripts_dir: Path, write_builder: Callable) -> None:
+def test_load_builder_returns_callable(
+    mock_scripts_dir: Path, write_builder: Callable
+) -> None:
     """Returns a callable."""
-    write_builder(mock_scripts_dir, "ds", "0.1.0", """
+    write_builder(
+        mock_scripts_dir,
+        "ds",
+        "0.1.0",
+        """
 def build(dependencies, timestamp):
     return {"value": 1}
-""")
+""",
+    )
     fn = loader.load_builder("ds", "0.1.0")
     assert callable(fn)
 
 
-def test_load_builder_function_works(mock_scripts_dir: Path, write_builder: Callable) -> None:
+def test_load_builder_function_works(
+    mock_scripts_dir: Path, write_builder: Callable
+) -> None:
     """Returned function produces correct output."""
-    write_builder(mock_scripts_dir, "ds", "0.1.0", """
+    write_builder(
+        mock_scripts_dir,
+        "ds",
+        "0.1.0",
+        """
 def build(dependencies, timestamp):
     return {"ticker": "AAPL", "price": 42}
-""")
+""",
+    )
     fn = loader.load_builder("ds", "0.1.0")
     result = fn({}, None)
     assert result == {"ticker": "AAPL", "price": 42}
 
 
-def test_load_builder_adds_to_sys_path(mock_scripts_dir: Path, write_builder: Callable) -> None:
+def test_load_builder_adds_to_sys_path(
+    mock_scripts_dir: Path, write_builder: Callable
+) -> None:
     """Script dir is added to sys.path."""
-    write_builder(mock_scripts_dir, "ds", "0.1.0", """
+    write_builder(
+        mock_scripts_dir,
+        "ds",
+        "0.1.0",
+        """
 def build(dependencies, timestamp):
     return {}
-""")
+""",
+    )
     loader.load_builder("ds", "0.1.0")
     script_dir = str(mock_scripts_dir / "ds" / "0.1.0")
     assert script_dir in sys.path
@@ -46,27 +67,41 @@ def test_load_builder_missing_file_raises(mock_scripts_dir: Path) -> None:
         loader.load_builder("ds", "0.1.0")
 
 
-def test_load_builder_missing_build_function(mock_scripts_dir: Path, write_builder: Callable) -> None:
+def test_load_builder_missing_build_function(
+    mock_scripts_dir: Path, write_builder: Callable
+) -> None:
     """Builder.py without build function raises AttributeError."""
-    write_builder(mock_scripts_dir, "ds", "0.1.0", """
+    write_builder(
+        mock_scripts_dir,
+        "ds",
+        "0.1.0",
+        """
 def not_build():
     pass
-""")
+""",
+    )
     with pytest.raises(AttributeError):
         loader.load_builder("ds", "0.1.0")
 
 
-def test_load_builder_with_relative_import(mock_scripts_dir: Path, write_builder: Callable) -> None:
+def test_load_builder_with_relative_import(
+    mock_scripts_dir: Path, write_builder: Callable
+) -> None:
     """Builder that imports from a sibling module works."""
     d = mock_scripts_dir / "ds" / "0.1.0"
     d.mkdir(parents=True, exist_ok=True)
     (d / "helper.py").write_text("VALUE = 99\n")
-    write_builder(mock_scripts_dir, "ds", "0.1.0", """
+    write_builder(
+        mock_scripts_dir,
+        "ds",
+        "0.1.0",
+        """
 import helper
 
 def build(dependencies, timestamp):
     return {"value": helper.VALUE}
-""")
+""",
+    )
     fn = loader.load_builder("ds", "0.1.0")
     result = fn({}, None)
     assert result == {"value": 99}

--- a/builders/server/tests/test_main.py
+++ b/builders/server/tests/test_main.py
@@ -11,9 +11,12 @@ client: TestClient = TestClient(app)
 
 # --- generate_timestamps tests ---
 
+
 def test_generate_timestamps_1d() -> None:
     """Daily over 3 days returns 3 timestamps."""
-    result = generate_timestamps(pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-03"), "1d")
+    result = generate_timestamps(
+        pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-03"), "1d"
+    )
     assert len(result) == 3
     assert result[0] == pd.Timestamp("2024-01-01")
     assert result[-1] == pd.Timestamp("2024-01-03")
@@ -21,41 +24,54 @@ def test_generate_timestamps_1d() -> None:
 
 def test_generate_timestamps_1h() -> None:
     """Hourly frequency works."""
-    result = generate_timestamps(pd.Timestamp("2024-01-01 00:00"), pd.Timestamp("2024-01-01 02:00"), "1h")
+    result = generate_timestamps(
+        pd.Timestamp("2024-01-01 00:00"), pd.Timestamp("2024-01-01 02:00"), "1h"
+    )
     assert len(result) == 3
 
 
 def test_generate_timestamps_1m() -> None:
     """Minute frequency works."""
-    result = generate_timestamps(pd.Timestamp("2024-01-01 00:00"), pd.Timestamp("2024-01-01 00:05"), "1m")
+    result = generate_timestamps(
+        pd.Timestamp("2024-01-01 00:00"), pd.Timestamp("2024-01-01 00:05"), "1m"
+    )
     assert len(result) == 6
 
 
 def test_generate_timestamps_1s() -> None:
     """Second frequency works."""
-    result = generate_timestamps(pd.Timestamp("2024-01-01 00:00:00"), pd.Timestamp("2024-01-01 00:00:03"), "1s")
+    result = generate_timestamps(
+        pd.Timestamp("2024-01-01 00:00:00"), pd.Timestamp("2024-01-01 00:00:03"), "1s"
+    )
     assert len(result) == 4
 
 
 def test_generate_timestamps_unsupported_granularity() -> None:
     """Raises ValueError for unsupported granularity."""
     with pytest.raises(ValueError, match="Unsupported granularity"):
-        generate_timestamps(pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-02"), "1w")
+        generate_timestamps(
+            pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-02"), "1w"
+        )
 
 
 def test_generate_timestamps_same_start_end() -> None:
     """Returns single timestamp when start equals end."""
-    result = generate_timestamps(pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-01"), "1d")
+    result = generate_timestamps(
+        pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-01"), "1d"
+    )
     assert len(result) == 1
 
 
 def test_generate_timestamps_end_before_start() -> None:
     """Returns empty list when end is before start."""
-    result = generate_timestamps(pd.Timestamp("2024-01-03"), pd.Timestamp("2024-01-01"), "1d")
+    result = generate_timestamps(
+        pd.Timestamp("2024-01-03"), pd.Timestamp("2024-01-01"), "1d"
+    )
     assert len(result) == 0
 
 
 # --- endpoint tests ---
+
 
 @patch("main._build_dataset")
 def test_build_endpoint_success(mock_build: MagicMock) -> None:
@@ -81,21 +97,30 @@ def test_build_endpoint_internal_error(mock_build: MagicMock) -> None:
 
 # --- _build_dataset tests ---
 
+
 @patch("main.db")
 @patch("main.config")
-def test_build_dataset_skips_existing(mock_config: MagicMock, mock_db: MagicMock) -> None:
+def test_build_dataset_skips_existing(
+    mock_config: MagicMock, mock_db: MagicMock
+) -> None:
     """All timestamps exist, runner never called."""
     mock_config.load_config.return_value = {
-        "name": "ds", "version": "0.1.0", "granularity": "1d",
+        "name": "ds",
+        "version": "0.1.0",
+        "granularity": "1d",
     }
     # All timestamps already exist
     mock_db.get_existing_timestamps.return_value = [
-        pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-02"),
+        pd.Timestamp("2024-01-01"),
+        pd.Timestamp("2024-01-02"),
     ]
 
     from main import _build_dataset
+
     with patch("main.runner") as mock_runner:
-        _build_dataset("ds", "0.1.0", pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-02"))
+        _build_dataset(
+            "ds", "0.1.0", pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-02")
+        )
         mock_runner.run_builder.assert_not_called()
     mock_db.insert_rows.assert_not_called()
 
@@ -105,17 +130,28 @@ def test_build_dataset_skips_existing(mock_config: MagicMock, mock_db: MagicMock
 @patch("main.loader")
 @patch("main.db")
 @patch("main.config")
-def test_build_dataset_builds_missing(mock_config: MagicMock, mock_db: MagicMock, mock_loader: MagicMock, mock_runner: MagicMock, mock_validator: MagicMock) -> None:
+def test_build_dataset_builds_missing(
+    mock_config: MagicMock,
+    mock_db: MagicMock,
+    mock_loader: MagicMock,
+    mock_runner: MagicMock,
+    mock_validator: MagicMock,
+) -> None:
     """Missing timestamps trigger runner + insert."""
     mock_config.load_config.return_value = {
-        "name": "ds", "version": "0.1.0", "granularity": "1d",
+        "name": "ds",
+        "version": "0.1.0",
+        "granularity": "1d",
     }
     mock_db.get_existing_timestamps.return_value = [pd.Timestamp("2024-01-01")]
     mock_loader.load_builder.return_value = lambda d, t: {"val": 1}
     mock_runner.run_builder.return_value = {"val": 1}
 
     from main import _build_dataset
-    _build_dataset("ds", "0.1.0", pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-02"))
+
+    _build_dataset(
+        "ds", "0.1.0", pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-02")
+    )
 
     # Only 2024-01-02 is missing, so runner called once
     assert mock_runner.run_builder.call_count == 1
@@ -130,14 +166,22 @@ def test_build_dataset_builds_missing(mock_config: MagicMock, mock_db: MagicMock
 @patch("main.loader")
 @patch("main.db")
 @patch("main.config")
-def test_build_dataset_recursive_dependencies(mock_config: MagicMock, mock_db: MagicMock, mock_loader: MagicMock, mock_runner: MagicMock, mock_validator: MagicMock) -> None:
+def test_build_dataset_recursive_dependencies(
+    mock_config: MagicMock,
+    mock_db: MagicMock,
+    mock_loader: MagicMock,
+    mock_runner: MagicMock,
+    mock_validator: MagicMock,
+) -> None:
     """Dependencies built before parent."""
     call_order = []
 
     def fake_load_config(name, version):
         if name == "parent":
             return {
-                "name": "parent", "version": "0.1.0", "granularity": "1d",
+                "name": "parent",
+                "version": "0.1.0",
+                "granularity": "1d",
                 "dependencies": {"child": "0.1.0"},
             }
         return {"name": "child", "version": "0.1.0", "granularity": "1d"}
@@ -147,7 +191,10 @@ def test_build_dataset_recursive_dependencies(mock_config: MagicMock, mock_db: M
     mock_db.get_existing_timestamps.return_value = [pd.Timestamp("2024-01-01")]
 
     from main import _build_dataset
-    _build_dataset("parent", "0.1.0", pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-01"))
+
+    _build_dataset(
+        "parent", "0.1.0", pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-01")
+    )
 
     # config.load_config should be called for child first (recursive), then parent is already loaded
     calls = mock_config.load_config.call_args_list
@@ -160,12 +207,20 @@ def test_build_dataset_recursive_dependencies(mock_config: MagicMock, mock_db: M
 @patch("main.loader")
 @patch("main.db")
 @patch("main.config")
-def test_build_dataset_missing_dependency_data_raises(mock_config: MagicMock, mock_db: MagicMock, mock_loader: MagicMock, mock_runner: MagicMock) -> None:
+def test_build_dataset_missing_dependency_data_raises(
+    mock_config: MagicMock,
+    mock_db: MagicMock,
+    mock_loader: MagicMock,
+    mock_runner: MagicMock,
+) -> None:
     """Missing dep data raises RuntimeError."""
+
     def fake_load_config(name, version):
         if name == "ds":
             return {
-                "name": "ds", "version": "0.1.0", "granularity": "1d",
+                "name": "ds",
+                "version": "0.1.0",
+                "granularity": "1d",
                 "dependencies": {"dep": "0.1.0"},
             }
         # dep has no dependencies, so recursion stops
@@ -180,5 +235,8 @@ def test_build_dataset_missing_dependency_data_raises(mock_config: MagicMock, mo
     mock_runner.run_builder.return_value = {}
 
     from main import _build_dataset
+
     with pytest.raises(RuntimeError, match="missing data for timestamp"):
-        _build_dataset("ds", "0.1.0", pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-01"))
+        _build_dataset(
+            "ds", "0.1.0", pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-01")
+        )

--- a/builders/server/tests/test_runner.py
+++ b/builders/server/tests/test_runner.py
@@ -9,33 +9,46 @@ import runner
 
 # Top-level functions so they are picklable for multiprocessing
 
-def _simple_build(dependencies: dict[str, dict], timestamp: pd.Timestamp) -> dict[str, Any]:
+
+def _simple_build(
+    dependencies: dict[str, dict], timestamp: pd.Timestamp
+) -> dict[str, Any]:
     """Return a simple dict."""
     return {"value": 42}
 
 
-def _raising_build(dependencies: dict[str, dict], timestamp: pd.Timestamp) -> dict[str, Any]:
+def _raising_build(
+    dependencies: dict[str, dict], timestamp: pd.Timestamp
+) -> dict[str, Any]:
     """Raise an exception."""
     raise ValueError("something went wrong")
 
 
-def _sleeping_build(dependencies: dict[str, dict], timestamp: pd.Timestamp) -> dict[str, Any]:
+def _sleeping_build(
+    dependencies: dict[str, dict], timestamp: pd.Timestamp
+) -> dict[str, Any]:
     """Sleep longer than the timeout."""
     time.sleep(10)
     return {}
 
 
-def _crashing_build(dependencies: dict[str, dict], timestamp: pd.Timestamp) -> dict[str, Any]:
+def _crashing_build(
+    dependencies: dict[str, dict], timestamp: pd.Timestamp
+) -> dict[str, Any]:
     """Hard-crash the subprocess."""
     os._exit(1)
 
 
-def _echo_build(dependencies: dict[str, dict], timestamp: pd.Timestamp) -> dict[str, Any]:
+def _echo_build(
+    dependencies: dict[str, dict], timestamp: pd.Timestamp
+) -> dict[str, Any]:
     """Echo back args to verify they are passed correctly."""
     return {"deps": dependencies, "ts": str(timestamp)}
 
 
-def _dep_read_build(dependencies: dict[str, dict], timestamp: pd.Timestamp) -> dict[str, Any]:
+def _dep_read_build(
+    dependencies: dict[str, dict], timestamp: pd.Timestamp
+) -> dict[str, Any]:
     """Read from dependencies dict."""
     return {"price": dependencies["prices"]["close"]}
 

--- a/builders/server/tests/test_trigger.py
+++ b/builders/server/tests/test_trigger.py
@@ -18,14 +18,21 @@ def trigger_module() -> types.ModuleType:
 
 
 @patch("requests.post")
-def test_trigger_success(mock_post: MagicMock, trigger_module: types.ModuleType, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+def test_trigger_success(
+    mock_post: MagicMock,
+    trigger_module: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     """Correct URL and params, prints success."""
     mock_resp = MagicMock()
     mock_resp.ok = True
     mock_resp.json.return_value = {"status": "ok"}
     mock_post.return_value = mock_resp
 
-    monkeypatch.setattr(sys, "argv", ["trigger.py", "ds", "0.1.0", "2024-01-01", "2024-01-31"])
+    monkeypatch.setattr(
+        sys, "argv", ["trigger.py", "ds", "0.1.0", "2024-01-01", "2024-01-31"]
+    )
     # Patch requests in the trigger module's namespace
     monkeypatch.setattr(trigger_module, "requests", sys.modules["requests"])
 
@@ -34,7 +41,9 @@ def test_trigger_success(mock_post: MagicMock, trigger_module: types.ModuleType,
     assert "Success" in captured.out
 
 
-def test_trigger_wrong_arg_count_exits(trigger_module: types.ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_trigger_wrong_arg_count_exits(
+    trigger_module: types.ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Too few args raises SystemExit(1)."""
     monkeypatch.setattr(sys, "argv", ["trigger.py", "ds"])
     with pytest.raises(SystemExit) as exc_info:
@@ -43,7 +52,11 @@ def test_trigger_wrong_arg_count_exits(trigger_module: types.ModuleType, monkeyp
 
 
 @patch("requests.post")
-def test_trigger_server_error_exits(mock_post: MagicMock, trigger_module: types.ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_trigger_server_error_exits(
+    mock_post: MagicMock,
+    trigger_module: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Non-ok response raises SystemExit(1)."""
     mock_resp = MagicMock()
     mock_resp.ok = False
@@ -51,7 +64,9 @@ def test_trigger_server_error_exits(mock_post: MagicMock, trigger_module: types.
     mock_resp.text = "Internal Server Error"
     mock_post.return_value = mock_resp
 
-    monkeypatch.setattr(sys, "argv", ["trigger.py", "ds", "0.1.0", "2024-01-01", "2024-01-31"])
+    monkeypatch.setattr(
+        sys, "argv", ["trigger.py", "ds", "0.1.0", "2024-01-01", "2024-01-31"]
+    )
     monkeypatch.setattr(trigger_module, "requests", sys.modules["requests"])
 
     with pytest.raises(SystemExit) as exc_info:
@@ -60,14 +75,20 @@ def test_trigger_server_error_exits(mock_post: MagicMock, trigger_module: types.
 
 
 @patch("requests.post")
-def test_trigger_correct_url_format(mock_post: MagicMock, trigger_module: types.ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_trigger_correct_url_format(
+    mock_post: MagicMock,
+    trigger_module: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """URL is http://localhost:8000/build/{name}/{version}."""
     mock_resp = MagicMock()
     mock_resp.ok = True
     mock_resp.json.return_value = {"status": "ok"}
     mock_post.return_value = mock_resp
 
-    monkeypatch.setattr(sys, "argv", ["trigger.py", "my-ds", "1.2.3", "2024-01-01", "2024-01-31"])
+    monkeypatch.setattr(
+        sys, "argv", ["trigger.py", "my-ds", "1.2.3", "2024-01-01", "2024-01-31"]
+    )
     monkeypatch.setattr(trigger_module, "requests", sys.modules["requests"])
 
     trigger_module.main()

--- a/builders/server/validator.py
+++ b/builders/server/validator.py
@@ -22,7 +22,9 @@ def validate(data: dict, schema: dict[str, str]) -> None:
             raise ValidationError(f"Missing key '{key}' in builder output")
 
         if type_name not in TYPE_MAP:
-            raise ValidationError(f"Unknown type '{type_name}' in schema for key '{key}'")
+            raise ValidationError(
+                f"Unknown type '{type_name}' in schema for key '{key}'"
+            )
         expected = TYPE_MAP[type_name]
 
         if not isinstance(data[key], expected):


### PR DESCRIPTION
Run `ruff format` on all Python files under `builders/`. Pure formatting changes, no logic changes.