### PR TITLE
docs: document pgweb postgres viewer in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ docker compose up --build -d
 This starts:
 - **Postgres** on the internal Docker network (also exposed on `localhost:5432`)
 - **Builder server** on the internal Docker network (also exposed on `localhost:8000`)
+- **Postgres viewer** (pgweb) at [http://localhost:8080](http://localhost:8080)
 
 To view logs:
 


### PR DESCRIPTION
documents pgweb in README

adds a bullet for the pgweb service under the docker compose up section so users know it's running at localhost:8080