### PR TITLE
feat: validate schema field in validate_config

### DIFF
--- a/builders/server/runtime/config.py
+++ b/builders/server/runtime/config.py
@@ -20,7 +20,7 @@ def validate_config(config: dict, dataset_name: str, dataset_version: SemVer) ->
     the dataset path."""
 
     # TODO (bryan): validate the existence of other fields in the config
-    # toml such as builder, calender, granularity, schema
+    # toml such as builder, calender, granularity
     if "name" not in config:
         raise ValueError(
             f"config.toml for {dataset_name}/{dataset_version} is missing 'name' field"
@@ -43,6 +43,23 @@ def validate_config(config: dict, dataset_name: str, dataset_version: SemVer) ->
             f"config.toml version '{config['version']}' does not match "
             f"directory version '{dataset_version}'"
         )
+
+    if "schema" not in config:
+        raise ValueError(
+            f"config.toml for {dataset_name}/{dataset_version} "
+            "is missing 'schema' field"
+        )
+    if not config["schema"]:
+        raise ValueError(
+            f"config.toml for {dataset_name}/{dataset_version} "
+            "'schema' must not be empty"
+        )
+    for key, type_name in config["schema"].items():
+        if type_name not in TYPE_MAP:
+            raise ValueError(
+                f"config.toml for {dataset_name}/{dataset_version} has unknown "
+                f"type '{type_name}' for schema key '{key}'"
+            )
 
 
 def load_config(dataset_name: str, dataset_version: SemVer) -> dict:

--- a/builders/server/runtime/validator.py
+++ b/builders/server/runtime/validator.py
@@ -15,10 +15,7 @@ def validate(data: dict, schema: dict[str, str]) -> None:
         if key not in data:
             raise ValidationError(f"Missing key '{key}' in builder output")
 
-        if type_name not in TYPE_MAP:
-            raise ValidationError(
-                f"Unknown type '{type_name}' in schema for key '{key}'"
-            )
+        # will never fail, since schema is validated in config.py
         expected = TYPE_MAP[type_name]
 
         if not isinstance(data[key], expected):  # type: ignore[arg-type]  # expected is always a concrete type from TYPE_MAP

--- a/builders/server/tests/runtime/test_config.py
+++ b/builders/server/tests/runtime/test_config.py
@@ -19,6 +19,9 @@ name = "my-dataset"
 version = "0.1.0"
 builder = "builder.py"
 granularity = "1d"
+
+[schema]
+price = "int"
 """,
     )
     cfg = config.load_config("my-dataset", V010)
@@ -110,6 +113,9 @@ def test_load_config_with_dependencies(
         """
 name = "ds"
 version = "0.1.0"
+
+[schema]
+price = "int"
 
 [dependencies]
 dep-a = "0.0.2"

--- a/builders/server/tests/runtime/test_validator.py
+++ b/builders/server/tests/runtime/test_validator.py
@@ -23,12 +23,6 @@ def test_missing_key_raises() -> None:
         validate({}, {"ticker": "str"})
 
 
-def test_unknown_type_in_schema_raises() -> None:
-    """Unknown type string in schema raises ValidationError."""
-    with pytest.raises(ValidationError, match="Unknown type 'datetime'"):
-        validate({"x": 1}, {"x": "datetime"})
-
-
 def test_type_mismatch_str_raises() -> None:
     """Int where str expected raises ValidationError."""
     with pytest.raises(ValidationError, match="expected type 'str'"):


### PR DESCRIPTION
Adds schema field validation to `validate_config`: errors on missing schema, empty schema, and unknown type strings. This catches bad configs at load time rather than at validation time per-row.