### PR TITLE
feat: update service layer for multi-row builders

### DIFF
--- a/builders/server/runtime/runner.py
+++ b/builders/server/runtime/runner.py
@@ -22,7 +22,9 @@ def _worker(
         queue.put((STATUS_ERROR, str(e)))
 
 
-def run_builder(build_fn: Callable, dependencies: dict, timestamp: datetime) -> dict:
+def run_builder(
+    build_fn: Callable, dependencies: dict, timestamp: datetime
+) -> list[dict]:
     """Run a builder function in an isolated subprocess and return its result."""
 
     # note: there is a performance overhead of using a multiprocessing queue as data has
@@ -51,4 +53,4 @@ def run_builder(build_fn: Callable, dependencies: dict, timestamp: datetime) -> 
     if status == STATUS_ERROR:
         raise RuntimeError(f"Builder failed for timestamp {timestamp}: {payload}")
 
-    return payload  # type: ignore[return-value]  # STATUS_ERROR case is handled above, payload is always dict here
+    return payload  # type: ignore[return-value]  # STATUS_ERROR case is handled above, payload is always list[dict] here

--- a/builders/server/service/builder.py
+++ b/builders/server/service/builder.py
@@ -82,7 +82,7 @@ def build_dataset(
         result = runner.run_builder(build_fn, dep_data, ts)
 
         # validate output against schema
-        validator.validate(result, schema)
+        validator.validate_rows(result, schema)
 
         rows.append((ts, result))
 

--- a/builders/server/tests/service/test_builder.py
+++ b/builders/server/tests/service/test_builder.py
@@ -102,8 +102,8 @@ def test_build_dataset_builds_missing(
         "granularity": "1d",
     }
     mock_db.get_existing_timestamps.return_value = [datetime(2024, 1, 1)]
-    mock_loader.load_builder.return_value = lambda d, t: {"val": 1}
-    mock_runner.run_builder.return_value = {"val": 1}
+    mock_loader.load_builder.return_value = lambda d, t: [{"val": 1}]
+    mock_runner.run_builder.return_value = [{"val": 1}]
 
     build_dataset("ds", "0.1.0", datetime(2024, 1, 1), datetime(2024, 1, 2))
 
@@ -113,6 +113,7 @@ def test_build_dataset_builds_missing(
     inserted_rows = mock_db.insert_rows.call_args[0][2]
     assert len(inserted_rows) == 1
     assert inserted_rows[0][0] == datetime(2024, 1, 2)
+    assert inserted_rows[0][1] == [{"val": 1}]
 
 
 @patch("service.builder.validator")
@@ -180,8 +181,52 @@ def test_build_dataset_missing_dependency_data_raises(
     mock_db.get_existing_timestamps.return_value = []
     # dep has no data for the timestamp (after dep build completes with no inserts)
     mock_db.get_rows.return_value = {}
-    mock_loader.load_builder.return_value = lambda d, t: {}
-    mock_runner.run_builder.return_value = {}
+    mock_loader.load_builder.return_value = lambda d, t: []
+    mock_runner.run_builder.return_value = []
 
     with pytest.raises(RuntimeError, match="missing data for timestamp"):
         build_dataset("ds", "0.1.0", datetime(2024, 1, 1), datetime(2024, 1, 1))
+
+
+@patch("service.builder.validator")
+@patch("service.builder.runner")
+@patch("service.builder.loader")
+@patch("service.builder.db.datasets")
+@patch("service.builder.config")
+def test_build_dataset_passes_dep_data_as_list(
+    mock_config: MagicMock,
+    mock_db: MagicMock,
+    mock_loader: MagicMock,
+    mock_runner: MagicMock,
+    mock_validator: MagicMock,
+) -> None:
+    """Dependency data is passed as list[dict] to the builder."""
+
+    def fake_load_config(name, version):
+        if name == "ds":
+            return {
+                "name": "ds",
+                "version": "0.1.0",
+                "granularity": "1d",
+                "dependencies": {"dep": "0.1.0"},
+            }
+        return {"name": "dep", "version": "0.1.0", "granularity": "1d"}
+
+    mock_config.load_config.side_effect = fake_load_config
+    # dep recurses first, then ds
+    mock_db.get_existing_timestamps.side_effect = [
+        [datetime(2024, 1, 1)],  # dep already built (recursive call happens first)
+        [],  # ds has no data
+    ]
+    # dep returns multi-row data
+    dep_data = [{"ticker": "AAPL", "close": 150}, {"ticker": "MSFT", "close": 200}]
+    mock_db.get_rows.return_value = {datetime(2024, 1, 1): dep_data}
+    mock_loader.load_builder.return_value = lambda d, t: [{"val": 1}]
+    mock_runner.run_builder.return_value = [{"val": 1}]
+
+    build_dataset("ds", "0.1.0", datetime(2024, 1, 1), datetime(2024, 1, 1))
+
+    # verify dep_data passed to runner is the list from get_rows
+    runner_call = mock_runner.run_builder.call_args
+    passed_deps = runner_call[0][1]
+    assert passed_deps["dep"] == dep_data


### PR DESCRIPTION
Update the service layer to work with multi-row builders:
- Use `validate_rows()` instead of `validate()` for list validation
- Update `run_builder` return type to `list[dict]`
- Dependencies now flow as `list[dict]` from `get_rows` through to the builder

Tests updated with new types and a new test verifying dep data passes through as a list.