### PR TITLE
feat: add mock-multi-close builder

### DIFF
--- a/builders/scripts/mock-multi-close/0.1.0/builder.py
+++ b/builders/scripts/mock-multi-close/0.1.0/builder.py
@@ -1,0 +1,9 @@
+from datetime import datetime
+
+
+def build(dependencies: dict[str, list[dict]], timestamp: datetime) -> list[dict]:
+    """Extract close prices from multi-row OHLC dependency."""
+    return [
+        {"ticker": row["ticker"], "close": row["close"]}
+        for row in dependencies["mock-multi-ohlc"]
+    ]

--- a/builders/scripts/mock-multi-close/0.1.0/config.toml
+++ b/builders/scripts/mock-multi-close/0.1.0/config.toml
@@ -1,0 +1,12 @@
+name = "mock-multi-close"
+version = "0.1.0"
+builder = "builder.py"
+calendar = "NYSE"
+granularity = "1d"
+
+[schema]
+ticker = "str"
+close = "float"
+
+[dependencies]
+mock-multi-ohlc = "0.1.0"


### PR DESCRIPTION
Add mock-multi-close builder that depends on mock-multi-ohlc. Takes the multi-row OHLC dependency and extracts close prices for each ticker, demonstrating multi-row dependency consumption.