### PR TITLE
chore: fix ruff lint errors

### DIFF
--- a/builders/server/config.py
+++ b/builders/server/config.py
@@ -5,16 +5,19 @@ SCRIPTS_DIR = Path(__file__).parent / "scripts"
 
 
 def validate_config(config: dict, dataset_name: str, dataset_version: str) -> None:
-    """Validate that a parsed config dict has required fields and matches the dataset path."""
+    """Validate that a parsed config dict has required fields and matches
+    the dataset path."""
 
-    # TODO (bryan): validate the existence of other fields in the config toml such as builder, calender, granularity, schema
+    # TODO (bryan): validate the existence of other fields in the config
+    # toml such as builder, calender, granularity, schema
     if "name" not in config:
         raise ValueError(
             f"config.toml for {dataset_name}/{dataset_version} is missing 'name' field"
         )
     if "version" not in config:
         raise ValueError(
-            f"config.toml for {dataset_name}/{dataset_version} is missing 'version' field"
+            f"config.toml for {dataset_name}/{dataset_version} "
+            "is missing 'version' field"
         )
 
     if config["name"] != dataset_name:

--- a/builders/server/db.py
+++ b/builders/server/db.py
@@ -2,7 +2,7 @@ import os
 
 import pandas as pd
 import psycopg2
-from psycopg2.extras import execute_values, RealDictCursor
+from psycopg2.extras import RealDictCursor, execute_values
 
 _pool = None
 

--- a/builders/server/loader.py
+++ b/builders/server/loader.py
@@ -1,7 +1,7 @@
 import importlib.util
 import sys
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 SCRIPTS_DIR = Path(__file__).parent / "scripts"
 

--- a/builders/server/main.py
+++ b/builders/server/main.py
@@ -100,7 +100,8 @@ def _build_dataset(
             dep_rows = db.get_rows(dep_name, dep_version, [ts])
             if ts not in dep_rows:
                 raise RuntimeError(
-                    f"Dependency '{dep_name}/{dep_version}' missing data for timestamp {ts}"
+                    f"Dependency '{dep_name}/{dep_version}' "
+                    f"missing data for timestamp {ts}"
                 )
             dep_data[dep_name] = dep_rows[ts]
 

--- a/builders/server/runner.py
+++ b/builders/server/runner.py
@@ -1,5 +1,5 @@
 import multiprocessing
-from typing import Callable
+from collections.abc import Callable
 
 import pandas as pd
 
@@ -46,7 +46,8 @@ def run_builder(
 
     if queue.empty():
         raise RuntimeError(
-            f"Builder subprocess crashed without returning a result for timestamp {timestamp}"
+            "Builder subprocess crashed without returning a result "
+            f"for timestamp {timestamp}"
         )
 
     status, payload = queue.get()

--- a/builders/server/tests/conftest.py
+++ b/builders/server/tests/conftest.py
@@ -1,11 +1,12 @@
-import pytest
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
+
+import pytest
 
 
 @pytest.fixture
 def mock_scripts_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Create a temp scripts dir and monkeypatch config.SCRIPTS_DIR and loader.SCRIPTS_DIR."""
+    """Create a temp scripts dir and monkeypatch SCRIPTS_DIR."""
     scripts = tmp_path / "scripts"
     scripts.mkdir()
     import config

--- a/builders/server/tests/test_config.py
+++ b/builders/server/tests/test_config.py
@@ -1,7 +1,8 @@
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 import pytest
+
 import config
 
 

--- a/builders/server/tests/test_db.py
+++ b/builders/server/tests/test_db.py
@@ -1,8 +1,9 @@
-from unittest.mock import patch, MagicMock, call
-from typing import Generator
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
 
-import pytest
 import pandas as pd
+import pytest
+
 import db
 
 

--- a/builders/server/tests/test_loader.py
+++ b/builders/server/tests/test_loader.py
@@ -1,8 +1,9 @@
 import sys
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 import pytest
+
 import loader
 
 

--- a/builders/server/tests/test_main.py
+++ b/builders/server/tests/test_main.py
@@ -1,10 +1,10 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
-import pytest
 import pandas as pd
+import pytest
 from fastapi.testclient import TestClient
-from main import app, generate_timestamps
 
+from main import app, generate_timestamps
 
 client: TestClient = TestClient(app)
 
@@ -174,7 +174,6 @@ def test_build_dataset_recursive_dependencies(
     mock_validator: MagicMock,
 ) -> None:
     """Dependencies built before parent."""
-    call_order = []
 
     def fake_load_config(name, version):
         if name == "parent":
@@ -196,7 +195,7 @@ def test_build_dataset_recursive_dependencies(
         "parent", "0.1.0", pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-01")
     )
 
-    # config.load_config should be called for child first (recursive), then parent is already loaded
+    # config.load_config called for child first (recursive), then parent
     calls = mock_config.load_config.call_args_list
     # First call is parent, second is child (recursive call)
     assert calls[0][0][0] == "parent"

--- a/builders/server/tests/test_runner.py
+++ b/builders/server/tests/test_runner.py
@@ -2,10 +2,10 @@ import os
 import time
 from typing import Any
 
-import pytest
 import pandas as pd
-import runner
+import pytest
 
+import runner
 
 # Top-level functions so they are picklable for multiprocessing
 

--- a/builders/server/tests/test_trigger.py
+++ b/builders/server/tests/test_trigger.py
@@ -1,7 +1,7 @@
 import importlib
 import sys
 import types
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/builders/server/tests/test_validator.py
+++ b/builders/server/tests/test_validator.py
@@ -1,5 +1,6 @@
 import pytest
-from validator import validate, ValidationError
+
+from validator import ValidationError, validate
 
 
 def test_valid_data_passes() -> None:


### PR DESCRIPTION
Fix all ruff lint errors: sort imports (I001), upgrade typing imports to `collections.abc` (UP035), remove unused import (F401), wrap long lines (E501), and remove unused variable (F841).