### PR TITLE
feat: add ping status UI

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,0 +1,17 @@
+<script>
+  let status = $state('');
+
+  async function ping() {
+    status = '...';
+    try {
+      const res = await fetch('/ping');
+      status = res.ok ? 'OK' : `Error (${res.status})`;
+    } catch {
+      status = 'Error (network)';
+    }
+  }
+</script>
+
+<h1>Datastream</h1>
+<button onclick={ping}>Ping API</button>
+<p>{status}</p>


### PR DESCRIPTION
Adds the ping status UI component.

- Ping button that calls `GET /ping` on the API
- Shows `OK`, `Error (status)`, or `Error (network)` based on the response
- No styling, just functional for internal use