### PR TITLE
docs: add dev workflow section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,44 @@ See @SPEC.md for the project description.
 
 Always run `gt sync` to sync the latest changes from the remote repository before writing any code. This ensures you're working with the latest version and properly restacks any open PRs.
 
+## Dev workflow
+
+### Planning
+
+Before writing any code for a feature or fix, always plan the full PR stack upfront:
+1. Identify all PRs needed and their order
+2. Present the stack plan to the user and get approval
+3. Only then begin writing code
+
+### PR stack structure
+
+Structure stacks by architectural layer, bottom-up:
+1. Schema / data model changes
+2. Business logic / service layer
+3. API / interface layer
+4. If there is a significant spec change: SPEC.md update as the final PR
+
+Each PR in a stack should make one logical change. It is acceptable — and sometimes desirable — for a later PR to overwrite or refine what an earlier PR did. This is intentional: the stack shows the logical progression to the final state, not just the diff.
+
+### Command sequence for each PR
+
+1. `gt sync` — sync from trunk and restack (already required before writing code)
+2. Write the code for this PR
+3. `gt create -am "type: message"` — stage all and create branch+commit (or `git add <files>` + `gt create -m "..."` to commit selectively)
+4. `gt submit --no-interactive` — push and open the PR
+5. `gh pr edit <number> --body "description"` — add PR description (what changed, why, benefit)
+
+Repeat steps 2–5 for each PR in the stack.
+
+### PR description
+
+Every PR must have a description set via `gh pr edit`. Keep it short and casual:
+- What changed
+- Why
+- The benefit
+
+No fluff, no em dashes.
+
 ## Tech specifications
 
 After EVERY SET of udpates to the code, update @dev-docs/SPEC.md with what has been changed in the code.
@@ -17,6 +55,8 @@ After EVERY SET of udpates to the code, update @dev-docs/SPEC.md with what has b
 ## Pull requests
 
 This repository uses Graphite for pull requests, instead of Git. **Never run commands to create or submit PRs without explicit instructions to do so.**
+
+**Always use `gt` commands over `git` commands.** PRs must ONLY ever be created and submitted using Graphite (`gt create`, `gt submit`). Never use `git commit`, `git push`, or `gh pr create` directly.
 
 When explicitly instructed to make a pull request, use the Graphite skill to make a series of pull requests.
 


### PR DESCRIPTION
adds a dev workflow section to CLAUDE.md covering the full PR sequence (gt sync, gt create, gt submit, gh pr edit), how to structure stacks by layer, the rule to always plan the full stack before writing code, and that PRs must only ever be created via Graphite