### PR TITLE
feat: validate granularity field in validate_config

### DIFF
--- a/builders/server/runtime/config.py
+++ b/builders/server/runtime/config.py
@@ -28,7 +28,7 @@ def validate_config(config: dict, dataset_name: str, dataset_version: SemVer) ->
     the dataset path."""
 
     # TODO (bryan): validate the existence of other fields in the config
-    # toml such as builder, calender, granularity
+    # toml such as builder, calender
     if "name" not in config:
         raise ValueError(
             f"config.toml for {dataset_name}/{dataset_version} is missing 'name' field"
@@ -68,6 +68,17 @@ def validate_config(config: dict, dataset_name: str, dataset_version: SemVer) ->
                 f"config.toml for {dataset_name}/{dataset_version} has unknown "
                 f"type '{type_name}' for schema key '{key}'"
             )
+
+    if "granularity" not in config:
+        raise ValueError(
+            f"config.toml for {dataset_name}/{dataset_version} "
+            "is missing 'granularity' field"
+        )
+    if config["granularity"] not in GRANULARITY_MAP:
+        raise ValueError(
+            f"config.toml for {dataset_name}/{dataset_version} has unknown "
+            f"granularity '{config['granularity']}'"
+        )
 
 
 def load_config(dataset_name: str, dataset_version: SemVer) -> dict:

--- a/builders/server/tests/runtime/test_config.py
+++ b/builders/server/tests/runtime/test_config.py
@@ -113,6 +113,7 @@ def test_load_config_with_dependencies(
         """
 name = "ds"
 version = "0.1.0"
+granularity = "1d"
 
 [schema]
 price = "int"
@@ -193,6 +194,7 @@ def test_load_config_with_schema(
         """
 name = "ds"
 version = "0.1.0"
+granularity = "1d"
 
 [schema]
 ticker = "str"
@@ -201,3 +203,38 @@ price = "int"
     )
     cfg = config.load_config("ds", V010)
     assert cfg["schema"] == {"ticker": "str", "price": "int"}
+
+
+def test_load_config_missing_granularity_raises(
+    mock_scripts_dir: Path, write_config: Callable
+) -> None:
+    """Config without granularity raises ValueError."""
+    write_config(
+        mock_scripts_dir,
+        "ds",
+        "0.1.0",
+        """
+name = "ds"
+version = "0.1.0"
+""",
+    )
+    with pytest.raises(ValueError, match="missing 'granularity' field"):
+        config.load_config("ds", V010)
+
+
+def test_load_config_invalid_granularity_raises(
+    mock_scripts_dir: Path, write_config: Callable
+) -> None:
+    """Config with unknown granularity raises ValueError."""
+    write_config(
+        mock_scripts_dir,
+        "ds",
+        "0.1.0",
+        """
+name = "ds"
+version = "0.1.0"
+granularity = "1w"
+""",
+    )
+    with pytest.raises(ValueError, match="unknown granularity '1w'"):
+        config.load_config("ds", V010)


### PR DESCRIPTION
validates the granularity field in validate_config. field must be present and must be one of the known values in GRANULARITY_MAP (1s, 1m, 1h, 1d).

removes granularity from the TODO comment in validate_config since it's now handled. updates existing test fixtures missing granularity and adds two new tests.