### PR TITLE
refactor: replace pd.Timestamp with datetime in api layer

### DIFF
--- a/builders/server/api/routes.py
+++ b/builders/server/api/routes.py
@@ -1,6 +1,6 @@
 import logging
+from datetime import datetime
 
-import pandas as pd
 from fastapi import APIRouter, HTTPException, Query
 from service.builder import build_dataset
 
@@ -18,8 +18,8 @@ def build(
 ):
     """Build missing data for a dataset in the given time range."""
     try:
-        start_ts = pd.Timestamp(start)
-        end_ts = pd.Timestamp(end)
+        start_ts = datetime.fromisoformat(start)
+        end_ts = datetime.fromisoformat(end)
     except Exception as exc:
         raise HTTPException(
             status_code=400, detail="Invalid start/end timestamp"


### PR DESCRIPTION
Replace pd.Timestamp(start/end) with datetime.fromisoformat() in the API route. Removes the last pandas import from the server code.