### PR TITLE
feat: set up barebones rust api server with ping endpoint

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+axum = "0.8"
+tokio = { version = "1", features = ["full"] }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,3 +1,16 @@
-fn main() {
-    println!("Hello, world!");
+use axum::{Router, http::StatusCode, routing::get};
+use tokio::net::TcpListener;
+
+/// Returns 200 OK.
+async fn ping() -> StatusCode {
+    StatusCode::OK
+}
+
+#[tokio::main]
+async fn main() {
+    let app = Router::new().route("/ping", get(ping));
+
+    let listener = TcpListener::bind("0.0.0.0:3000").await.unwrap();
+    println!("listening on {}", listener.local_addr().unwrap());
+    axum::serve(listener, app).await.unwrap();
 }


### PR DESCRIPTION
Set up the barebones Rust API server using axum and tokio with a single GET /ping endpoint that returns 200. This is the foundation for the main API service described in the spec.