### PR TITLE
chore: add precommit recipe to justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -3,3 +3,6 @@ lint:
 
 test:
     uv run pytest
+
+precommit:
+    uv run pre-commit run --all-files


### PR DESCRIPTION
Adds a `precommit` recipe to the justfile that runs `pre-commit run --all-files` via uv. Makes it easy to dry-run the pre-commit hooks locally without needing to stage a commit.