### PR TITLE
feat: add pgweb read-only postgres viewer

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -7,6 +7,11 @@ services:
       - "5432:5432"
     networks:
       - internal
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U datastream -d datastream"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
 
   builder:
     build:
@@ -19,6 +24,19 @@ services:
       - "8000:8000"
     depends_on:
       - postgres
+    networks:
+      - internal
+
+  pgweb:
+    image: sosedoff/pgweb:latest
+    command: ["--readonly", "--bind=0.0.0.0", "--listen=8080"]
+    environment:
+      PGWEB_DATABASE_URL: postgresql://datastream_readonly:readonly@postgres:5432/datastream?sslmode=disable
+    ports:
+      - "8080:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
     networks:
       - internal
 

--- a/infra/postgres/init.sql
+++ b/infra/postgres/init.sql
@@ -7,7 +7,16 @@ CREATE TABLE datasets (
     data JSONB NOT NULL
 );
 
--- non-unique index for range queries on 
+-- non-unique index for range queries on
 -- (dataset_name, dataset_version, timestamp)
 CREATE INDEX idx_datasets_name_version_ts
 ON datasets (dataset_name, dataset_version, timestamp);
+
+-- read-only role for the pgweb UI
+CREATE USER datastream_readonly WITH PASSWORD 'readonly';
+GRANT CONNECT ON DATABASE datastream TO datastream_readonly;
+GRANT USAGE ON SCHEMA public TO datastream_readonly;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO datastream_readonly;
+-- apply to future tables too
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+GRANT SELECT ON TABLES TO datastream_readonly;


### PR DESCRIPTION
adds pgweb as a read-only postgres viewer in docker compose

- new pgweb service using sosedoff/pgweb image, bound to port 8080
- postgres read-only user created in init.sql with select-only grants

makes it easy to browse the DB without needing a local client