### PR TITLE
fix: update trigger.py port to 3000

### DIFF
--- a/trigger.py
+++ b/trigger.py
@@ -18,7 +18,7 @@ def main():
         sys.exit(1)
 
     dataset_name, dataset_version, start, end = sys.argv[1:]
-    url = f"http://localhost:8000/build/{dataset_name}/{dataset_version}"
+    url = f"http://localhost:3000/build/{dataset_name}/{dataset_version}"
 
     print(f"Triggering build: {dataset_name}/{dataset_version} [{start}, {end}]")  # noqa: T201 -- cli output
     resp = requests.post(url, params={"start": start, "end": end})


### PR DESCRIPTION
trigger.py was pointing at port 8000 but the server listens on 3000. Fixes the CLI trigger so it can actually reach the builder.