### PR TITLE
dev: add just migrate command

### DIFF
--- a/justfile
+++ b/justfile
@@ -16,5 +16,8 @@ test:
 precommit:
     uv run pre-commit run --all-files
 
+migrate:
+    tern migrate --migrations builders/migrations --conn-string postgresql://datastream:changeme@localhost:5432/datastream
+
 frontend-dev:
     cd frontend && bun install && bun run dev


### PR DESCRIPTION
add `just migrate` to run tern against the local Docker-exposed postgres. requires tern installed locally (`go install github.com/jackc/tern/v2@latest` or homebrew).