### PR TITLE
fix: resolve ruff check errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.2
+    rev: v0.15.4
     hooks:
       - id: ruff
         files: ^builders/

--- a/builders/server/api/routes.py
+++ b/builders/server/api/routes.py
@@ -2,7 +2,6 @@ import logging
 
 import pandas as pd
 from fastapi import APIRouter, HTTPException, Query
-
 from service.builder import build_dataset
 
 logger = logging.getLogger(__name__)

--- a/builders/server/main.py
+++ b/builders/server/main.py
@@ -1,8 +1,7 @@
 import logging
 
-from fastapi import FastAPI
-
 from api.routes import router
+from fastapi import FastAPI
 
 logging.basicConfig(level=logging.INFO)
 

--- a/builders/server/service/builder.py
+++ b/builders/server/service/builder.py
@@ -1,8 +1,7 @@
 import logging
 
-import pandas as pd
-
 import db.datasets
+import pandas as pd
 from runtime import config, loader, runner, validator
 
 logger = logging.getLogger(__name__)

--- a/builders/server/tests/api/test_routes.py
+++ b/builders/server/tests/api/test_routes.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient
-
 from main import app
 
 client: TestClient = TestClient(app)

--- a/builders/server/tests/db/test_connection.py
+++ b/builders/server/tests/db/test_connection.py
@@ -2,7 +2,6 @@ from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from db import connection
 
 

--- a/builders/server/tests/db/test_datasets.py
+++ b/builders/server/tests/db/test_datasets.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
-
 from db import datasets
 
 

--- a/builders/server/tests/runtime/test_config.py
+++ b/builders/server/tests/runtime/test_config.py
@@ -2,7 +2,6 @@ from collections.abc import Callable
 from pathlib import Path
 
 import pytest
-
 from runtime import config
 
 

--- a/builders/server/tests/runtime/test_loader.py
+++ b/builders/server/tests/runtime/test_loader.py
@@ -3,7 +3,6 @@ from collections.abc import Callable
 from pathlib import Path
 
 import pytest
-
 from runtime import loader
 
 

--- a/builders/server/tests/runtime/test_runner.py
+++ b/builders/server/tests/runtime/test_runner.py
@@ -4,7 +4,6 @@ from typing import Any
 
 import pandas as pd
 import pytest
-
 from runtime import runner
 
 # Top-level functions so they are picklable for multiprocessing

--- a/builders/server/tests/runtime/test_validator.py
+++ b/builders/server/tests/runtime/test_validator.py
@@ -1,5 +1,4 @@
 import pytest
-
 from runtime.validator import ValidationError, validate
 
 

--- a/builders/server/tests/service/test_builder.py
+++ b/builders/server/tests/service/test_builder.py
@@ -2,7 +2,6 @@ from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
-
 from service.builder import build_dataset, generate_timestamps
 
 # --- generate_timestamps tests ---

--- a/trigger.py
+++ b/trigger.py
@@ -14,19 +14,19 @@ import requests
 
 def main():
     if len(sys.argv) != 5:
-        print(f"Usage: {sys.argv[0]} <dataset_name> <dataset_version> <start> <end>")
+        print(f"Usage: {sys.argv[0]} <dataset_name> <dataset_version> <start> <end>")  # noqa: T201 -- cli output
         sys.exit(1)
 
     dataset_name, dataset_version, start, end = sys.argv[1:]
     url = f"http://localhost:8000/build/{dataset_name}/{dataset_version}"
 
-    print(f"Triggering build: {dataset_name}/{dataset_version} [{start}, {end}]")
+    print(f"Triggering build: {dataset_name}/{dataset_version} [{start}, {end}]")  # noqa: T201 -- cli output
     resp = requests.post(url, params={"start": start, "end": end})
 
     if resp.ok:
-        print(f"Success: {resp.json()}")
+        print(f"Success: {resp.json()}")  # noqa: T201 -- cli output
     else:
-        print(f"Error ({resp.status_code}): {resp.text}")
+        print(f"Error ({resp.status_code}): {resp.text}")  # noqa: T201 -- cli output
         sys.exit(1)
 
 


### PR DESCRIPTION
Fixes all `uv run ruff check` errors after moving pyproject.toml to the project root.

Changes:
- Auto-fixed import ordering (I001) across all builder server files
- Added `# noqa: T201` suppressions on `print` calls in `trigger.py` (intentional CLI output)
- Bumped pre-commit ruff hook from v0.11.2 to v0.15.4 to match the installed ruff version and avoid import-sort disagreements between the two