### PR TITLE
refactor: move validate_dependency_graph to _validate_dependency_graph_granularity

### DIFF
--- a/builders/server/service/builder.py
+++ b/builders/server/service/builder.py
@@ -24,9 +24,36 @@ def generate_timestamps(
     return timestamps
 
 
-def validate_dependency_graph(
-    dataset_name: str,
-    dataset_version: SemVer,
+def _validate_dependency_graph_start_date(
+    dataset_name: str, dataset_version: SemVer
+) -> datetime:
+    """
+    Walk the dependency tree and validate start date constrants.
+
+    A dataset's start date must be no earlier than any of its
+    dependency's start dates. Raises ValueError if violated.
+
+    Returns the current dataset's start date.
+    """
+    cfg = config.load_config(dataset_name, dataset_version)
+    parent_start_date = datetime.strptime(cfg["start-date"], "%Y-%m-%d")
+
+    for dep_name, dep_info in cfg.get("dependencies", {}).items():
+        dep_version = SemVer.parse(dep_info["version"])
+        dep_start_date = _validate_dependency_graph_start_date(dep_name, dep_version)
+
+        if parent_start_date < dep_start_date:
+            raise ValueError(
+                f"{dataset_name}/{dataset_version} has start date "
+                f"'{parent_start_date}' which comes before dependency "
+                f"{dep_name}/{dep_version} with start date {dep_start_date}"
+            )
+
+    return parent_start_date
+
+
+def _validate_dependency_graph_granularity(
+    dataset_name: str, dataset_version: SemVer
 ) -> None:
     """Walk the dependency tree and validate granularity constraints.
 
@@ -54,7 +81,15 @@ def validate_dependency_graph(
             )
 
         # recurse into dependency's own dependencies
-        validate_dependency_graph(dep_name, dep_version)
+        _validate_dependency_graph_granularity(dep_name, dep_version)
+
+
+def validate_dependency_graph(
+    dataset_name: str,
+    dataset_version: SemVer,
+) -> None:
+    _validate_dependency_graph_granularity(dataset_name, dataset_version)
+    _validate_dependency_graph_start_date(dataset_name, dataset_version)
 
 
 def build_dataset(

--- a/builders/server/tests/service/test_builder.py
+++ b/builders/server/tests/service/test_builder.py
@@ -484,6 +484,214 @@ def test_validate_graph_two_deps_one_coarser_raises(
         validate_dependency_graph("parent", V010)
 
 
+@pytest.mark.parametrize(
+    ["parent_start", "child1_start", "child2_start"],
+    [
+        ("2020-01-01", "2020-01-01", "2020-01-01"),
+        ("2020-01-03", "2020-01-01", "2020-01-02"),
+        ("2022-10-15", "2021-05-22", "2022-09-09"),
+    ],
+)
+@patch("service.builder.config")
+def test_validate_graph_start_dates_ok(
+    mock_config: MagicMock,
+    parent_start: str,
+    child1_start: str,
+    child2_start: str,
+) -> None:
+    """Parent has start date after children."""
+    configs = {
+        "parent": {
+            "name": "parent",
+            "version": "0.1.0",
+            "granularity": "1d",
+            "schema": {"val": "int"},
+            "start-date": parent_start,
+            "dependencies": {
+                "child1": {"version": "0.1.0", "lookback": None},
+                "child2": {"version": "0.1.0", "lookback": None},
+            },
+        },
+        "child1": {
+            "name": "child1",
+            "version": "0.1.0",
+            "granularity": "1d",
+            "schema": {"val": "int"},
+            "start-date": child1_start,
+        },
+        "child2": {
+            "name": "child2",
+            "version": "0.1.0",
+            "granularity": "1d",
+            "schema": {"val": "int"},
+            "start-date": child2_start,
+        },
+    }
+    mock_config.load_config.side_effect = lambda name, version: configs[name]
+    validate_dependency_graph("parent", V010)
+
+
+@patch("service.builder.config")
+def test_validate_graph_start_dates_parent_before_dep_raises(
+    mock_config: MagicMock,
+) -> None:
+    """Parent with start date before dep raises ValueError."""
+
+    def fake_load_config(name, version):
+        if name == "parent":
+            return {
+                "name": "parent",
+                "version": "0.1.0",
+                "granularity": "1d",
+                "schema": {"val": "int"},
+                "start-date": "2020-01-01",
+                "dependencies": {"child": {"version": "0.1.0", "lookback": None}},
+            }
+        return {
+            "name": "child",
+            "version": "0.1.0",
+            "granularity": "1d",
+            "schema": {"val": "int"},
+            "start-date": "2021-06-01",
+        }
+
+    mock_config.load_config.side_effect = fake_load_config
+    with pytest.raises(ValueError, match="comes before dependency"):
+        validate_dependency_graph("parent", V010)
+
+
+@patch("service.builder.config")
+def test_validate_graph_start_dates_no_deps_ok(
+    mock_config: MagicMock,
+) -> None:
+    """Root dataset with no dependencies always passes start date check."""
+    mock_config.load_config.return_value = {
+        "name": "root",
+        "version": "0.1.0",
+        "granularity": "1d",
+        "schema": {"val": "int"},
+        "start-date": "2020-01-01",
+    }
+    validate_dependency_graph("root", V010)
+
+
+@patch("service.builder.config")
+def test_validate_graph_start_dates_deep_chain_ok(
+    mock_config: MagicMock,
+) -> None:
+    """Three-level chain where each ancestor starts after its descendant passes."""
+    configs = {
+        "grandparent": {
+            "name": "grandparent",
+            "version": "0.1.0",
+            "granularity": "1d",
+            "schema": {"val": "int"},
+            "start-date": "2022-01-01",
+            "dependencies": {"parent": {"version": "0.1.0", "lookback": None}},
+        },
+        "parent": {
+            "name": "parent",
+            "version": "0.1.0",
+            "granularity": "1d",
+            "schema": {"val": "int"},
+            "start-date": "2021-01-01",
+            "dependencies": {"child": {"version": "0.1.0", "lookback": None}},
+        },
+        "child": {
+            "name": "child",
+            "version": "0.1.0",
+            "granularity": "1d",
+            "schema": {"val": "int"},
+            "start-date": "2020-01-01",
+        },
+    }
+    mock_config.load_config.side_effect = lambda name, version: configs[name]
+    validate_dependency_graph("grandparent", V010)
+
+
+@patch("service.builder.config")
+def test_validate_graph_start_dates_deep_chain_violation_raises(
+    mock_config: MagicMock,
+) -> None:
+    """Grandparent violating grandchild's start date raises ValueError."""
+    configs = {
+        "grandparent": {
+            "name": "grandparent",
+            "version": "0.1.0",
+            "granularity": "1d",
+            "schema": {"val": "int"},
+            "start-date": "2019-01-01",
+            "dependencies": {"parent": {"version": "0.1.0", "lookback": None}},
+        },
+        "parent": {
+            "name": "parent",
+            "version": "0.1.0",
+            "granularity": "1d",
+            "schema": {"val": "int"},
+            "start-date": "2020-01-01",
+            "dependencies": {"child": {"version": "0.1.0", "lookback": None}},
+        },
+        "child": {
+            "name": "child",
+            "version": "0.1.0",
+            "granularity": "1d",
+            "schema": {"val": "int"},
+            "start-date": "2020-01-01",
+        },
+    }
+    mock_config.load_config.side_effect = lambda name, version: configs[name]
+    with pytest.raises(ValueError, match="comes before dependency"):
+        validate_dependency_graph("grandparent", V010)
+
+
+@pytest.mark.parametrize(
+    ["parent_start", "child1_start", "child2_start"],
+    [
+        ("2020-01-01", "2021-01-01", "2020-01-01"),
+        ("2020-01-01", "2020-01-01", "2021-01-01"),
+        ("2020-01-01", "2021-06-15", "2020-12-31"),
+    ],
+)
+@patch("service.builder.config")
+def test_validate_graph_start_dates_parent_before_any_dep_raises(
+    mock_config: MagicMock,
+    parent_start: str,
+    child1_start: str,
+    child2_start: str,
+) -> None:
+    """Parent has start date before at least one child — raises ValueError."""
+    configs = {
+        "parent": {
+            "name": "parent",
+            "version": "0.1.0",
+            "granularity": "1d",
+            "schema": {"val": "int"},
+            "start-date": parent_start,
+            "dependencies": {
+                "child1": {"version": "0.1.0", "lookback": None},
+                "child2": {"version": "0.1.0", "lookback": None},
+            },
+        },
+        "child1": {
+            "name": "child1",
+            "version": "0.1.0",
+            "granularity": "1d",
+            "schema": {"val": "int"},
+            "start-date": child1_start,
+        },
+        "child2": {
+            "name": "child2",
+            "version": "0.1.0",
+            "granularity": "1d",
+            "schema": {"val": "int"},
+            "start-date": child2_start,
+        },
+    }
+    mock_config.load_config.side_effect = lambda name, version: configs[name]
+    with pytest.raises(ValueError, match="comes before dependency"):
+        validate_dependency_graph("parent", V010)
+
+
 # --- lookback tests ---
 
 


### PR DESCRIPTION
Fix two bugs in `_validate_dependency_graph_start_date` (wrong config key `start_date` → `start-date`, missing return statement) and wire it into `validate_dependency_graph` so start date constraints are actually enforced. Add tests covering the failure case, root datasets, deep chains, and multi-dep violations.