### PR TITLE
refactor: replace pd.Timestamp with datetime in db layer

### DIFF
--- a/builders/server/db/datasets.py
+++ b/builders/server/db/datasets.py
@@ -1,4 +1,5 @@
-import pandas as pd
+from datetime import datetime
+
 import psycopg2
 from psycopg2.extras import RealDictCursor, execute_values
 
@@ -8,9 +9,9 @@ from db.connection import get_conn
 def get_existing_timestamps(
     dataset_name: str,
     dataset_version: str,
-    start: pd.Timestamp,
-    end: pd.Timestamp,
-) -> list[pd.Timestamp]:
+    start: datetime,
+    end: datetime,
+) -> list[datetime]:
     """Query all timestamps in [start, end] that already have rows for this dataset."""
     conn = get_conn()
     with conn.cursor() as cur:
@@ -23,15 +24,15 @@ def get_existing_timestamps(
               AND timestamp <= %s
             ORDER BY timestamp
             """,
-            (dataset_name, dataset_version, start.to_pydatetime(), end.to_pydatetime()),
+            (dataset_name, dataset_version, start, end),
         )
-        return [pd.Timestamp(row[0]) for row in cur.fetchall()]
+        return [row[0] for row in cur.fetchall()]
 
 
 def insert_rows(
     dataset_name: str,
     dataset_version: str,
-    rows: list[tuple[pd.Timestamp, dict]],
+    rows: list[tuple[datetime, dict]],
 ) -> None:
     """Bulk insert rows into the datasets table."""
     if not rows:
@@ -48,7 +49,7 @@ def insert_rows(
                 (
                     dataset_name,
                     dataset_version,
-                    ts.to_pydatetime(),
+                    ts,
                     psycopg2.extras.Json(data),
                 )
                 for ts, data in rows
@@ -60,8 +61,8 @@ def insert_rows(
 def get_rows(
     dataset_name: str,
     dataset_version: str,
-    timestamps: list[pd.Timestamp],
-) -> dict[pd.Timestamp, dict]:
+    timestamps: list[datetime],
+) -> dict[datetime, dict]:
     """Fetch data for specific timestamps."""
     if not timestamps:
         return {}
@@ -77,7 +78,7 @@ def get_rows(
             (
                 dataset_name,
                 dataset_version,
-                [ts.to_pydatetime() for ts in timestamps],
+                timestamps,
             ),
         )
-        return {pd.Timestamp(row["timestamp"]): row["data"] for row in cur.fetchall()}
+        return {row["timestamp"]: row["data"] for row in cur.fetchall()}

--- a/builders/server/tests/db/test_datasets.py
+++ b/builders/server/tests/db/test_datasets.py
@@ -1,16 +1,16 @@
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
-import pandas as pd
 from db import datasets
 
 
 @patch("db.datasets.get_conn")
 def test_get_existing_timestamps(mock_get_conn: MagicMock) -> None:
-    """Returns list[pd.Timestamp] from cursor rows."""
+    """Returns list[datetime] from cursor rows."""
     mock_cursor = MagicMock()
     mock_cursor.fetchall.return_value = [
-        (pd.Timestamp("2024-01-01").to_pydatetime(),),
-        (pd.Timestamp("2024-01-02").to_pydatetime(),),
+        (datetime(2024, 1, 1),),
+        (datetime(2024, 1, 2),),
     ]
     mock_conn = MagicMock()
     mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
@@ -18,11 +18,11 @@ def test_get_existing_timestamps(mock_get_conn: MagicMock) -> None:
     mock_get_conn.return_value = mock_conn
 
     result = datasets.get_existing_timestamps(
-        "ds", "0.1.0", pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-31")
+        "ds", "0.1.0", datetime(2024, 1, 1), datetime(2024, 1, 31)
     )
     assert len(result) == 2
-    assert result[0] == pd.Timestamp("2024-01-01")
-    assert result[1] == pd.Timestamp("2024-01-02")
+    assert result[0] == datetime(2024, 1, 1)
+    assert result[1] == datetime(2024, 1, 2)
 
 
 @patch("db.datasets.get_conn")
@@ -36,7 +36,7 @@ def test_get_existing_timestamps_empty(mock_get_conn: MagicMock) -> None:
     mock_get_conn.return_value = mock_conn
 
     result = datasets.get_existing_timestamps(
-        "ds", "0.1.0", pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-31")
+        "ds", "0.1.0", datetime(2024, 1, 1), datetime(2024, 1, 31)
     )
     assert result == []
 
@@ -60,7 +60,7 @@ def test_insert_rows_calls_execute_values(
     mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
     mock_get_conn.return_value = mock_conn
 
-    rows = [(pd.Timestamp("2024-01-01"), {"ticker": "AAPL"})]
+    rows = [(datetime(2024, 1, 1), {"ticker": "AAPL"})]
     datasets.insert_rows("ds", "0.1.0", rows)
 
     mock_exec_values.assert_called_once()
@@ -78,11 +78,11 @@ def test_get_rows_empty_timestamps_returns_empty_dict(mock_get_conn: MagicMock) 
 
 @patch("db.datasets.get_conn")
 def test_get_rows_returns_mapped_data(mock_get_conn: MagicMock) -> None:
-    """Returns dict[pd.Timestamp, dict] correctly."""
-    ts = pd.Timestamp("2024-01-01")
+    """Returns dict[datetime, dict] correctly."""
+    ts = datetime(2024, 1, 1)
     mock_cursor = MagicMock()
     mock_cursor.fetchall.return_value = [
-        {"timestamp": ts.to_pydatetime(), "data": {"ticker": "AAPL", "price": 100}},
+        {"timestamp": ts, "data": {"ticker": "AAPL", "price": 100}},
     ]
     mock_conn = MagicMock()
     mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)


### PR DESCRIPTION
Replace pd.Timestamp type hints with datetime, remove .to_pydatetime() calls (psycopg2 already returns datetime for TIMESTAMP columns), and update tests. Removes pandas dependency from the db layer.