### PR TITLE
feat: remove unique constraint on datasets table

### DIFF
--- a/infra/postgres/init.sql
+++ b/infra/postgres/init.sql
@@ -4,6 +4,10 @@ CREATE TABLE datasets (
     dataset_name TEXT NOT NULL,
     dataset_version TEXT NOT NULL,
     timestamp TIMESTAMP(6) NOT NULL,
-    data JSONB NOT NULL,
-    UNIQUE (dataset_name, dataset_version, timestamp)
+    data JSONB NOT NULL
 );
+
+-- non-unique index for range queries on 
+-- (dataset_name, dataset_version, timestamp)
+CREATE INDEX idx_datasets_name_version_ts
+ON datasets (dataset_name, dataset_version, timestamp);


### PR DESCRIPTION
Remove the UNIQUE constraint on (dataset_name, dataset_version, timestamp) to allow multiple rows per timestamp (e.g. multiple tickers at the same timestamp). Add a non-unique index on those columns to keep range queries fast.

No data exists in the DB yet so this is a clean schema change.