### PR TITLE
chore: add build-rs and clippy recipes to justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -4,5 +4,11 @@ lint:
 test:
     uv run pytest
 
+build-rs:
+    cd api && cargo build
+
+clippy:
+    cd api && cargo clippy -- -D warnings
+
 precommit:
     uv run pre-commit run --all-files


### PR DESCRIPTION
Add two justfile recipes for the Rust API: `just build-rs` to build and `just clippy` to lint with warnings-as-errors.