### PR TITLE
refactor: add DependencyInfo frozen dataclass definition

### DIFF
--- a/builders/server/runtime/config.py
+++ b/builders/server/runtime/config.py
@@ -1,9 +1,24 @@
 import re
 import tomllib
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
 
 from utils.semver import SemVer
+
+
+@dataclass(frozen=True)
+class DependencyInfo:
+    """
+    Parsed dependency with version and optional lookback window.
+
+    A lookback of None means buliding a dataset for a timestamp
+    retrieves the same timestamp from the dependency.
+    """
+
+    version: SemVer
+    lookback: timedelta | None = None
+
 
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
 


### PR DESCRIPTION
Adds a frozen `DependencyInfo` dataclass to `config.py` with `version: SemVer` and `lookback: timedelta | None` fields. Definition only, not used anywhere yet. Subsequent PRs will adopt it in `_validate_dependencies` and consumers.