### PR TITLE
refactor: move GRANULARITY_MAP to runtime/config

### DIFF
--- a/builders/server/runtime/config.py
+++ b/builders/server/runtime/config.py
@@ -1,4 +1,5 @@
 import tomllib
+from datetime import timedelta
 from pathlib import Path
 
 from utils.semver import SemVer
@@ -12,6 +13,13 @@ TYPE_MAP = {
     "int": int,
     "float": (int, float),  # accept int as valid float
     "bool": bool,
+}
+
+GRANULARITY_MAP = {
+    "1s": timedelta(seconds=1),
+    "1m": timedelta(minutes=1),
+    "1h": timedelta(hours=1),
+    "1d": timedelta(days=1),
 }
 
 

--- a/builders/server/service/builder.py
+++ b/builders/server/service/builder.py
@@ -1,18 +1,12 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import db.datasets
 from runtime import config, loader, runner, validator
+from runtime.config import GRANULARITY_MAP
 from utils.semver import SemVer
 
 logger = logging.getLogger(__name__)
-
-GRANULARITY_MAP = {
-    "1s": timedelta(seconds=1),
-    "1m": timedelta(minutes=1),
-    "1h": timedelta(hours=1),
-    "1d": timedelta(days=1),
-}
 
 
 def generate_timestamps(


### PR DESCRIPTION
moves GRANULARITY_MAP from service/builder.py to runtime/config.py, next to TYPE_MAP where other config-level constants live. builder.py now imports it from there.

no behavior change.