### PR TITLE
feat: use SemVer in db layer

### DIFF
--- a/builders/server/db/datasets.py
+++ b/builders/server/db/datasets.py
@@ -3,13 +3,14 @@ from datetime import datetime
 
 import psycopg2
 from psycopg2.extras import RealDictCursor, execute_values
+from utils.semver import SemVer
 
 from db.connection import get_conn
 
 
 def get_existing_timestamps(
     dataset_name: str,
-    dataset_version: str,
+    dataset_version: SemVer,
     start: datetime,
     end: datetime,
 ) -> list[datetime]:
@@ -25,14 +26,14 @@ def get_existing_timestamps(
               AND timestamp <= %s
             ORDER BY timestamp
             """,
-            (dataset_name, dataset_version, start, end),
+            (dataset_name, str(dataset_version), start, end),
         )
         return [row[0] for row in cur.fetchall()]
 
 
 def insert_rows(
     dataset_name: str,
-    dataset_version: str,
+    dataset_version: SemVer,
     rows: list[tuple[datetime, list[dict]]],
 ) -> None:
     """Bulk insert rows into the datasets table.
@@ -53,7 +54,7 @@ def insert_rows(
             [
                 (
                     dataset_name,
-                    dataset_version,
+                    str(dataset_version),
                     ts,
                     psycopg2.extras.Json(data),
                 )
@@ -66,7 +67,7 @@ def insert_rows(
 
 def get_rows(
     dataset_name: str,
-    dataset_version: str,
+    dataset_version: SemVer,
     timestamps: list[datetime],
 ) -> dict[datetime, list[dict]]:
     """Fetch data for specific timestamps, returning a list of dicts per timestamp."""
@@ -83,7 +84,7 @@ def get_rows(
             """,
             (
                 dataset_name,
-                dataset_version,
+                str(dataset_version),
                 timestamps,
             ),
         )

--- a/builders/server/tests/db/test_datasets.py
+++ b/builders/server/tests/db/test_datasets.py
@@ -2,6 +2,9 @@ from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 from db import datasets
+from utils.semver import SemVer
+
+V010 = SemVer.parse("0.1.0")
 
 
 @patch("db.datasets.get_conn")
@@ -18,7 +21,7 @@ def test_get_existing_timestamps(mock_get_conn: MagicMock) -> None:
     mock_get_conn.return_value = mock_conn
 
     result = datasets.get_existing_timestamps(
-        "ds", "0.1.0", datetime(2024, 1, 1), datetime(2024, 1, 31)
+        "ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 31)
     )
     assert len(result) == 2
     assert result[0] == datetime(2024, 1, 1)
@@ -40,7 +43,7 @@ def test_get_existing_timestamps_empty(mock_get_conn: MagicMock) -> None:
     mock_get_conn.return_value = mock_conn
 
     result = datasets.get_existing_timestamps(
-        "ds", "0.1.0", datetime(2024, 1, 1), datetime(2024, 1, 31)
+        "ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 31)
     )
     assert result == []
 
@@ -48,7 +51,7 @@ def test_get_existing_timestamps_empty(mock_get_conn: MagicMock) -> None:
 @patch("db.datasets.get_conn")
 def test_insert_rows_empty_returns_early(mock_get_conn: MagicMock) -> None:
     """Empty rows list skips DB call."""
-    datasets.insert_rows("ds", "0.1.0", [])
+    datasets.insert_rows("ds", V010, [])
     mock_get_conn.assert_not_called()
 
 
@@ -67,7 +70,7 @@ def test_insert_rows_calls_execute_values(
     rows: list[tuple[datetime, list[dict]]] = [
         (datetime(2024, 1, 1), [{"ticker": "AAPL"}, {"ticker": "MSFT"}])
     ]
-    datasets.insert_rows("ds", "0.1.0", rows)
+    datasets.insert_rows("ds", V010, rows)
 
     mock_exec_values.assert_called_once()
     args = mock_exec_values.call_args
@@ -78,9 +81,11 @@ def test_insert_rows_calls_execute_values(
 
 
 @patch("db.datasets.get_conn")
-def test_get_rows_empty_timestamps_returns_empty_dict(mock_get_conn: MagicMock) -> None:
+def test_get_rows_empty_timestamps_returns_empty_dict(
+    mock_get_conn: MagicMock,
+) -> None:
     """Empty input returns empty dict."""
-    result = datasets.get_rows("ds", "0.1.0", [])
+    result = datasets.get_rows("ds", V010, [])
     assert result == {}
     mock_get_conn.assert_not_called()
 
@@ -99,7 +104,7 @@ def test_get_rows_returns_list_per_timestamp(mock_get_conn: MagicMock) -> None:
     mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
     mock_get_conn.return_value = mock_conn
 
-    result = datasets.get_rows("ds", "0.1.0", [ts])
+    result = datasets.get_rows("ds", V010, [ts])
     assert ts in result
     assert len(result[ts]) == 2
     assert result[ts][0] == {"ticker": "AAPL", "price": 100}


### PR DESCRIPTION
Changes `db/datasets.py` to accept `SemVer` instead of raw strings for `dataset_version`. Converts to string via `str()` only when passing to SQL params. Tests updated accordingly.