### PR TITLE
feat: support multi-row timestamps in db layer

### DIFF
--- a/builders/server/db/datasets.py
+++ b/builders/server/db/datasets.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from datetime import datetime
 
 import psycopg2
@@ -17,7 +18,7 @@ def get_existing_timestamps(
     with conn.cursor() as cur:
         cur.execute(
             """
-            SELECT timestamp FROM datasets
+            SELECT DISTINCT timestamp FROM datasets
             WHERE dataset_name = %s
               AND dataset_version = %s
               AND timestamp >= %s
@@ -32,9 +33,13 @@ def get_existing_timestamps(
 def insert_rows(
     dataset_name: str,
     dataset_version: str,
-    rows: list[tuple[datetime, dict]],
+    rows: list[tuple[datetime, list[dict]]],
 ) -> None:
-    """Bulk insert rows into the datasets table."""
+    """Bulk insert rows into the datasets table.
+
+    Each entry is a (timestamp, list[dict]) pair where the list contains one or more
+    data dicts to insert for that timestamp.
+    """
     if not rows:
         return
     conn = get_conn()
@@ -52,7 +57,8 @@ def insert_rows(
                     ts,
                     psycopg2.extras.Json(data),
                 )
-                for ts, data in rows
+                for ts, data_list in rows
+                for data in data_list
             ],
         )
     conn.commit()
@@ -62,8 +68,8 @@ def get_rows(
     dataset_name: str,
     dataset_version: str,
     timestamps: list[datetime],
-) -> dict[datetime, dict]:
-    """Fetch data for specific timestamps."""
+) -> dict[datetime, list[dict]]:
+    """Fetch data for specific timestamps, returning a list of dicts per timestamp."""
     if not timestamps:
         return {}
     conn = get_conn()
@@ -81,4 +87,7 @@ def get_rows(
                 timestamps,
             ),
         )
-        return {row["timestamp"]: row["data"] for row in cur.fetchall()}
+        result: dict[datetime, list[dict]] = defaultdict(list)
+        for row in cur.fetchall():
+            result[row["timestamp"]].append(row["data"])
+        return dict(result)

--- a/builders/server/tests/db/test_datasets.py
+++ b/builders/server/tests/db/test_datasets.py
@@ -24,6 +24,10 @@ def test_get_existing_timestamps(mock_get_conn: MagicMock) -> None:
     assert result[0] == datetime(2024, 1, 1)
     assert result[1] == datetime(2024, 1, 2)
 
+    # verify DISTINCT is in the query
+    executed_sql = mock_cursor.execute.call_args[0][0]
+    assert "DISTINCT" in executed_sql
+
 
 @patch("db.datasets.get_conn")
 def test_get_existing_timestamps_empty(mock_get_conn: MagicMock) -> None:
@@ -60,12 +64,17 @@ def test_insert_rows_calls_execute_values(
     mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
     mock_get_conn.return_value = mock_conn
 
-    rows = [(datetime(2024, 1, 1), {"ticker": "AAPL"})]
+    rows: list[tuple[datetime, list[dict]]] = [
+        (datetime(2024, 1, 1), [{"ticker": "AAPL"}, {"ticker": "MSFT"}])
+    ]
     datasets.insert_rows("ds", "0.1.0", rows)
 
     mock_exec_values.assert_called_once()
     args = mock_exec_values.call_args
     assert "INSERT INTO datasets" in args[0][1]
+    # two data dicts should be flattened into two insert tuples
+    insert_tuples = args[0][2]
+    assert len(insert_tuples) == 2
 
 
 @patch("db.datasets.get_conn")
@@ -77,12 +86,13 @@ def test_get_rows_empty_timestamps_returns_empty_dict(mock_get_conn: MagicMock) 
 
 
 @patch("db.datasets.get_conn")
-def test_get_rows_returns_mapped_data(mock_get_conn: MagicMock) -> None:
-    """Returns dict[datetime, dict] correctly."""
+def test_get_rows_returns_list_per_timestamp(mock_get_conn: MagicMock) -> None:
+    """Returns dict[datetime, list[dict]] with multiple rows aggregated."""
     ts = datetime(2024, 1, 1)
     mock_cursor = MagicMock()
     mock_cursor.fetchall.return_value = [
         {"timestamp": ts, "data": {"ticker": "AAPL", "price": 100}},
+        {"timestamp": ts, "data": {"ticker": "MSFT", "price": 200}},
     ]
     mock_conn = MagicMock()
     mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
@@ -91,4 +101,6 @@ def test_get_rows_returns_mapped_data(mock_get_conn: MagicMock) -> None:
 
     result = datasets.get_rows("ds", "0.1.0", [ts])
     assert ts in result
-    assert result[ts] == {"ticker": "AAPL", "price": 100}
+    assert len(result[ts]) == 2
+    assert result[ts][0] == {"ticker": "AAPL", "price": 100}
+    assert result[ts][1] == {"ticker": "MSFT", "price": 200}


### PR DESCRIPTION
Update the DB layer for multi-row per timestamp support:
- `get_existing_timestamps`: add DISTINCT since multiple rows can share a timestamp
- `get_rows`: return `dict[datetime, list[dict]]` using defaultdict aggregation
- `insert_rows`: accept `list[tuple[datetime, list[dict]]]` and flatten in the insert

Tests updated to match new types.