### PR TITLE
refactor: adopt DependencyInfo in _validate_dependencies and consumers

### DIFF
--- a/builders/server/runtime/config.py
+++ b/builders/server/runtime/config.py
@@ -163,7 +163,7 @@ def _validate_start_date(
 def _validate_dependencies(
     config: dict, dataset_name: str, dataset_version: SemVer
 ) -> None:
-    """Normalize dependencies to ``{version: str, lookback: timedelta | None}``.
+    """Normalize dependencies to ``DependencyInfo`` instances.
 
     Supports both simple string format (``dep = "0.1.0"``) and table format
     (``dep = {version = "0.1.0", lookback = "5d"}``).
@@ -172,11 +172,13 @@ def _validate_dependencies(
     if deps is None:
         return
 
-    normalized: dict[str, dict[str, str | timedelta | None]] = {}
+    normalized: dict[str, DependencyInfo] = {}
     for dep_name, dep_value in deps.items():
         if isinstance(dep_value, str):
             # simple format: dep = "0.1.0"
-            normalized[dep_name] = {"version": dep_value, "lookback": None}
+            normalized[dep_name] = DependencyInfo(
+                version=SemVer.parse(dep_value),
+            )
         elif isinstance(dep_value, dict):
             # table format: dep = {version = "0.1.0", lookback = "5d"}
             if "version" not in dep_value:
@@ -187,10 +189,10 @@ def _validate_dependencies(
             lookback: timedelta | None = None
             if "lookback" in dep_value:
                 lookback = parse_lookback(dep_value["lookback"])
-            normalized[dep_name] = {
-                "version": dep_value["version"],
-                "lookback": lookback,
-            }
+            normalized[dep_name] = DependencyInfo(
+                version=SemVer.parse(dep_value["version"]),
+                lookback=lookback,
+            )
         else:
             raise ValueError(
                 f"config.toml for {dataset_name}/{dataset_version}: "

--- a/builders/server/service/builder.py
+++ b/builders/server/service/builder.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import db.datasets
 from runtime import config, loader, runner, validator
@@ -39,14 +39,15 @@ def _validate_dependency_graph_start_date(
     parent_start_date = datetime.strptime(cfg["start-date"], "%Y-%m-%d")
 
     for dep_name, dep_info in cfg.get("dependencies", {}).items():
-        dep_version = SemVer.parse(dep_info["version"])
-        dep_start_date = _validate_dependency_graph_start_date(dep_name, dep_version)
+        dep_start_date = _validate_dependency_graph_start_date(
+            dep_name, dep_info.version
+        )
 
         if parent_start_date < dep_start_date:
             raise ValueError(
                 f"{dataset_name}/{dataset_version} has start date "
                 f"'{parent_start_date}' which comes before dependency "
-                f"{dep_name}/{dep_version} with start date {dep_start_date}"
+                f"{dep_name}/{dep_info.version} with start date {dep_start_date}"
             )
 
     return parent_start_date
@@ -67,8 +68,7 @@ def _validate_dependency_graph_granularity(
     parent_delta = GRANULARITY_MAP[granularity]
 
     for dep_name, dep_info in cfg.get("dependencies", {}).items():
-        dep_version = SemVer.parse(dep_info["version"])
-        dep_cfg = config.load_config(dep_name, dep_version)
+        dep_cfg = config.load_config(dep_name, dep_info.version)
         dep_granularity = dep_cfg.get("granularity", "1d")
         dep_delta = GRANULARITY_MAP[dep_granularity]
 
@@ -76,12 +76,12 @@ def _validate_dependency_graph_granularity(
             raise ValueError(
                 f"{dataset_name}/{dataset_version} has granularity "
                 f"'{granularity}' which is finer than dependency "
-                f"'{dep_name}/{dep_version}' with granularity "
+                f"'{dep_name}/{dep_info.version}' with granularity "
                 f"'{dep_granularity}'"
             )
 
         # recurse into dependency's own dependencies
-        _validate_dependency_graph_granularity(dep_name, dep_version)
+        _validate_dependency_graph_granularity(dep_name, dep_info.version)
 
 
 def validate_dependency_graph(
@@ -130,10 +130,10 @@ def _build_recursive(
 
     # recursively build dependencies first, expanding range for lookback
     for dep_name, dep_info in dependencies.items():
-        dep_version = SemVer.parse(dep_info["version"])
-        lookback: timedelta | None = dep_info["lookback"]
-        dep_start = start - lookback if lookback is not None else start
-        _build_recursive(dep_name, dep_version, dep_start, end)
+        dep_start = (
+            start - dep_info.lookback if dep_info.lookback is not None else start
+        )
+        _build_recursive(dep_name, dep_info.version, dep_start, end)
 
     # determine which timestamps are missing
     all_timestamps = generate_timestamps(start, end, granularity)
@@ -166,21 +166,18 @@ def _build_recursive(
         # fetch dependency data for this timestamp
         dep_data: dict[str, dict[datetime, list[dict]]] = {}
         for dep_name, dep_info in dependencies.items():
-            dep_version = SemVer.parse(dep_info["version"])
-            lookback = dep_info["lookback"]
-
-            if lookback is not None:
+            if dep_info.lookback is not None:
                 # fetch time window [ts - lookback, ts]
                 dep_rows = db.datasets.get_rows_range(
-                    dep_name, dep_version, ts - lookback, ts
+                    dep_name, dep_info.version, ts - dep_info.lookback, ts
                 )
             else:
                 # no lookback, fetch just this timestamp
-                dep_rows = db.datasets.get_rows(dep_name, dep_version, [ts])
+                dep_rows = db.datasets.get_rows(dep_name, dep_info.version, [ts])
 
             if not dep_rows:
                 raise RuntimeError(
-                    f"Dependency '{dep_name}/{dep_version}' "
+                    f"Dependency '{dep_name}/{dep_info.version}' "
                     f"missing data for timestamp {ts}"
                 )
             dep_data[dep_name] = dep_rows

--- a/builders/server/tests/runtime/test_config.py
+++ b/builders/server/tests/runtime/test_config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 from runtime import config
-from runtime.config import parse_lookback
+from runtime.config import DependencyInfo, parse_lookback
 from utils.semver import SemVer
 
 V010 = SemVer.parse("0.1.0")
@@ -129,8 +129,8 @@ dep-b = "1.0.0"
     )
     cfg = config.load_config("ds", V010)
     assert cfg["dependencies"] == {
-        "dep-a": {"version": "0.0.2", "lookback": None},
-        "dep-b": {"version": "1.0.0", "lookback": None},
+        "dep-a": DependencyInfo(version=SemVer.parse("0.0.2")),
+        "dep-b": DependencyInfo(version=SemVer.parse("1.0.0")),
     }
 
 
@@ -413,10 +413,9 @@ dep-a = {version = "0.0.2", lookback = "5d"}
 """,
     )
     cfg = config.load_config("ds", V010)
-    assert cfg["dependencies"]["dep-a"] == {
-        "version": "0.0.2",
-        "lookback": timedelta(days=5),
-    }
+    assert cfg["dependencies"]["dep-a"] == DependencyInfo(
+        version=SemVer.parse("0.0.2"), lookback=timedelta(days=5)
+    )
 
 
 def test_load_config_dep_table_without_lookback(
@@ -441,10 +440,9 @@ dep-a = {version = "0.0.2"}
 """,
     )
     cfg = config.load_config("ds", V010)
-    assert cfg["dependencies"]["dep-a"] == {
-        "version": "0.0.2",
-        "lookback": None,
-    }
+    assert cfg["dependencies"]["dep-a"] == DependencyInfo(
+        version=SemVer.parse("0.0.2"),
+    )
 
 
 def test_load_config_dep_table_missing_version_raises(

--- a/builders/server/tests/service/test_builder.py
+++ b/builders/server/tests/service/test_builder.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
+from runtime.config import DependencyInfo
 from service.builder import (
     build_dataset,
     generate_timestamps,
@@ -147,7 +148,7 @@ def test_build_dataset_recursive_dependencies(
                 "granularity": "1d",
                 "start-date": "2020-01-01",
                 "dependencies": {
-                    "child": {"version": "0.1.0", "lookback": None},
+                    "child": DependencyInfo(version=V010),
                 },
             }
         return {
@@ -190,7 +191,7 @@ def test_build_dataset_missing_dependency_data_raises(
                 "granularity": "1d",
                 "start-date": "2020-01-01",
                 "dependencies": {
-                    "dep": {"version": "0.1.0", "lookback": None},
+                    "dep": DependencyInfo(version=V010),
                 },
             }
         # dep has no dependencies, so recursion stops
@@ -235,7 +236,7 @@ def test_build_dataset_passes_dep_data_as_dict_of_timestamps(
                 "granularity": "1d",
                 "start-date": "2020-01-01",
                 "dependencies": {
-                    "dep": {"version": "0.1.0", "lookback": None},
+                    "dep": DependencyInfo(version=V010),
                 },
             }
         return {
@@ -369,7 +370,7 @@ def test_validate_graph_coarser_parent_passes(
                 "schema": {"val": "int"},
                 "start-date": "2020-01-01",
                 "dependencies": {
-                    "child": {"version": "0.1.0", "lookback": None},
+                    "child": DependencyInfo(version=V010),
                 },
             }
         return {
@@ -400,7 +401,7 @@ def test_validate_graph_equal_granularity_passes(
                 "schema": {"val": "int"},
                 "start-date": "2020-01-01",
                 "dependencies": {
-                    "child": {"version": "0.1.0", "lookback": None},
+                    "child": DependencyInfo(version=V010),
                 },
             }
         return {
@@ -431,7 +432,7 @@ def test_validate_graph_finer_parent_raises(
                 "schema": {"val": "int"},
                 "start-date": "2020-01-01",
                 "dependencies": {
-                    "child": {"version": "0.1.0", "lookback": None},
+                    "child": DependencyInfo(version=V010),
                 },
             }
         return {
@@ -460,8 +461,8 @@ def test_validate_graph_two_deps_one_coarser_raises(
             "schema": {"val": "int"},
             "start-date": "2020-01-01",
             "dependencies": {
-                "fine": {"version": "0.1.0", "lookback": None},
-                "coarse": {"version": "0.1.0", "lookback": None},
+                "fine": DependencyInfo(version=V010),
+                "coarse": DependencyInfo(version=V010),
             },
         },
         "fine": {
@@ -508,8 +509,8 @@ def test_validate_graph_start_dates_ok(
             "schema": {"val": "int"},
             "start-date": parent_start,
             "dependencies": {
-                "child1": {"version": "0.1.0", "lookback": None},
-                "child2": {"version": "0.1.0", "lookback": None},
+                "child1": DependencyInfo(version=V010),
+                "child2": DependencyInfo(version=V010),
             },
         },
         "child1": {
@@ -545,7 +546,7 @@ def test_validate_graph_start_dates_parent_before_dep_raises(
                 "granularity": "1d",
                 "schema": {"val": "int"},
                 "start-date": "2020-01-01",
-                "dependencies": {"child": {"version": "0.1.0", "lookback": None}},
+                "dependencies": {"child": DependencyInfo(version=V010)},
             }
         return {
             "name": "child",
@@ -587,7 +588,7 @@ def test_validate_graph_start_dates_deep_chain_ok(
             "granularity": "1d",
             "schema": {"val": "int"},
             "start-date": "2022-01-01",
-            "dependencies": {"parent": {"version": "0.1.0", "lookback": None}},
+            "dependencies": {"parent": DependencyInfo(version=V010)},
         },
         "parent": {
             "name": "parent",
@@ -595,7 +596,7 @@ def test_validate_graph_start_dates_deep_chain_ok(
             "granularity": "1d",
             "schema": {"val": "int"},
             "start-date": "2021-01-01",
-            "dependencies": {"child": {"version": "0.1.0", "lookback": None}},
+            "dependencies": {"child": DependencyInfo(version=V010)},
         },
         "child": {
             "name": "child",
@@ -621,7 +622,7 @@ def test_validate_graph_start_dates_deep_chain_violation_raises(
             "granularity": "1d",
             "schema": {"val": "int"},
             "start-date": "2019-01-01",
-            "dependencies": {"parent": {"version": "0.1.0", "lookback": None}},
+            "dependencies": {"parent": DependencyInfo(version=V010)},
         },
         "parent": {
             "name": "parent",
@@ -629,7 +630,7 @@ def test_validate_graph_start_dates_deep_chain_violation_raises(
             "granularity": "1d",
             "schema": {"val": "int"},
             "start-date": "2020-01-01",
-            "dependencies": {"child": {"version": "0.1.0", "lookback": None}},
+            "dependencies": {"child": DependencyInfo(version=V010)},
         },
         "child": {
             "name": "child",
@@ -668,8 +669,8 @@ def test_validate_graph_start_dates_parent_before_any_dep_raises(
             "schema": {"val": "int"},
             "start-date": parent_start,
             "dependencies": {
-                "child1": {"version": "0.1.0", "lookback": None},
-                "child2": {"version": "0.1.0", "lookback": None},
+                "child1": DependencyInfo(version=V010),
+                "child2": DependencyInfo(version=V010),
             },
         },
         "child1": {
@@ -717,10 +718,7 @@ def test_build_dataset_lookback_expands_dep_build_range(
                 "granularity": "1d",
                 "start-date": "2020-01-01",
                 "dependencies": {
-                    "dep": {
-                        "version": "0.1.0",
-                        "lookback": timedelta(days=5),
-                    },
+                    "dep": DependencyInfo(version=V010, lookback=timedelta(days=5)),
                 },
             }
         return {
@@ -769,10 +767,7 @@ def test_build_dataset_lookback_fetches_range(
                 "granularity": "1d",
                 "start-date": "2020-01-01",
                 "dependencies": {
-                    "dep": {
-                        "version": "0.1.0",
-                        "lookback": timedelta(days=2),
-                    },
+                    "dep": DependencyInfo(version=V010, lookback=timedelta(days=2)),
                 },
             }
         return {
@@ -837,7 +832,7 @@ def test_build_dataset_no_lookback_uses_get_rows(
                 "granularity": "1d",
                 "start-date": "2020-01-01",
                 "dependencies": {
-                    "dep": {"version": "0.1.0", "lookback": None},
+                    "dep": DependencyInfo(version=V010),
                 },
             }
         return {


### PR DESCRIPTION
Updates `_validate_dependencies` to produce `dict[str, DependencyInfo]` instead of `dict[str, dict]`. Version strings are parsed to `SemVer` during normalization. All consumers in `builder.py` now use attribute access (`dep_info.version`, `dep_info.lookback`) instead of dict key access. Tests updated accordingly.