### PR TITLE
infra: containerize Rust API and frontend

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,43 @@
+# Svelte + Vite
+
+This template should help get you started developing with Svelte in Vite.
+
+## Recommended IDE Setup
+
+[VS Code](https://code.visualstudio.com/) + [Svelte](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode).
+
+## Need an official Svelte framework?
+
+Check out [SvelteKit](https://github.com/sveltejs/kit#readme), which is also powered by Vite. Deploy anywhere with its serverless-first approach and adapt to various platforms, with out of the box support for TypeScript, SCSS, and Less, and easily-added support for mdsvex, GraphQL, PostCSS, Tailwind CSS, and more.
+
+## Technical considerations
+
+**Why use this over SvelteKit?**
+
+- It brings its own routing solution which might not be preferable for some users.
+- It is first and foremost a framework that just happens to use Vite under the hood, not a Vite app.
+
+This template contains as little as possible to get started with Vite + Svelte, while taking into account the developer experience with regards to HMR and intellisense. It demonstrates capabilities on par with the other `create-vite` templates and is a good starting point for beginners dipping their toes into a Vite + Svelte project.
+
+Should you later need the extended capabilities and extensibility provided by SvelteKit, the template has been structured similarly to SvelteKit so that it is easy to migrate.
+
+**Why include `.vscode/extensions.json`?**
+
+Other templates indirectly recommend extensions via the README, but this file allows VS Code to prompt the user to install the recommended extension upon opening the project.
+
+**Why enable `checkJs` in the JS template?**
+
+It is likely that most cases of changing variable types in runtime are likely to be accidental, rather than deliberate. This provides advanced typechecking out of the box. Should you like to take advantage of the dynamically-typed nature of JavaScript, it is trivial to change the configuration.
+
+**Why is HMR not preserving my local component state?**
+
+HMR state preservation comes with a number of gotchas! It has been disabled by default in both `svelte-hmr` and `@sveltejs/vite-plugin-svelte` due to its often surprising behavior. You can read the details [here](https://github.com/sveltejs/svelte-hmr/tree/master/packages/svelte-hmr#preservation-of-local-state).
+
+If you have state that's important to retain within a component, consider creating an external store which would not be replaced by HMR.
+
+```js
+// store.js
+// An extremely simple external store
+import { writable } from 'svelte/store'
+export default writable(0)
+```

--- a/infra/api/Dockerfile
+++ b/infra/api/Dockerfile
@@ -1,0 +1,14 @@
+FROM rust:1.86 AS builder
+
+WORKDIR /build
+COPY api/ .
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /build/target/release/datastream-rs /usr/local/bin/datastream-rs
+
+EXPOSE 3000
+ENTRYPOINT ["datastream-rs"]

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -27,6 +27,18 @@ services:
     networks:
       - internal
 
+  api:
+    build:
+      context: ..
+      dockerfile: infra/api/Dockerfile
+    ports:
+      - "3000:3000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - internal
+
   pgweb:
     image: sosedoff/pgweb:latest
     command: ["--readonly", "--bind=0.0.0.0", "--listen=8080"]

--- a/justfile
+++ b/justfile
@@ -21,3 +21,6 @@ clippy:
 
 precommit:
     uv run pre-commit run --all-files
+
+frontend-dev:
+    cd frontend && bun install && bun run dev


### PR DESCRIPTION
Adds a Docker container for the Rust API.

- Multi-stage Dockerfile: compile with `rust:1.86`, run on `debian:bookworm-slim`
- Exposes port 3000 to the host so the local frontend dev server can proxy to it
- Added to docker-compose on the existing `internal` network

The frontend is not containerized — it runs locally via `just frontend-dev` and the Vite proxy forwards `/ping` to `localhost:3000`.