### PR TITLE
chore: add sqlfluff to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,11 @@ repos:
           - types-requests
           - types-psycopg2
 
+  - repo: https://github.com/sqlfluff/sqlfluff
+    rev: 4.0.4
+    hooks:
+      - id: sqlfluff-lint
+
   - repo: local
     hooks:
       - id: pytest

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,0 +1,6 @@
+[sqlfluff]
+dialect = postgres
+
+[sqlfluff:rules:references.keywords]
+# timestamp and data are valid postgres column names; quoting them triggers RF06
+ignore_words = timestamp,data

--- a/infra/postgres/init.sql
+++ b/infra/postgres/init.sql
@@ -1,9 +1,9 @@
 CREATE TABLE datasets (
-    id          BIGSERIAL PRIMARY KEY,
-    created_at  TIMESTAMP(6) NOT NULL DEFAULT now(),
-    dataset_name    TEXT NOT NULL,
+    id BIGSERIAL PRIMARY KEY,
+    created_at TIMESTAMP(6) NOT NULL DEFAULT now(),
+    dataset_name TEXT NOT NULL,
     dataset_version TEXT NOT NULL,
-    timestamp       TIMESTAMP(6) NOT NULL,
-    data            JSONB NOT NULL,
+    timestamp TIMESTAMP(6) NOT NULL,
+    data JSONB NOT NULL,
     UNIQUE (dataset_name, dataset_version, timestamp)
 );


### PR DESCRIPTION
Adds sqlfluff 4.0.4 to the pre-commit hook config to lint SQL files.

Also adds a .sqlfluff config that sets the dialect to postgres and ignores RF04 (keywords as identifiers) for timestamp and data, which are valid postgres column names but would otherwise conflict with RF06 (unnecessary quoting). Fixes the alignment spacing in init.sql to pass the linter.