### PR TITLE
feat: update runner return type for multi-row builders

### DIFF
--- a/builders/server/tests/runtime/test_runner.py
+++ b/builders/server/tests/runtime/test_runner.py
@@ -9,49 +9,53 @@ from runtime import runner
 # Top-level functions so they are picklable for multiprocessing
 
 
-def _simple_build(dependencies: dict[str, dict], timestamp: datetime) -> dict[str, Any]:
-    """Return a simple dict."""
-    return {"value": 42}
+def _simple_build(
+    dependencies: dict[str, list[dict]], timestamp: datetime
+) -> list[dict[str, Any]]:
+    """Return a simple list of dicts."""
+    return [{"value": 42}]
 
 
 def _raising_build(
-    dependencies: dict[str, dict], timestamp: datetime
-) -> dict[str, Any]:
+    dependencies: dict[str, list[dict]], timestamp: datetime
+) -> list[dict[str, Any]]:
     """Raise an exception."""
     raise ValueError("something went wrong")
 
 
 def _sleeping_build(
-    dependencies: dict[str, dict], timestamp: datetime
-) -> dict[str, Any]:
+    dependencies: dict[str, list[dict]], timestamp: datetime
+) -> list[dict[str, Any]]:
     """Sleep longer than the timeout."""
     time.sleep(10)
-    return {}
+    return []
 
 
 def _crashing_build(
-    dependencies: dict[str, dict], timestamp: datetime
-) -> dict[str, Any]:
+    dependencies: dict[str, list[dict]], timestamp: datetime
+) -> list[dict[str, Any]]:
     """Hard-crash the subprocess."""
     os._exit(1)
 
 
-def _echo_build(dependencies: dict[str, dict], timestamp: datetime) -> dict[str, Any]:
+def _echo_build(
+    dependencies: dict[str, list[dict]], timestamp: datetime
+) -> list[dict[str, Any]]:
     """Echo back args to verify they are passed correctly."""
-    return {"deps": dependencies, "ts": str(timestamp)}
+    return [{"deps": dependencies, "ts": str(timestamp)}]
 
 
 def _dep_read_build(
-    dependencies: dict[str, dict], timestamp: datetime
-) -> dict[str, Any]:
-    """Read from dependencies dict."""
-    return {"price": dependencies["prices"]["close"]}
+    dependencies: dict[str, list[dict]], timestamp: datetime
+) -> list[dict[str, Any]]:
+    """Read from dependencies dict (multi-row)."""
+    return [{"price": row["close"]} for row in dependencies["prices"]]
 
 
 def test_successful_build() -> None:
-    """Simple function returns expected dict."""
+    """Simple function returns expected list."""
     result = runner.run_builder(_simple_build, {}, datetime(2024, 1, 1))
-    assert result == {"value": 42}
+    assert result == [{"value": 42}]
 
 
 def test_builder_exception_raises_runtime_error() -> None:
@@ -60,7 +64,9 @@ def test_builder_exception_raises_runtime_error() -> None:
         runner.run_builder(_raising_build, {}, datetime(2024, 1, 1))
 
 
-def test_builder_timeout_raises_runtime_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_builder_timeout_raises_runtime_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Function that sleeps too long raises timeout error."""
     monkeypatch.setattr(runner, "TIMEOUT_SECONDS", 1)
     with pytest.raises(RuntimeError, match="timed out"):
@@ -75,15 +81,15 @@ def test_builder_crash_raises_runtime_error() -> None:
 
 def test_builder_receives_correct_args() -> None:
     """Verify dependencies and timestamp are passed through correctly."""
-    deps = {"my-dep": {"val": 1}}
+    deps: dict[str, list[dict]] = {"my-dep": [{"val": 1}]}
     ts = datetime(2024, 6, 15)
     result = runner.run_builder(_echo_build, deps, ts)
-    assert result["deps"] == deps
-    assert result["ts"] == str(ts)
+    assert result[0]["deps"] == deps
+    assert result[0]["ts"] == str(ts)
 
 
 def test_builder_with_dependencies() -> None:
-    """Function that reads from dependencies dict works."""
-    deps = {"prices": {"close": 150.5}}
+    """Function that reads from multi-row dependencies works."""
+    deps: dict[str, list[dict]] = {"prices": [{"close": 150.5}, {"close": 200.0}]}
     result = runner.run_builder(_dep_read_build, deps, datetime(2024, 1, 1))
-    assert result == {"price": 150.5}
+    assert result == [{"price": 150.5}, {"price": 200.0}]


### PR DESCRIPTION
Update runner test stubs to use the new `list[dict]` interface. All builder stubs now return `list[dict]` and accept `dict[str, list[dict]]` dependencies.