### PR TITLE
chore: add absolute path check to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,11 @@ repos:
 
   - repo: local
     hooks:
+      - id: no-absolute-paths
+        name: check for absolute paths
+        language: pygrep
+        entry: '/(?:Users|home|root)/[a-zA-Z0-9_.-]+|[A-Z]:\\[A-Za-z]'
+
       - id: pytest
         name: pytest
         entry: bash -c 'uv run pytest'


### PR DESCRIPTION
Adds a local pygrep pre-commit hook that fails if any staged file contains a hardcoded absolute path matching common Unix user dirs (/Users/, /home/, /root/) or Windows drive paths (C:\...).

Catches accidentally committed machine-specific paths before they hit the repo.