### PR TITLE
docs: split SPEC.md into backend and frontend specs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-See @SPEC.md for the project description.
+See @dev-docs/SPEC-backend.md for the backend spec and @dev-docs/SPEC-frontend.md for the frontend spec.
 
 ## Before writing code
 
@@ -29,7 +29,7 @@ Structure stacks by architectural layer, bottom-up:
 1. Schema / data model changes
 2. Business logic / service layer
 3. API / interface layer
-4. If there is a significant spec change: SPEC.md update as the final PR
+4. If there is a significant spec change: update the relevant spec file (`SPEC-backend.md` or `SPEC-frontend.md`) as the final PR
 
 Each PR in a stack should make one logical change. It is acceptable — and sometimes desirable — for a later PR to overwrite or refine what an earlier PR did. This is intentional: the stack shows the logical progression to the final state, not just the diff.
 
@@ -54,7 +54,7 @@ No fluff, no em dashes.
 
 ## Tech specifications
 
-After EVERY SET of udpates to the code, update @dev-docs/SPEC.md with what has been changed in the code.
+After EVERY SET of updates to the code, update the relevant spec file (@dev-docs/SPEC-backend.md or @dev-docs/SPEC-frontend.md) with what has been changed in the code.
 
 ## Plans
 

--- a/dev-docs/SPEC-backend.md
+++ b/dev-docs/SPEC-backend.md
@@ -1,4 +1,4 @@
-# Datastream
+# Datastream Backend
 
 A service to serve and build financial time-series data.
 
@@ -61,15 +61,6 @@ builders/server/
 
 `main.py` is the uvicorn entrypoint (`main:app`). It creates the `FastAPI` app and mounts routers from `api/`. Dependencies flow strictly downward: `api → service → db/runtime`. No layer imports upward.
 
-## Frontend
-
-A lightweight internal UI built with Svelte + Vite, using Bun as the package manager.
-
-- **Local dev**: `just frontend-dev` starts the Vite dev server on port 5173. The Vite config proxies `/ping` to `http://localhost:3000` (the Rust API) to avoid CORS issues.
-- **Docker**: the frontend is built as static files (`bun run build`) and served by nginx on port 80. nginx proxies `/ping` to `http://api:3000` via Docker internal DNS.
-- Current functionality: a ping button that calls `GET /ping` on the Rust API and displays the status.
-- The frontend is not containerized — it runs locally via `just frontend-dev` and proxies to the API container on port 3000.
-
 ## MVP trigger
 
 - For MVP (no main API server), builds are triggered via a standalone Python CLI script.
@@ -99,7 +90,7 @@ infra/
 
 ## Dataset and builder model
 
-The two main components of the service are datasets and builders. 
+The two main components of the service are datasets and builders.
 - Datasets define the data, they are typically series of (timestamp, data) pairs.
     - Datasets are uniquely identified by a (name, version) pair, where name is a string and version is a SemVer (e.g. 1.1.12).
     - Datasets may have dependencies on other datasets. For example, a 5 day moving average may depend on daily pricing data.

--- a/dev-docs/SPEC-frontend.md
+++ b/dev-docs/SPEC-frontend.md
@@ -1,0 +1,8 @@
+# Datastream Frontend
+
+A lightweight internal UI built with Svelte + Vite, using Bun as the package manager.
+
+- **Local dev**: `just frontend-dev` starts the Vite dev server on port 5173. The Vite config proxies `/ping` to `http://localhost:3000` (the Rust API) to avoid CORS issues.
+- **Docker**: the frontend is built as static files (`bun run build`) and served by nginx on port 80. nginx proxies `/ping` to `http://api:3000` via Docker internal DNS.
+- Current functionality: a ping button that calls `GET /ping` on the Rust API and displays the status.
+- The frontend is not containerized — it runs locally via `just frontend-dev` and proxies to the API container on port 3000.


### PR DESCRIPTION
splits SPEC.md into SPEC-backend.md and SPEC-frontend.md under dev-docs/, and updates AGENTS.md to reference both. easier to navigate when working on one side.