### PR TITLE
infra: run tern migrate before uvicorn in entrypoint

### DIFF
--- a/infra/builder/Dockerfile
+++ b/infra/builder/Dockerfile
@@ -17,4 +17,4 @@ RUN uv sync --no-dev
 COPY builders/server/ /app/
 COPY builders/migrations/ /app/migrations/
 
-ENTRYPOINT ["uv", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "3000"]
+ENTRYPOINT ["sh", "-c", "tern migrate --migrations /app/migrations --conn-string $DATABASE_URL && uv run uvicorn main:app --host 0.0.0.0 --port 3000"]


### PR DESCRIPTION
update Dockerfile entrypoint to run `tern migrate` before starting uvicorn. migrations apply automatically on container startup; if tern fails the server does not start. uses `$DATABASE_URL` already set in docker-compose via `.env`.