### PR TITLE
feat: add ping endpoint to python server

### DIFF
--- a/builders/server/api/routes.py
+++ b/builders/server/api/routes.py
@@ -10,6 +10,12 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+@router.get("/ping")
+def ping():
+    """Health check endpoint."""
+    return {"status": "ok"}
+
+
 @router.post("/build/{dataset_name}/{dataset_version}")
 def build(
     dataset_name: str,


### PR DESCRIPTION
Add a `GET /ping` health check endpoint to the Python FastAPI server. This is needed so the Python service can serve as the single public-facing backend, replacing the Rust API.