### PR TITLE
chore: add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.2
+    hooks:
+      - id: ruff
+        files: ^builders/
+      - id: ruff-format
+        args: [--check]
+        files: ^builders/
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.15.0
+    hooks:
+      - id: mypy
+        files: ^builders/server/
+        exclude: ^builders/server/tests/
+        args: [--config-file=builders/server/pyproject.toml]
+        additional_dependencies:
+          - pandas-stubs
+          - types-requests
+          - types-psycopg2
+
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: bash -c 'cd builders/server && uv run pytest'
+        language: system
+        files: ^builders/server/
+        pass_filenames: false


### PR DESCRIPTION
Add `.pre-commit-config.yaml` with hooks for ruff (lint), ruff-format, mypy (type checking), and pytest (unit tests). Hooks run on every commit targeting Python files under `builders/`.