### PR TITLE
feat: add mock-moving-avg builder with lookback dependency

### DIFF
--- a/builders/scripts/mock-moving-avg/0.1.0/builder.py
+++ b/builders/scripts/mock-moving-avg/0.1.0/builder.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+
+
+def build(
+    dependencies: dict[str, dict[datetime, list[dict]]], timestamp: datetime
+) -> list[dict]:
+    """Compute 5-day moving average of close prices from lookback data."""
+    close_data = dependencies["mock-daily-close"]
+    prices = [rows[0]["close"] for rows in close_data.values()]
+
+    if not prices:
+        return [{"ticker": "AAPL", "average": 0.0}]
+
+    average = sum(prices) / len(prices)
+    return [{"ticker": "AAPL", "average": round(average, 2)}]

--- a/builders/scripts/mock-moving-avg/0.1.0/config.toml
+++ b/builders/scripts/mock-moving-avg/0.1.0/config.toml
@@ -1,0 +1,13 @@
+name = "mock-moving-avg"
+version = "0.1.0"
+builder = "builder.py"
+calendar = "NYSE"
+granularity = "1d"
+start-date = "2020-01-01"
+
+[schema]
+ticker = "str"
+average = "float"
+
+[dependencies]
+mock-daily-close = {version = "0.1.0", lookback = "5d"}


### PR DESCRIPTION
Add `mock-moving-avg/0.1.0` builder that depends on `mock-daily-close` with `lookback = "5d"`. Computes the average close price over the lookback window.

This is the first builder that uses the lookback feature, serving as a test/example for the new capability.