### PR TITLE
feat: use SemVer in runtime layer

### DIFF
--- a/builders/server/runtime/config.py
+++ b/builders/server/runtime/config.py
@@ -1,10 +1,12 @@
 import tomllib
 from pathlib import Path
 
+from utils.semver import SemVer
+
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
 
 
-def validate_config(config: dict, dataset_name: str, dataset_version: str) -> None:
+def validate_config(config: dict, dataset_name: str, dataset_version: SemVer) -> None:
     """Validate that a parsed config dict has required fields and matches
     the dataset path."""
 
@@ -25,16 +27,18 @@ def validate_config(config: dict, dataset_name: str, dataset_version: str) -> No
             f"config.toml name '{config['name']}' does not match "
             f"directory name '{dataset_name}'"
         )
-    if config["version"] != dataset_version:
+
+    config_version = SemVer.parse(config["version"])
+    if config_version != dataset_version:
         raise ValueError(
             f"config.toml version '{config['version']}' does not match "
             f"directory version '{dataset_version}'"
         )
 
 
-def load_config(dataset_name: str, dataset_version: str) -> dict:
+def load_config(dataset_name: str, dataset_version: SemVer) -> dict:
     """Load and validate config.toml for a given dataset."""
-    config_path = SCRIPTS_DIR / dataset_name / dataset_version / "config.toml"
+    config_path = SCRIPTS_DIR / dataset_name / str(dataset_version) / "config.toml"
     with open(config_path, "rb") as f:
         config = tomllib.load(f)
 

--- a/builders/server/runtime/loader.py
+++ b/builders/server/runtime/loader.py
@@ -3,12 +3,14 @@ import sys
 from collections.abc import Callable
 from pathlib import Path
 
+from utils.semver import SemVer
+
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
 
 
-def load_builder(dataset_name: str, dataset_version: str) -> Callable:
+def load_builder(dataset_name: str, dataset_version: SemVer) -> Callable:
     """Dynamically import the build function from a builder script."""
-    script_dir = SCRIPTS_DIR / dataset_name / dataset_version
+    script_dir = SCRIPTS_DIR / dataset_name / str(dataset_version)
     builder_path = script_dir / "builder.py"
 
     # Add the script's directory to sys.path so relative imports work

--- a/builders/server/tests/runtime/test_config.py
+++ b/builders/server/tests/runtime/test_config.py
@@ -3,6 +3,9 @@ from pathlib import Path
 
 import pytest
 from runtime import config
+from utils.semver import SemVer
+
+V010 = SemVer.parse("0.1.0")
 
 
 def test_load_valid_config(mock_scripts_dir: Path, write_config: Callable) -> None:
@@ -18,7 +21,7 @@ builder = "builder.py"
 granularity = "1d"
 """,
     )
-    cfg = config.load_config("my-dataset", "0.1.0")
+    cfg = config.load_config("my-dataset", V010)
     assert cfg["name"] == "my-dataset"
     assert cfg["version"] == "0.1.0"
     assert cfg["granularity"] == "1d"
@@ -27,7 +30,7 @@ granularity = "1d"
 def test_load_config_missing_file_raises(mock_scripts_dir: Path) -> None:
     """Nonexistent file raises FileNotFoundError."""
     with pytest.raises(FileNotFoundError):
-        config.load_config("nonexistent", "0.0.1")
+        config.load_config("nonexistent", SemVer.parse("0.0.1"))
 
 
 def test_load_config_missing_name_field(
@@ -43,7 +46,7 @@ version = "0.1.0"
 """,
     )
     with pytest.raises(ValueError, match="missing 'name' field"):
-        config.load_config("ds", "0.1.0")
+        config.load_config("ds", V010)
 
 
 def test_load_config_missing_version_field(
@@ -59,7 +62,7 @@ name = "ds"
 """,
     )
     with pytest.raises(ValueError, match="missing 'version' field"):
-        config.load_config("ds", "0.1.0")
+        config.load_config("ds", V010)
 
 
 def test_load_config_name_mismatch(
@@ -76,7 +79,7 @@ version = "0.1.0"
 """,
     )
     with pytest.raises(ValueError, match="does not match"):
-        config.load_config("ds", "0.1.0")
+        config.load_config("ds", V010)
 
 
 def test_load_config_version_mismatch(
@@ -93,7 +96,7 @@ version = "9.9.9"
 """,
     )
     with pytest.raises(ValueError, match="does not match"):
-        config.load_config("ds", "0.1.0")
+        config.load_config("ds", V010)
 
 
 def test_load_config_with_dependencies(
@@ -113,7 +116,7 @@ dep-a = "0.0.2"
 dep-b = "1.0.0"
 """,
     )
-    cfg = config.load_config("ds", "0.1.0")
+    cfg = config.load_config("ds", V010)
     assert cfg["dependencies"] == {"dep-a": "0.0.2", "dep-b": "1.0.0"}
 
 
@@ -134,5 +137,5 @@ ticker = "str"
 price = "int"
 """,
     )
-    cfg = config.load_config("ds", "0.1.0")
+    cfg = config.load_config("ds", V010)
     assert cfg["schema"] == {"ticker": "str", "price": "int"}

--- a/builders/server/tests/runtime/test_loader.py
+++ b/builders/server/tests/runtime/test_loader.py
@@ -4,6 +4,9 @@ from pathlib import Path
 
 import pytest
 from runtime import loader
+from utils.semver import SemVer
+
+V010 = SemVer.parse("0.1.0")
 
 
 def test_load_builder_returns_callable(
@@ -19,7 +22,7 @@ def build(dependencies, timestamp):
     return {"value": 1}
 """,
     )
-    fn = loader.load_builder("ds", "0.1.0")
+    fn = loader.load_builder("ds", V010)
     assert callable(fn)
 
 
@@ -36,7 +39,7 @@ def build(dependencies, timestamp):
     return {"ticker": "AAPL", "price": 42}
 """,
     )
-    fn = loader.load_builder("ds", "0.1.0")
+    fn = loader.load_builder("ds", V010)
     result = fn({}, None)
     assert result == {"ticker": "AAPL", "price": 42}
 
@@ -54,7 +57,7 @@ def build(dependencies, timestamp):
     return {}
 """,
     )
-    loader.load_builder("ds", "0.1.0")
+    loader.load_builder("ds", V010)
     script_dir = str(mock_scripts_dir / "ds" / "0.1.0")
     assert script_dir in sys.path
 
@@ -64,7 +67,7 @@ def test_load_builder_missing_file_raises(mock_scripts_dir: Path) -> None:
     d = mock_scripts_dir / "ds" / "0.1.0"
     d.mkdir(parents=True)
     with pytest.raises(FileNotFoundError):
-        loader.load_builder("ds", "0.1.0")
+        loader.load_builder("ds", V010)
 
 
 def test_load_builder_missing_build_function(
@@ -81,7 +84,7 @@ def not_build():
 """,
     )
     with pytest.raises(AttributeError):
-        loader.load_builder("ds", "0.1.0")
+        loader.load_builder("ds", V010)
 
 
 def test_load_builder_with_relative_import(
@@ -102,6 +105,6 @@ def build(dependencies, timestamp):
     return {"value": helper.VALUE}
 """,
     )
-    fn = loader.load_builder("ds", "0.1.0")
+    fn = loader.load_builder("ds", V010)
     result = fn({}, None)
     assert result == {"value": 99}


### PR DESCRIPTION
Updates `config.py` and `loader.py` to accept `SemVer` for `dataset_version`. Config validation now compares parsed SemVer objects instead of raw strings. Loader uses `str()` for path construction. Tests updated.