### PR TITLE
infra: fix depends_on and minimize init.sql

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -23,7 +23,8 @@ services:
     ports:
       - "3000:3000"
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     networks:
       - internal
 

--- a/infra/postgres/init.sql
+++ b/infra/postgres/init.sql
@@ -1,17 +1,3 @@
-CREATE TABLE datasets (
-    id BIGSERIAL PRIMARY KEY,
-    created_at TIMESTAMP(6) NOT NULL DEFAULT now(),
-    dataset_name TEXT NOT NULL,
-    dataset_version TEXT NOT NULL,
-    timestamp TIMESTAMP(6) NOT NULL,
-    data JSONB NOT NULL
-);
-
--- non-unique index for range queries on
--- (dataset_name, dataset_version, timestamp)
-CREATE INDEX idx_datasets_name_version_ts
-ON datasets (dataset_name, dataset_version, timestamp);
-
 -- read-only role for the pgweb UI
 CREATE USER datastream_readonly WITH PASSWORD 'readonly';
 GRANT CONNECT ON DATABASE datastream TO datastream_readonly;


### PR DESCRIPTION
fix builder `depends_on` to use `service_healthy` so it waits for postgres to be ready before starting. remove `CREATE TABLE` and `CREATE INDEX` from `init.sql` — those move into tern migrations. `init.sql` now only bootstraps the read-only role (requires superuser, can't run via tern).