### PR TITLE
feat: add sqlx and set up postgres connection pool

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2024"
 [dependencies]
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "macros"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,5 +1,15 @@
 use axum::{Router, http::StatusCode, routing::get};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
 use tokio::net::TcpListener;
+
+/// Shared application state passed to all route handlers.
+#[derive(Clone)]
+struct AppState {
+    // pool will be used by data endpoints in future PRs
+    #[allow(dead_code)]
+    pool: PgPool,
+}
 
 /// Returns 200 OK.
 async fn ping() -> StatusCode {
@@ -8,7 +18,19 @@ async fn ping() -> StatusCode {
 
 #[tokio::main]
 async fn main() {
-    let app = Router::new().route("/ping", get(ping));
+    let database_url = std::env::var("DATABASE_URL")
+        .expect("DATABASE_URL must be set");
+
+    let pool = PgPoolOptions::new()
+        .connect(&database_url)
+        .await
+        .expect("failed to connect to postgres");
+
+    let state = AppState { pool };
+
+    let app = Router::new()
+        .route("/ping", get(ping))
+        .with_state(state);
 
     let listener = TcpListener::bind("0.0.0.0:3000").await.unwrap();
     println!("listening on {}", listener.local_addr().unwrap());

--- a/justfile
+++ b/justfile
@@ -22,5 +22,8 @@ clippy:
 precommit:
     uv run pre-commit run --all-files
 
+migrate:
+    sqlx migrate run
+
 frontend-dev:
     cd frontend && bun install && bun run dev


### PR DESCRIPTION
- adds sqlx 0.8 with postgres, tokio runtime, and macros features
- adds serde and serde_json for JSONB mapping
- wires up PgPool at startup from DATABASE_URL env var, panics clearly on failure
- stores pool in AppState for future route handlers
- adds `just migrate` recipe for running sqlx migrations

sets up the db plumbing before any data endpoints are added