### PR TITLE
refactor: replace pd.Timestamp with datetime in service and runtime layers

### DIFF
--- a/builders/server/runtime/runner.py
+++ b/builders/server/runtime/runner.py
@@ -1,7 +1,6 @@
 import multiprocessing
 from collections.abc import Callable
-
-import pandas as pd
+from datetime import datetime
 
 TIMEOUT_SECONDS = 120
 
@@ -12,7 +11,7 @@ STATUS_ERROR = "error"
 def _worker(
     build_fn: Callable,
     dependencies: dict,
-    timestamp: pd.Timestamp,
+    timestamp: datetime,
     queue: multiprocessing.Queue,
 ):
     """Subprocess target that runs the builder and puts the result in the queue."""
@@ -23,9 +22,7 @@ def _worker(
         queue.put((STATUS_ERROR, str(e)))
 
 
-def run_builder(
-    build_fn: Callable, dependencies: dict, timestamp: pd.Timestamp
-) -> dict:
+def run_builder(build_fn: Callable, dependencies: dict, timestamp: datetime) -> dict:
     """Run a builder function in an isolated subprocess and return its result."""
 
     # note: there is a performance overhead of using a multiprocessing queue as data has

--- a/builders/server/service/builder.py
+++ b/builders/server/service/builder.py
@@ -1,34 +1,38 @@
 import logging
+from datetime import datetime, timedelta
 
 import db.datasets
-import pandas as pd
 from runtime import config, loader, runner, validator
 
 logger = logging.getLogger(__name__)
 
 GRANULARITY_MAP = {
-    "1s": "s",
-    "1m": "min",
-    "1h": "h",
-    "1d": "D",
+    "1s": timedelta(seconds=1),
+    "1m": timedelta(minutes=1),
+    "1h": timedelta(hours=1),
+    "1d": timedelta(days=1),
 }
 
 
 def generate_timestamps(
-    start: pd.Timestamp, end: pd.Timestamp, granularity: str
-) -> list[pd.Timestamp]:
+    start: datetime, end: datetime, granularity: str
+) -> list[datetime]:
     """Generate all timestamps in [start, end] for the given granularity."""
-    freq = GRANULARITY_MAP.get(granularity)
-    if freq is None:
+    delta = GRANULARITY_MAP.get(granularity)
+    if delta is None:
         raise ValueError(f"Unsupported granularity: {granularity}")
-    return list(pd.date_range(start=start, end=end, freq=freq))
+    timestamps, current = [], start
+    while current <= end:
+        timestamps.append(current)
+        current += delta
+    return timestamps
 
 
 def build_dataset(
     dataset_name: str,
     dataset_version: str,
-    start: pd.Timestamp,
-    end: pd.Timestamp,
+    start: datetime,
+    end: datetime,
 ) -> None:
     """Core build logic: resolve dependencies, build missing timestamps, insert rows."""
     cfg = config.load_config(dataset_name, dataset_version)

--- a/builders/server/tests/service/test_builder.py
+++ b/builders/server/tests/service/test_builder.py
@@ -1,6 +1,6 @@
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
-import pandas as pd
 import pytest
 from service.builder import build_dataset, generate_timestamps
 
@@ -9,18 +9,16 @@ from service.builder import build_dataset, generate_timestamps
 
 def test_generate_timestamps_1d() -> None:
     """Daily over 3 days returns 3 timestamps."""
-    result = generate_timestamps(
-        pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-03"), "1d"
-    )
+    result = generate_timestamps(datetime(2024, 1, 1), datetime(2024, 1, 3), "1d")
     assert len(result) == 3
-    assert result[0] == pd.Timestamp("2024-01-01")
-    assert result[-1] == pd.Timestamp("2024-01-03")
+    assert result[0] == datetime(2024, 1, 1)
+    assert result[-1] == datetime(2024, 1, 3)
 
 
 def test_generate_timestamps_1h() -> None:
     """Hourly frequency works."""
     result = generate_timestamps(
-        pd.Timestamp("2024-01-01 00:00"), pd.Timestamp("2024-01-01 02:00"), "1h"
+        datetime(2024, 1, 1, 0, 0), datetime(2024, 1, 1, 2, 0), "1h"
     )
     assert len(result) == 3
 
@@ -28,7 +26,7 @@ def test_generate_timestamps_1h() -> None:
 def test_generate_timestamps_1m() -> None:
     """Minute frequency works."""
     result = generate_timestamps(
-        pd.Timestamp("2024-01-01 00:00"), pd.Timestamp("2024-01-01 00:05"), "1m"
+        datetime(2024, 1, 1, 0, 0), datetime(2024, 1, 1, 0, 5), "1m"
     )
     assert len(result) == 6
 
@@ -36,7 +34,7 @@ def test_generate_timestamps_1m() -> None:
 def test_generate_timestamps_1s() -> None:
     """Second frequency works."""
     result = generate_timestamps(
-        pd.Timestamp("2024-01-01 00:00:00"), pd.Timestamp("2024-01-01 00:00:03"), "1s"
+        datetime(2024, 1, 1, 0, 0, 0), datetime(2024, 1, 1, 0, 0, 3), "1s"
     )
     assert len(result) == 4
 
@@ -44,24 +42,18 @@ def test_generate_timestamps_1s() -> None:
 def test_generate_timestamps_unsupported_granularity() -> None:
     """Raises ValueError for unsupported granularity."""
     with pytest.raises(ValueError, match="Unsupported granularity"):
-        generate_timestamps(
-            pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-02"), "1w"
-        )
+        generate_timestamps(datetime(2024, 1, 1), datetime(2024, 1, 2), "1w")
 
 
 def test_generate_timestamps_same_start_end() -> None:
     """Returns single timestamp when start equals end."""
-    result = generate_timestamps(
-        pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-01"), "1d"
-    )
+    result = generate_timestamps(datetime(2024, 1, 1), datetime(2024, 1, 1), "1d")
     assert len(result) == 1
 
 
 def test_generate_timestamps_end_before_start() -> None:
     """Returns empty list when end is before start."""
-    result = generate_timestamps(
-        pd.Timestamp("2024-01-03"), pd.Timestamp("2024-01-01"), "1d"
-    )
+    result = generate_timestamps(datetime(2024, 1, 3), datetime(2024, 1, 1), "1d")
     assert len(result) == 0
 
 
@@ -81,14 +73,12 @@ def test_build_dataset_skips_existing(
     }
     # All timestamps already exist
     mock_db.get_existing_timestamps.return_value = [
-        pd.Timestamp("2024-01-01"),
-        pd.Timestamp("2024-01-02"),
+        datetime(2024, 1, 1),
+        datetime(2024, 1, 2),
     ]
 
     with patch("service.builder.runner") as mock_runner:
-        build_dataset(
-            "ds", "0.1.0", pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-02")
-        )
+        build_dataset("ds", "0.1.0", datetime(2024, 1, 1), datetime(2024, 1, 2))
         mock_runner.run_builder.assert_not_called()
     mock_db.insert_rows.assert_not_called()
 
@@ -111,18 +101,18 @@ def test_build_dataset_builds_missing(
         "version": "0.1.0",
         "granularity": "1d",
     }
-    mock_db.get_existing_timestamps.return_value = [pd.Timestamp("2024-01-01")]
+    mock_db.get_existing_timestamps.return_value = [datetime(2024, 1, 1)]
     mock_loader.load_builder.return_value = lambda d, t: {"val": 1}
     mock_runner.run_builder.return_value = {"val": 1}
 
-    build_dataset("ds", "0.1.0", pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-02"))
+    build_dataset("ds", "0.1.0", datetime(2024, 1, 1), datetime(2024, 1, 2))
 
     # Only 2024-01-02 is missing, so runner called once
     assert mock_runner.run_builder.call_count == 1
     mock_db.insert_rows.assert_called_once()
     inserted_rows = mock_db.insert_rows.call_args[0][2]
     assert len(inserted_rows) == 1
-    assert inserted_rows[0][0] == pd.Timestamp("2024-01-02")
+    assert inserted_rows[0][0] == datetime(2024, 1, 2)
 
 
 @patch("service.builder.validator")
@@ -151,11 +141,9 @@ def test_build_dataset_recursive_dependencies(
 
     mock_config.load_config.side_effect = fake_load_config
     # All timestamps exist so no building needed, but we track config load order
-    mock_db.get_existing_timestamps.return_value = [pd.Timestamp("2024-01-01")]
+    mock_db.get_existing_timestamps.return_value = [datetime(2024, 1, 1)]
 
-    build_dataset(
-        "parent", "0.1.0", pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-01")
-    )
+    build_dataset("parent", "0.1.0", datetime(2024, 1, 1), datetime(2024, 1, 1))
 
     # config.load_config called for child first (recursive), then parent
     calls = mock_config.load_config.call_args_list
@@ -196,6 +184,4 @@ def test_build_dataset_missing_dependency_data_raises(
     mock_runner.run_builder.return_value = {}
 
     with pytest.raises(RuntimeError, match="missing data for timestamp"):
-        build_dataset(
-            "ds", "0.1.0", pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-01")
-        )
+        build_dataset("ds", "0.1.0", datetime(2024, 1, 1), datetime(2024, 1, 1))


### PR DESCRIPTION
Replace pd.date_range + pandas freq strings with a stdlib timedelta loop in generate_timestamps. Update service and runtime function signatures to use datetime. Removes pandas from two more layers.