### PR TITLE
feat: add start-date validation to config.py

### DIFF
--- a/builders/server/runtime/config.py
+++ b/builders/server/runtime/config.py
@@ -1,5 +1,6 @@
+import re
 import tomllib
-from datetime import timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 
 from utils.semver import SemVer
@@ -87,6 +88,30 @@ def _validate_granularity(
         )
 
 
+def _validate_start_date(
+    config: dict, dataset_name: str, dataset_version: SemVer
+) -> None:
+    """Validate that start-date is present and a valid YYYY-MM-DD date."""
+    if "start-date" not in config:
+        raise ValueError(
+            f"config.toml for {dataset_name}/{dataset_version} "
+            "is missing 'start-date' field"
+        )
+    value = config["start-date"]
+    if not isinstance(value, str) or not re.fullmatch(r"\d{4}-\d{2}-\d{2}", value):
+        raise ValueError(
+            f"config.toml for {dataset_name}/{dataset_version} has invalid "
+            f"start-date '{value}', expected YYYY-MM-DD format"
+        )
+    try:
+        datetime.strptime(value, "%Y-%m-%d")
+    except ValueError as err:
+        raise ValueError(
+            f"config.toml for {dataset_name}/{dataset_version} has invalid "
+            f"start-date '{value}', not a real date"
+        ) from err
+
+
 def validate_config(config: dict, dataset_name: str, dataset_version: SemVer) -> None:
     """Validate that a parsed config dict has required fields and matches
     the dataset path."""
@@ -95,6 +120,7 @@ def validate_config(config: dict, dataset_name: str, dataset_version: SemVer) ->
     _validate_name_version(config, dataset_name, dataset_version)
     _validate_schema(config, dataset_name, dataset_version)
     _validate_granularity(config, dataset_name, dataset_version)
+    _validate_start_date(config, dataset_name, dataset_version)
 
 
 def load_config(dataset_name: str, dataset_version: SemVer) -> dict:

--- a/builders/server/tests/runtime/test_config.py
+++ b/builders/server/tests/runtime/test_config.py
@@ -19,6 +19,7 @@ name = "my-dataset"
 version = "0.1.0"
 builder = "builder.py"
 granularity = "1d"
+start-date = "2020-01-01"
 
 [schema]
 price = "int"
@@ -114,6 +115,7 @@ def test_load_config_with_dependencies(
 name = "ds"
 version = "0.1.0"
 granularity = "1d"
+start-date = "2020-01-01"
 
 [schema]
 price = "int"
@@ -195,6 +197,7 @@ def test_load_config_with_schema(
 name = "ds"
 version = "0.1.0"
 granularity = "1d"
+start-date = "2020-01-01"
 
 [schema]
 ticker = "str"
@@ -244,3 +247,90 @@ price = "int"
     )
     with pytest.raises(ValueError, match="unknown granularity '1w'"):
         config.load_config("ds", V010)
+
+
+def test_load_config_missing_start_date_raises(
+    mock_scripts_dir: Path, write_config: Callable
+) -> None:
+    """Config without start-date raises ValueError."""
+    write_config(
+        mock_scripts_dir,
+        "ds",
+        "0.1.0",
+        """
+name = "ds"
+version = "0.1.0"
+granularity = "1d"
+
+[schema]
+price = "int"
+""",
+    )
+    with pytest.raises(ValueError, match="missing 'start-date' field"):
+        config.load_config("ds", V010)
+
+
+def test_load_config_invalid_start_date_format_raises(
+    mock_scripts_dir: Path, write_config: Callable
+) -> None:
+    """Config with wrong date format raises ValueError."""
+    write_config(
+        mock_scripts_dir,
+        "ds",
+        "0.1.0",
+        """
+name = "ds"
+version = "0.1.0"
+granularity = "1d"
+start-date = "01-01-2024"
+
+[schema]
+price = "int"
+""",
+    )
+    with pytest.raises(ValueError, match="invalid start-date"):
+        config.load_config("ds", V010)
+
+
+def test_load_config_invalid_start_date_not_a_date_raises(
+    mock_scripts_dir: Path, write_config: Callable
+) -> None:
+    """Config with impossible date raises ValueError."""
+    write_config(
+        mock_scripts_dir,
+        "ds",
+        "0.1.0",
+        """
+name = "ds"
+version = "0.1.0"
+granularity = "1d"
+start-date = "2024-13-01"
+
+[schema]
+price = "int"
+""",
+    )
+    with pytest.raises(ValueError, match="not a real date"):
+        config.load_config("ds", V010)
+
+
+def test_load_config_valid_start_date(
+    mock_scripts_dir: Path, write_config: Callable
+) -> None:
+    """Config with valid start-date passes validation."""
+    write_config(
+        mock_scripts_dir,
+        "ds",
+        "0.1.0",
+        """
+name = "ds"
+version = "0.1.0"
+granularity = "1d"
+start-date = "2024-06-15"
+
+[schema]
+price = "int"
+""",
+    )
+    cfg = config.load_config("ds", V010)
+    assert cfg["start-date"] == "2024-06-15"


### PR DESCRIPTION
Add `_validate_start_date()` helper to `config.py` that checks:
- field exists
- format is YYYY-MM-DD
- value is an actual date (not e.g. 2024-13-01)

Called from `validate_config()` alongside existing validators. Tests cover missing field, bad format, impossible date, and valid date.