### PR TITLE
chore: add justfile with lint and test commands

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,5 @@
+lint:
+    uv run ruff check
+
+test:
+    uv run pytest


### PR DESCRIPTION
adds a justfile with `lint` and `test` commands for running ruff and pytest via uv