### PR TITLE
chore: fix mypy type errors

### DIFF
--- a/builders/server/loader.py
+++ b/builders/server/loader.py
@@ -19,7 +19,8 @@ def load_builder(dataset_name: str, dataset_version: str) -> Callable:
     spec = importlib.util.spec_from_file_location(
         f"builder_{dataset_name}_{dataset_version}", builder_path
     )
+    assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    spec.loader.exec_module(module)  # type: ignore[union-attr]  # loader is checked non-None above
 
     return module.build

--- a/builders/server/runner.py
+++ b/builders/server/runner.py
@@ -30,7 +30,7 @@ def run_builder(
 
     # note: there is a performance overhead of using a multiprocessing queue as data has
     # to be serialized when passed between processes
-    queue = multiprocessing.Queue()
+    queue: multiprocessing.Queue[tuple[str, object]] = multiprocessing.Queue()
     proc = multiprocessing.Process(
         target=_worker, args=(build_fn, dependencies, timestamp, queue)
     )
@@ -54,4 +54,4 @@ def run_builder(
     if status == STATUS_ERROR:
         raise RuntimeError(f"Builder failed for timestamp {timestamp}: {payload}")
 
-    return payload
+    return payload  # type: ignore[return-value]  # STATUS_ERROR case is handled above, payload is always dict here

--- a/builders/server/tests/test_trigger.py
+++ b/builders/server/tests/test_trigger.py
@@ -12,8 +12,9 @@ def trigger_module() -> types.ModuleType:
     spec = importlib.util.spec_from_file_location(
         "trigger", "/Users/bdeng/coding/datastream-rs/trigger.py"
     )
+    assert spec is not None and spec.loader is not None
     mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]  # loader is checked non-None above
     return mod
 
 

--- a/builders/server/validator.py
+++ b/builders/server/validator.py
@@ -27,7 +27,7 @@ def validate(data: dict, schema: dict[str, str]) -> None:
             )
         expected = TYPE_MAP[type_name]
 
-        if not isinstance(data[key], expected):
+        if not isinstance(data[key], expected):  # type: ignore[arg-type]  # expected is always a concrete type from TYPE_MAP
             raise ValidationError(
                 f"Key '{key}' expected type '{type_name}', "
                 f"got '{type(data[key]).__name__}'"


### PR DESCRIPTION
Fix mypy type errors across the codebase: add assertions for `None` checks on `ModuleSpec`, annotate multiprocessing queue, and add targeted `type: ignore` comments where needed.