### PR TITLE
refactor: move TYPE_MAP from validator to config

### DIFF
--- a/builders/server/runtime/config.py
+++ b/builders/server/runtime/config.py
@@ -5,6 +5,15 @@ from utils.semver import SemVer
 
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
 
+# values must be valid arguments to isinstance (type or tuple of types)
+# keys define what strings are allowed in config.toml schema fields
+TYPE_MAP = {
+    "str": str,
+    "int": int,
+    "float": (int, float),  # accept int as valid float
+    "bool": bool,
+}
+
 
 def validate_config(config: dict, dataset_name: str, dataset_version: SemVer) -> None:
     """Validate that a parsed config dict has required fields and matches

--- a/builders/server/runtime/validator.py
+++ b/builders/server/runtime/validator.py
@@ -1,14 +1,8 @@
+from runtime.config import TYPE_MAP
+
+
 class ValidationError(Exception):
     pass
-
-
-# Values must be valid arguments to isinstance (type or tuple of types)
-TYPE_MAP = {
-    "str": str,
-    "int": int,
-    "float": (int, float),  # accept int as valid float
-    "bool": bool,
-}
 
 
 def validate(data: dict, schema: dict[str, str]) -> None:


### PR DESCRIPTION
Moves `TYPE_MAP` from `validator.py` to `config.py` so that the type registry lives next to the config spec. `validator.py` now imports it from there.