### PR TITLE
chore: add cargo build and clippy pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,20 @@ repos:
         language: pygrep
         entry: '/(?:Users|home|root)/[a-zA-Z0-9_.-]+|[A-Z]:\\[A-Za-z]'
 
+      - id: cargo-build
+        name: cargo build
+        entry: bash -c 'cd api && cargo build'
+        language: system
+        files: ^api/
+        pass_filenames: false
+
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: bash -c 'cd api && cargo clippy -- -D warnings'
+        language: system
+        files: ^api/
+        pass_filenames: false
+
       - id: pytest
         name: pytest
         entry: bash -c 'uv run pytest'


### PR DESCRIPTION
Add cargo build and clippy as pre-commit hooks, scoped to files under api/. Catches compile errors and lint warnings before they hit CI.