### PR TITLE
docs: add atomicity spec for build requests

### DIFF
--- a/dev-docs/SPEC.md
+++ b/dev-docs/SPEC.md
@@ -110,6 +110,10 @@ The `start-date` field is required and validated when loading the config.
 - Only missing timestamps are built and inserted — existing rows are never overwritten.
 - This avoids re-running builders unnecessarily; DB writes are plain `INSERT` (no upsert needed).
 
+### Atomicity
+
+Builds are atomic at the request level. If any single timestamp in the requested range fails to build, no data from that request is committed to the database — not even the timestamps that succeeded. This is enforced by batching all inserts for the range into a single database transaction and rolling back on any failure.
+
 ### Datasets postgres schema
 
 Datasets will be stored in a Postgres database. The table used to store datasets is `datasets`. Each row contains some timeseries data along with some metadata. It has the following columns:


### PR DESCRIPTION
Adds an Atomicity section to the spec under the overwrite policy. Specifies that all inserts for a build request are batched into a single DB transaction and rolled back if any timestamp fails, so partial data never lands in the DB.