### PR TITLE
refactor: replace pd.Timestamp with datetime in builder scripts

### DIFF
--- a/builders/scripts/mock-daily-close/0.1.0/builder.py
+++ b/builders/scripts/mock-daily-close/0.1.0/builder.py
@@ -1,7 +1,7 @@
-import pandas as pd
+from datetime import datetime
 
 
-def build(dependencies: dict[str, dict], timestamp: pd.Timestamp) -> dict:
+def build(dependencies: dict[str, dict], timestamp: datetime) -> dict:
     """Extract the close price from the mock-ohlc dependency."""
     ohlc = dependencies["mock-ohlc"]
     return {

--- a/builders/scripts/mock-ohlc/0.1.0/builder.py
+++ b/builders/scripts/mock-ohlc/0.1.0/builder.py
@@ -1,9 +1,8 @@
 import random
+from datetime import datetime
 
-import pandas as pd
 
-
-def build(dependencies: dict[str, dict], timestamp: pd.Timestamp) -> dict:
+def build(dependencies: dict[str, dict], timestamp: datetime) -> dict:
     """Generate deterministic mock OHLC data for AAPL based on the timestamp."""
     random.seed(str(timestamp))
     base = round(random.uniform(100, 300), 2)


### PR DESCRIPTION
Update builder script signatures from pd.Timestamp to datetime and drop the pandas import.