### PR TITLE
refactor: adopt SchemaType enum in validation and consumers

### DIFF
--- a/builders/server/runtime/config.py
+++ b/builders/server/runtime/config.py
@@ -2,7 +2,7 @@ import re
 import tomllib
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 
 from utils.semver import SemVer
@@ -21,7 +21,7 @@ class DependencyInfo:
     lookback: timedelta | None = None
 
 
-class SchemaType(Enum):
+class SchemaType(StrEnum):
     """Allowed types for dataset schema fields."""
 
     STR = "str"
@@ -29,17 +29,18 @@ class SchemaType(Enum):
     FLOAT = "float"
     BOOL = "bool"
 
+    def to_type(self) -> type | tuple[type, ...]:
+        """Convert `SchemaType` to its corresponding python type(s)."""
+        TYPE_MAP: dict[str, type | tuple[type, ...]] = {
+            SchemaType.STR: str,
+            SchemaType.INT: int,
+            SchemaType.FLOAT: (int, float),  # accept int as float
+            SchemaType.BOOL: bool,
+        }
+        return TYPE_MAP[self]
+
 
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
-
-# values must be valid arguments to isinstance (type or tuple of types)
-# keys define what strings are allowed in config.toml schema fields
-TYPE_MAP = {
-    "str": str,
-    "int": int,
-    "float": (int, float),  # accept int as valid float
-    "bool": bool,
-}
 
 GRANULARITY_MAP = {
     "1s": timedelta(seconds=1),
@@ -102,6 +103,7 @@ def _validate_name_version(
 
 def _validate_schema(config: dict, dataset_name: str, dataset_version: SemVer) -> None:
     """Validate that the schema field is present, non-empty, and uses known types."""
+    # check that the schema exists and is non-empty
     if "schema" not in config:
         raise ValueError(
             f"config.toml for {dataset_name}/{dataset_version} "
@@ -112,8 +114,10 @@ def _validate_schema(config: dict, dataset_name: str, dataset_version: SemVer) -
             f"config.toml for {dataset_name}/{dataset_version} "
             "'schema' must not be empty"
         )
+
+    # validate each schema value
     for key, type_name in config["schema"].items():
-        if type_name not in TYPE_MAP:
+        if type_name not in SchemaType:
             raise ValueError(
                 f"config.toml for {dataset_name}/{dataset_version} has unknown "
                 f"type '{type_name}' for schema key '{key}'"
@@ -214,6 +218,27 @@ def validate_config(config: dict, dataset_name: str, dataset_version: SemVer) ->
     _validate_dependencies(config, dataset_name, dataset_version)
 
 
+def _normalize_config_schema(config: dict) -> None:
+    """
+    Normalize **in place** a config's schema, by converting values from
+    type `str` to type `SchemaType`.
+
+    Assumes that config has already been validated. That is, the schema
+    field exists, and all values are valid types.
+    """
+    normalized_schema: dict[str, SchemaType] = {}
+    for key, type_name in config["schema"].items():
+        normalized_schema[key] = SchemaType(type_name)
+    config["schema"] = normalized_schema
+
+
+def normalize_config(config: dict) -> None:
+    """
+    Normalize **in place** a config's values based off a set of rules.
+    """
+    _normalize_config_schema(config)
+
+
 # TODO: results from this can be cached
 # TODO: strengthen return type
 def load_config(dataset_name: str, dataset_version: SemVer) -> dict:
@@ -223,5 +248,6 @@ def load_config(dataset_name: str, dataset_version: SemVer) -> dict:
         config = tomllib.load(f)
 
     validate_config(config, dataset_name, dataset_version)
+    normalize_config(config)
 
     return config

--- a/builders/server/runtime/validator.py
+++ b/builders/server/runtime/validator.py
@@ -1,31 +1,29 @@
-from runtime.config import TYPE_MAP
+from runtime.config import SchemaType
 
 
 class ValidationError(Exception):
     pass
 
 
-def validate(data: dict, schema: dict[str, str]) -> None:
+def validate(data: dict, schema: dict[str, SchemaType]) -> None:
     """Validate that data matches the declared schema.
 
     Checks that all declared keys are present and values match declared types.
     Raises ValidationError on failure.
     """
-    for key, type_name in schema.items():
+    for key, schema_type in schema.items():
         if key not in data:
             raise ValidationError(f"Missing key '{key}' in builder output")
 
-        # will never fail, since schema is validated in config.py
-        expected = TYPE_MAP[type_name]
-
-        if not isinstance(data[key], expected):  # type: ignore[arg-type]  # expected is always a concrete type from TYPE_MAP
+        expected = schema_type.to_type()
+        if not isinstance(data[key], expected):
             raise ValidationError(
-                f"Key '{key}' expected type '{type_name}', "
+                f"Key '{key}' expected type '{schema_type.value}', "
                 f"got '{type(data[key]).__name__}'"
             )
 
 
-def validate_rows(data_list: list[dict], schema: dict[str, str]) -> None:
+def validate_rows(data_list: list[dict], schema: dict[str, SchemaType]) -> None:
     """Validate each dict in a list against the declared schema."""
     for data in data_list:
         validate(data, schema)

--- a/builders/server/tests/runtime/test_config.py
+++ b/builders/server/tests/runtime/test_config.py
@@ -4,10 +4,67 @@ from pathlib import Path
 
 import pytest
 from runtime import config
-from runtime.config import DependencyInfo, parse_lookback
+from runtime.config import DependencyInfo, SchemaType, parse_lookback
 from utils.semver import SemVer
 
 V010 = SemVer.parse("0.1.0")
+
+# --- SchemaType tests ---
+
+
+@pytest.mark.parametrize(
+    ["schema_type", "py_type"],
+    [
+        (SchemaType.INT, int),
+        (SchemaType.FLOAT, (int, float)),
+        (SchemaType.BOOL, bool),
+        (SchemaType.STR, str),
+    ],
+)
+def test_schema_type_to_type(
+    schema_type: SchemaType, py_type: type | tuple[type, ...]
+) -> None:
+    assert schema_type.to_type() == py_type
+
+
+# --- normalize_config tests ---
+
+
+def test_normalize_config() -> None:
+    mock_config = {
+        "name": "my-dataset",
+        "version": "2.0.0",
+        "builder": "builder.py",
+        "granularity": "1m",
+        "start-date": "2020-01-01",
+        "schema": {
+            "val1": "int",
+            "val2": "float",
+            "val3": "str",
+            "val4": "bool",
+            "val5": "float",
+        },
+    }
+    expected = {
+        "name": "my-dataset",
+        "version": "2.0.0",
+        "builder": "builder.py",
+        "granularity": "1m",
+        "start-date": "2020-01-01",
+        "schema": {
+            "val1": SchemaType.INT,
+            "val2": SchemaType.FLOAT,
+            "val3": SchemaType.STR,
+            "val4": SchemaType.BOOL,
+            "val5": SchemaType.FLOAT,
+        },
+    }
+
+    config.normalize_config(mock_config)
+    assert mock_config == expected
+
+
+# --- load_config tests ---
 
 
 def test_load_valid_config(mock_scripts_dir: Path, write_config: Callable) -> None:
@@ -210,7 +267,7 @@ price = "int"
 """,
     )
     cfg = config.load_config("ds", V010)
-    assert cfg["schema"] == {"ticker": "str", "price": "int"}
+    assert cfg["schema"] == {"ticker": SchemaType.STR, "price": SchemaType.INT}
 
 
 def test_load_config_missing_granularity_raises(

--- a/builders/server/tests/runtime/test_validator.py
+++ b/builders/server/tests/runtime/test_validator.py
@@ -1,10 +1,14 @@
 import pytest
+from runtime.config import SchemaType
 from runtime.validator import ValidationError, validate, validate_rows
 
 
 def test_valid_data_passes() -> None:
     """Valid data matching schema raises nothing."""
-    validate({"ticker": "AAPL", "price": 100}, {"ticker": "str", "price": "int"})
+    validate(
+        {"ticker": "AAPL", "price": 100},
+        {"ticker": SchemaType.STR, "price": SchemaType.INT},
+    )
 
 
 def test_empty_schema_passes_anything() -> None:
@@ -14,52 +18,52 @@ def test_empty_schema_passes_anything() -> None:
 
 def test_extra_keys_allowed() -> None:
     """Data with extra keys beyond schema passes."""
-    validate({"ticker": "AAPL", "extra": 999}, {"ticker": "str"})
+    validate({"ticker": "AAPL", "extra": 999}, {"ticker": SchemaType.STR})
 
 
 def test_missing_key_raises() -> None:
     """Missing required key raises ValidationError."""
     with pytest.raises(ValidationError, match="Missing key 'ticker'"):
-        validate({}, {"ticker": "str"})
+        validate({}, {"ticker": SchemaType.STR})
 
 
 def test_type_mismatch_str_raises() -> None:
     """Int where str expected raises ValidationError."""
     with pytest.raises(ValidationError, match="expected type 'str'"):
-        validate({"name": 123}, {"name": "str"})
+        validate({"name": 123}, {"name": SchemaType.STR})
 
 
 def test_type_mismatch_int_raises() -> None:
     """Str where int expected raises ValidationError."""
     with pytest.raises(ValidationError, match="expected type 'int'"):
-        validate({"count": "five"}, {"count": "int"})
+        validate({"count": "five"}, {"count": SchemaType.INT})
 
 
 def test_float_accepts_int() -> None:
     """Int passes float schema since int is a valid float."""
-    validate({"value": 42}, {"value": "float"})
+    validate({"value": 42}, {"value": SchemaType.FLOAT})
 
 
 def test_float_accepts_actual_float() -> None:
     """Float passes float schema."""
-    validate({"value": 3.14}, {"value": "float"})
+    validate({"value": 3.14}, {"value": SchemaType.FLOAT})
 
 
 def test_float_rejects_str() -> None:
     """Str where float expected raises ValidationError."""
     with pytest.raises(ValidationError, match="expected type 'float'"):
-        validate({"value": "pi"}, {"value": "float"})
+        validate({"value": "pi"}, {"value": SchemaType.FLOAT})
 
 
 def test_bool_type() -> None:
     """True passes bool schema."""
-    validate({"flag": True}, {"flag": "bool"})
+    validate({"flag": True}, {"flag": SchemaType.BOOL})
 
 
 def test_bool_rejects_int() -> None:
     """1 fails bool schema since int is not bool."""
     with pytest.raises(ValidationError, match="expected type 'bool'"):
-        validate({"flag": 1}, {"flag": "bool"})
+        validate({"flag": 1}, {"flag": SchemaType.BOOL})
 
 
 # --- validate_rows tests ---
@@ -69,13 +73,13 @@ def test_validate_rows_valid_list() -> None:
     """All dicts in the list pass validation."""
     validate_rows(
         [{"ticker": "AAPL", "price": 100}, {"ticker": "MSFT", "price": 200}],
-        {"ticker": "str", "price": "int"},
+        {"ticker": SchemaType.STR, "price": SchemaType.INT},
     )
 
 
 def test_validate_rows_empty_list() -> None:
     """Empty list passes without error."""
-    validate_rows([], {"ticker": "str"})
+    validate_rows([], {"ticker": SchemaType.STR})
 
 
 def test_validate_rows_invalid_item_raises() -> None:
@@ -83,5 +87,5 @@ def test_validate_rows_invalid_item_raises() -> None:
     with pytest.raises(ValidationError, match="Missing key 'price'"):
         validate_rows(
             [{"ticker": "AAPL", "price": 100}, {"ticker": "MSFT"}],
-            {"ticker": "str", "price": "int"},
+            {"ticker": SchemaType.STR, "price": SchemaType.INT},
         )


### PR DESCRIPTION
Replaces string-based schema type validation with `SchemaType` enum. Schema values are now normalized from strings to `SchemaType` members during config loading. `validator.py` uses a `_SCHEMA_TYPE_MAP` keyed by `SchemaType` instead of the old `TYPE_MAP` keyed by strings. Removes the now-unused `TYPE_MAP` from `config.py`.