### PR TITLE
feat: use SemVer in API layer

### DIFF
--- a/builders/server/api/routes.py
+++ b/builders/server/api/routes.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from fastapi import APIRouter, HTTPException, Query
 from service.builder import build_dataset
+from utils.semver import SemVer
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +19,13 @@ def build(
 ):
     """Build missing data for a dataset in the given time range."""
     try:
+        version = SemVer.parse(dataset_version)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400, detail=f"Invalid version: {dataset_version}"
+        ) from exc
+
+    try:
         start_ts = datetime.fromisoformat(start)
         end_ts = datetime.fromisoformat(end)
     except Exception as exc:
@@ -26,9 +34,9 @@ def build(
         ) from exc
 
     try:
-        build_dataset(dataset_name, dataset_version, start_ts, end_ts)
+        build_dataset(dataset_name, version, start_ts, end_ts)
     except Exception as e:
-        logger.exception(f"Build failed for {dataset_name}/{dataset_version}")
+        logger.exception(f"Build failed for {dataset_name}/{version}")
         raise HTTPException(status_code=500, detail=str(e)) from e
 
     return {"status": "ok"}

--- a/builders/server/tests/api/test_routes.py
+++ b/builders/server/tests/api/test_routes.py
@@ -15,6 +15,12 @@ def test_build_endpoint_success(mock_build: MagicMock) -> None:
     assert resp.json() == {"status": "ok"}
 
 
+def test_build_endpoint_invalid_version() -> None:
+    """Bad version returns 400."""
+    resp = client.post("/build/ds/bad-version?start=2024-01-01&end=2024-01-31")
+    assert resp.status_code == 400
+
+
 def test_build_endpoint_invalid_timestamp() -> None:
     """Bad timestamp returns 400."""
     resp = client.post("/build/ds/0.1.0?start=not-a-date&end=2024-01-31")


### PR DESCRIPTION
Parses the `dataset_version` URL path param into `SemVer` at the API boundary. Returns 400 for invalid version strings. Added a test for invalid version format.