### PR TITLE
feat: add start-date field to mock builder configs

### DIFF
--- a/builders/scripts/mock-daily-close/0.1.0/config.toml
+++ b/builders/scripts/mock-daily-close/0.1.0/config.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 builder = "builder.py"
 calendar = "NYSE"
 granularity = "1d"
+start-date = "2020-01-01"
 
 [schema]
 ticker = "str"

--- a/builders/scripts/mock-multi-close/0.1.0/config.toml
+++ b/builders/scripts/mock-multi-close/0.1.0/config.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 builder = "builder.py"
 calendar = "NYSE"
 granularity = "1d"
+start-date = "2020-01-01"
 
 [schema]
 ticker = "str"

--- a/builders/scripts/mock-multi-ohlc/0.1.0/config.toml
+++ b/builders/scripts/mock-multi-ohlc/0.1.0/config.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 builder = "builder.py"
 calendar = "NYSE"
 granularity = "1d"
+start-date = "2020-01-01"
 
 [schema]
 ticker = "str"

--- a/builders/scripts/mock-ohlc/0.1.0/config.toml
+++ b/builders/scripts/mock-ohlc/0.1.0/config.toml
@@ -3,6 +3,7 @@ version = "0.1.0"
 builder = "builder.py"
 calendar = "NYSE"
 granularity = "1d"
+start-date = "2020-01-01"
 
 [schema]
 ticker = "str"


### PR DESCRIPTION
Add `start-date = "2020-01-01"` to all 4 mock builder configs (mock-ohlc, mock-daily-close, mock-multi-ohlc, mock-multi-close).

This is prep for enforcing start-date validation and build-time clamping in later PRs.