### PR TITLE
feat: add validate_dependency_graph and enforce granularity constraint

### DIFF
--- a/builders/server/service/builder.py
+++ b/builders/server/service/builder.py
@@ -24,6 +24,37 @@ def generate_timestamps(
     return timestamps
 
 
+def validate_dependency_graph(
+    dataset_name: str,
+    dataset_version: SemVer,
+) -> None:
+    """Walk the dependency tree and validate granularity constraints.
+
+    A dataset's granularity must be >= (coarser or equal to) each
+    dependency's granularity. Raises ValueError if violated.
+    """
+    cfg = config.load_config(dataset_name, dataset_version)
+    granularity = cfg.get("granularity", "1d")
+    parent_delta = GRANULARITY_MAP[granularity]
+
+    for dep_name, dep_version_str in cfg.get("dependencies", {}).items():
+        dep_version = SemVer.parse(dep_version_str)
+        dep_cfg = config.load_config(dep_name, dep_version)
+        dep_granularity = dep_cfg.get("granularity", "1d")
+        dep_delta = GRANULARITY_MAP[dep_granularity]
+
+        if parent_delta < dep_delta:
+            raise ValueError(
+                f"{dataset_name}/{dataset_version} has granularity "
+                f"'{granularity}' which is finer than dependency "
+                f"'{dep_name}/{dep_version}' with granularity "
+                f"'{dep_granularity}'"
+            )
+
+        # recurse into dependency's own dependencies
+        validate_dependency_graph(dep_name, dep_version)
+
+
 def build_dataset(
     dataset_name: str,
     dataset_version: SemVer,
@@ -31,6 +62,7 @@ def build_dataset(
     end: datetime,
 ) -> None:
     """Public entrypoint for building a dataset and its dependencies."""
+    validate_dependency_graph(dataset_name, dataset_version)
     _build_recursive(dataset_name, dataset_version, start, end)
 
 

--- a/builders/server/tests/service/test_builder.py
+++ b/builders/server/tests/service/test_builder.py
@@ -2,7 +2,11 @@ from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
-from service.builder import build_dataset, generate_timestamps
+from service.builder import (
+    build_dataset,
+    generate_timestamps,
+    validate_dependency_graph,
+)
 from utils.semver import SemVer
 
 V010 = SemVer.parse("0.1.0")
@@ -338,3 +342,127 @@ def test_build_dataset_after_start_date_proceeds_normally(
     timestamps = [row[0] for row in inserted_rows]
     assert timestamps[0] == datetime(2024, 1, 1)
     assert len(timestamps) == 3
+
+
+# --- validate_dependency_graph tests ---
+
+
+@patch("service.builder.config")
+def test_validate_graph_coarser_parent_passes(
+    mock_config: MagicMock,
+) -> None:
+    """1d parent depending on 1h dep is valid."""
+
+    def fake_load_config(name, version):
+        if name == "parent":
+            return {
+                "name": "parent",
+                "version": "0.1.0",
+                "granularity": "1d",
+                "schema": {"val": "int"},
+                "start-date": "2020-01-01",
+                "dependencies": {"child": "0.1.0"},
+            }
+        return {
+            "name": "child",
+            "version": "0.1.0",
+            "granularity": "1h",
+            "schema": {"val": "int"},
+            "start-date": "2020-01-01",
+        }
+
+    mock_config.load_config.side_effect = fake_load_config
+    # should not raise
+    validate_dependency_graph("parent", V010)
+
+
+@patch("service.builder.config")
+def test_validate_graph_equal_granularity_passes(
+    mock_config: MagicMock,
+) -> None:
+    """1d parent depending on 1d dep is valid."""
+
+    def fake_load_config(name, version):
+        if name == "parent":
+            return {
+                "name": "parent",
+                "version": "0.1.0",
+                "granularity": "1d",
+                "schema": {"val": "int"},
+                "start-date": "2020-01-01",
+                "dependencies": {"child": "0.1.0"},
+            }
+        return {
+            "name": "child",
+            "version": "0.1.0",
+            "granularity": "1d",
+            "schema": {"val": "int"},
+            "start-date": "2020-01-01",
+        }
+
+    mock_config.load_config.side_effect = fake_load_config
+    # should not raise
+    validate_dependency_graph("parent", V010)
+
+
+@patch("service.builder.config")
+def test_validate_graph_finer_parent_raises(
+    mock_config: MagicMock,
+) -> None:
+    """1h parent depending on 1d dep raises ValueError."""
+
+    def fake_load_config(name, version):
+        if name == "parent":
+            return {
+                "name": "parent",
+                "version": "0.1.0",
+                "granularity": "1h",
+                "schema": {"val": "int"},
+                "start-date": "2020-01-01",
+                "dependencies": {"child": "0.1.0"},
+            }
+        return {
+            "name": "child",
+            "version": "0.1.0",
+            "granularity": "1d",
+            "schema": {"val": "int"},
+            "start-date": "2020-01-01",
+        }
+
+    mock_config.load_config.side_effect = fake_load_config
+    with pytest.raises(ValueError, match="finer than dependency"):
+        validate_dependency_graph("parent", V010)
+
+
+@patch("service.builder.config")
+def test_validate_graph_two_deps_one_coarser_raises(
+    mock_config: MagicMock,
+) -> None:
+    """1h parent with 1m and 1d deps raises on the coarser dep."""
+    configs = {
+        "parent": {
+            "name": "parent",
+            "version": "0.1.0",
+            "granularity": "1h",
+            "schema": {"val": "int"},
+            "start-date": "2020-01-01",
+            "dependencies": {"fine": "0.1.0", "coarse": "0.1.0"},
+        },
+        "fine": {
+            "name": "fine",
+            "version": "0.1.0",
+            "granularity": "1m",
+            "schema": {"val": "int"},
+            "start-date": "2020-01-01",
+        },
+        "coarse": {
+            "name": "coarse",
+            "version": "0.1.0",
+            "granularity": "1d",
+            "schema": {"val": "int"},
+            "start-date": "2020-01-01",
+        },
+    }
+    mock_config.load_config.side_effect = lambda name, version: configs[name]
+    with pytest.raises(ValueError, match="finer than dependency"):
+        validate_dependency_graph("parent", V010)


### PR DESCRIPTION
Add `validate_dependency_graph()` that walks the dependency tree and checks that a dataset's granularity is coarser than or equal to each dependency's granularity. Called from `build_dataset()` before any recursive building starts.

This prevents nonsensical dependency relationships (e.g. an hourly dataset depending on a daily one) and catches config mistakes early.