### PR TITLE
feat: update existing mock builders for multi-row interface

### DIFF
--- a/builders/scripts/mock-daily-close/0.1.0/builder.py
+++ b/builders/scripts/mock-daily-close/0.1.0/builder.py
@@ -1,10 +1,12 @@
 from datetime import datetime
 
 
-def build(dependencies: dict[str, dict], timestamp: datetime) -> dict:
+def build(dependencies: dict[str, list[dict]], timestamp: datetime) -> list[dict]:
     """Extract the close price from the mock-ohlc dependency."""
-    ohlc = dependencies["mock-ohlc"]
-    return {
-        "ticker": ohlc["ticker"],
-        "close": ohlc["close"],
-    }
+    ohlc = dependencies["mock-ohlc"][0]
+    return [
+        {
+            "ticker": ohlc["ticker"],
+            "close": ohlc["close"],
+        }
+    ]

--- a/builders/scripts/mock-ohlc/0.1.0/builder.py
+++ b/builders/scripts/mock-ohlc/0.1.0/builder.py
@@ -2,15 +2,17 @@ import random
 from datetime import datetime
 
 
-def build(dependencies: dict[str, dict], timestamp: datetime) -> dict:
+def build(dependencies: dict[str, list[dict]], timestamp: datetime) -> list[dict]:
     """Generate deterministic mock OHLC data for AAPL based on the timestamp."""
     random.seed(str(timestamp))
     base = round(random.uniform(100, 300), 2)
 
-    return {
-        "ticker": "AAPL",
-        "open": base,
-        "high": round(base + random.uniform(0, 50), 2),
-        "low": round(base - random.uniform(0, 30), 2),
-        "close": round(base + random.uniform(-10, 20), 2),
-    }
+    return [
+        {
+            "ticker": "AAPL",
+            "open": base,
+            "high": round(base + random.uniform(0, 50), 2),
+            "low": round(base - random.uniform(0, 30), 2),
+            "close": round(base + random.uniform(-10, 20), 2),
+        }
+    ]


### PR DESCRIPTION
Update mock-ohlc and mock-daily-close builders to use the new multi-row interface:
- Return `list[dict]` instead of `dict`
- Accept `dict[str, list[dict]]` dependencies
- mock-daily-close accesses `dependencies["mock-ohlc"][0]` instead of `dependencies["mock-ohlc"]`