### PR TITLE
refactor: add SchemaType enum definition

### DIFF
--- a/builders/server/runtime/config.py
+++ b/builders/server/runtime/config.py
@@ -2,6 +2,7 @@ import re
 import tomllib
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from enum import Enum
 from pathlib import Path
 
 from utils.semver import SemVer
@@ -18,6 +19,15 @@ class DependencyInfo:
 
     version: SemVer
     lookback: timedelta | None = None
+
+
+class SchemaType(Enum):
+    """Allowed types for dataset schema fields."""
+
+    STR = "str"
+    INT = "int"
+    FLOAT = "float"
+    BOOL = "bool"
 
 
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"


### PR DESCRIPTION
Adds a `SchemaType` enum to `config.py` with members STR, INT, FLOAT, BOOL. Definition only, not used anywhere yet. Subsequent PRs will adopt it in schema validation and consumers.