### PR TITLE
infra: install tern, add first migration

### DIFF
--- a/builders/migrations/001_create_datasets_table.sql
+++ b/builders/migrations/001_create_datasets_table.sql
@@ -1,0 +1,18 @@
+CREATE TABLE datasets (
+    id BIGSERIAL PRIMARY KEY,
+    created_at TIMESTAMP(6) NOT NULL DEFAULT now(),
+    dataset_name TEXT NOT NULL,
+    dataset_version TEXT NOT NULL,
+    timestamp TIMESTAMP(6) NOT NULL,
+    data JSONB NOT NULL
+);
+
+-- non-unique index for range queries on
+-- (dataset_name, dataset_version, timestamp)
+CREATE INDEX idx_datasets_name_version_ts
+ON datasets (dataset_name, dataset_version, timestamp);
+
+---- create above / drop below ----
+
+DROP INDEX idx_datasets_name_version_ts;
+DROP TABLE datasets;

--- a/infra/builder/Dockerfile
+++ b/infra/builder/Dockerfile
@@ -4,9 +4,17 @@ WORKDIR /app
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
+# install tern migration tool
+ARG TERN_VERSION=2.2.3
+RUN apt-get update && apt-get install -y --no-install-recommends curl tar \
+    && curl -fsSL https://github.com/jackc/tern/releases/download/v${TERN_VERSION}/tern_${TERN_VERSION}_linux_amd64.tar.gz \
+       | tar -xz -C /usr/local/bin/ tern \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY pyproject.toml uv.lock /app/
 RUN uv sync --no-dev
 
 COPY builders/server/ /app/
+COPY builders/migrations/ /app/migrations/
 
 ENTRYPOINT ["uv", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "3000"]


### PR DESCRIPTION
install the tern binary in the builder Dockerfile. add the first migration (`001_create_datasets_table.sql`) with up/down sections. migrations are copied into the image at `/app/migrations/`. entrypoint still uses uvicorn directly — wired in next PR.