### PR TITLE
chore: add docker-up and docker-down just commands

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,3 +1,9 @@
+docker-up:
+    docker compose -f infra/docker-compose.yml up --build -d
+
+docker-down:
+    docker compose -f infra/docker-compose.yml down
+
 lint:
     uv run ruff check
 


### PR DESCRIPTION
adds just docker-up and just docker-down commands

shortcuts for docker compose up --build -d and docker compose down so you don't have to remember the infra/ path