### PR TITLE
refactor: introduce DatasetConfig dataclass, update load_config

### DIFF
--- a/builders/server/runtime/config.py
+++ b/builders/server/runtime/config.py
@@ -40,6 +40,24 @@ class SchemaType(StrEnum):
         return TYPE_MAP[self]
 
 
+@dataclass(frozen=True)
+class DatasetConfig:
+    """Parsed and validated dataset configuration."""
+
+    name: str
+    version: SemVer
+    builder: str
+    calendar: str
+    granularity: timedelta
+    start_date: datetime
+    schema: dict[str, SchemaType]
+    dependencies: dict[str, DependencyInfo]
+
+
+# defaults for optional TOML fields
+DEFAULT_BUILDER = "builder.py"
+DEFAULT_CALENDAR = "NYSE"
+
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
 
 GRANULARITY_MAP = {
@@ -240,14 +258,22 @@ def normalize_config(config: dict) -> None:
 
 
 # TODO: results from this can be cached
-# TODO: strengthen return type
-def load_config(dataset_name: str, dataset_version: SemVer) -> dict:
+def load_config(dataset_name: str, dataset_version: SemVer) -> DatasetConfig:
     """Load and validate config.toml for a given dataset."""
     config_path = SCRIPTS_DIR / dataset_name / str(dataset_version) / "config.toml"
     with open(config_path, "rb") as f:
-        config = tomllib.load(f)
+        raw = tomllib.load(f)
 
-    validate_config(config, dataset_name, dataset_version)
-    normalize_config(config)
+    validate_config(raw, dataset_name, dataset_version)
+    normalize_config(raw)
 
-    return config
+    return DatasetConfig(
+        name=raw["name"],
+        version=SemVer.parse(raw["version"]),
+        builder=raw.get("builder", DEFAULT_BUILDER),
+        calendar=raw.get("calendar", DEFAULT_CALENDAR),
+        granularity=GRANULARITY_MAP[raw["granularity"]],
+        start_date=datetime.strptime(raw["start-date"], "%Y-%m-%d"),
+        schema=raw["schema"],
+        dependencies=raw.get("dependencies", {}),
+    )

--- a/builders/server/tests/runtime/test_config.py
+++ b/builders/server/tests/runtime/test_config.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from datetime import timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -85,9 +85,9 @@ price = "int"
 """,
     )
     cfg = config.load_config("my-dataset", V010)
-    assert cfg["name"] == "my-dataset"
-    assert cfg["version"] == "0.1.0"
-    assert cfg["granularity"] == "1d"
+    assert cfg.name == "my-dataset"
+    assert cfg.version == V010
+    assert cfg.granularity == timedelta(days=1)
 
 
 def test_load_config_missing_file_raises(mock_scripts_dir: Path) -> None:
@@ -185,7 +185,7 @@ dep-b = "1.0.0"
 """,
     )
     cfg = config.load_config("ds", V010)
-    assert cfg["dependencies"] == {
+    assert cfg.dependencies == {
         "dep-a": DependencyInfo(version=SemVer.parse("0.0.2")),
         "dep-b": DependencyInfo(version=SemVer.parse("1.0.0")),
     }
@@ -267,7 +267,7 @@ price = "int"
 """,
     )
     cfg = config.load_config("ds", V010)
-    assert cfg["schema"] == {"ticker": SchemaType.STR, "price": SchemaType.INT}
+    assert cfg.schema == {"ticker": SchemaType.STR, "price": SchemaType.INT}
 
 
 def test_load_config_missing_granularity_raises(
@@ -395,7 +395,7 @@ price = "int"
 """,
     )
     cfg = config.load_config("ds", V010)
-    assert cfg["start-date"] == "2024-06-15"
+    assert cfg.start_date == datetime(2024, 6, 15)
 
 
 # --- parse_lookback tests ---
@@ -470,7 +470,7 @@ dep-a = {version = "0.0.2", lookback = "5d"}
 """,
     )
     cfg = config.load_config("ds", V010)
-    assert cfg["dependencies"]["dep-a"] == DependencyInfo(
+    assert cfg.dependencies["dep-a"] == DependencyInfo(
         version=SemVer.parse("0.0.2"), lookback=timedelta(days=5)
     )
 
@@ -497,7 +497,7 @@ dep-a = {version = "0.0.2"}
 """,
     )
     cfg = config.load_config("ds", V010)
-    assert cfg["dependencies"]["dep-a"] == DependencyInfo(
+    assert cfg.dependencies["dep-a"] == DependencyInfo(
         version=SemVer.parse("0.0.2"),
     )
 


### PR DESCRIPTION
Adds a frozen `DatasetConfig` dataclass and updates `load_config` to return it instead of a raw dict. TOML string values are converted during construction: `start-date` to `datetime`, `version` to `SemVer`, `granularity` to `timedelta`. Removes the `# TODO: strengthen return type` comment. Tests updated to use attribute access.