### PR TITLE
chore: add ruff rule sets B, SIM, T20, PIE

### DIFF
--- a/builders/server/main.py
+++ b/builders/server/main.py
@@ -43,14 +43,16 @@ def build(
     try:
         start_ts = pd.Timestamp(start)
         end_ts = pd.Timestamp(end)
-    except Exception:
-        raise HTTPException(status_code=400, detail="Invalid start/end timestamp")
+    except Exception as exc:
+        raise HTTPException(
+            status_code=400, detail="Invalid start/end timestamp"
+        ) from exc
 
     try:
         _build_dataset(dataset_name, dataset_version, start_ts, end_ts)
     except Exception as e:
         logger.exception(f"Build failed for {dataset_name}/{dataset_version}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=str(e)) from e
 
     return {"status": "ok"}
 

--- a/builders/server/pyproject.toml
+++ b/builders/server/pyproject.toml
@@ -29,7 +29,7 @@ target-version = "py312"
 line-length = 88
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "UP"]
+select = ["B", "E", "F", "I", "PIE", "SIM", "T20", "UP"]
 
 [tool.mypy]
 python_version = "3.12"


### PR DESCRIPTION
Adds ruff rule sets B (flake8-bugbear), SIM (flake8-simplify), T20 (flake8-print), and PIE (flake8-pie) to catch more bugs and improve code quality.

Fixed 2 B904 violations in `main.py` — added `from exc`/`from e` to raise statements inside except clauses for proper exception chaining.