### PR TITLE
feat: add mock-multi-ohlc builder

### DIFF
--- a/builders/scripts/mock-multi-ohlc/0.1.0/builder.py
+++ b/builders/scripts/mock-multi-ohlc/0.1.0/builder.py
@@ -1,0 +1,22 @@
+import random
+from datetime import datetime
+
+TICKERS = ["AAPL", "MSFT", "GOOG"]
+
+
+def build(dependencies: dict[str, list[dict]], timestamp: datetime) -> list[dict]:
+    """Generate deterministic mock OHLC data for multiple tickers."""
+    rows = []
+    for ticker in TICKERS:
+        random.seed(f"{ticker}-{timestamp}")
+        base = round(random.uniform(100, 300), 2)
+        rows.append(
+            {
+                "ticker": ticker,
+                "open": base,
+                "high": round(base + random.uniform(0, 50), 2),
+                "low": round(base - random.uniform(0, 30), 2),
+                "close": round(base + random.uniform(-10, 20), 2),
+            }
+        )
+    return rows

--- a/builders/scripts/mock-multi-ohlc/0.1.0/config.toml
+++ b/builders/scripts/mock-multi-ohlc/0.1.0/config.toml
@@ -1,0 +1,12 @@
+name = "mock-multi-ohlc"
+version = "0.1.0"
+builder = "builder.py"
+calendar = "NYSE"
+granularity = "1d"
+
+[schema]
+ticker = "str"
+open = "float"
+high = "float"
+low = "float"
+close = "float"


### PR DESCRIPTION
Add a new mock builder that generates OHLC data for multiple tickers (AAPL, MSFT, GOOG) per timestamp. This exercises the multi-row per timestamp feature.