### PR TITLE
infra: run migrations on builder container startup

### DIFF
--- a/infra/builder/Dockerfile
+++ b/infra/builder/Dockerfile
@@ -7,6 +7,10 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 COPY pyproject.toml uv.lock /app/
 RUN uv sync --no-dev
 
+COPY alembic.ini /app/
 COPY builders/server/ /app/
 
-ENTRYPOINT ["uv", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "3000"]
+COPY infra/builder/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/infra/builder/entrypoint.sh
+++ b/infra/builder/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+alembic upgrade head
+exec uv run uvicorn main:app --host 0.0.0.0 --port 3000

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -23,7 +23,8 @@ services:
     ports:
       - "3000:3000"
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     networks:
       - internal
 


### PR DESCRIPTION
builder container now runs `alembic upgrade head` before starting uvicorn via an entrypoint script. also switches `depends_on` to `condition: service_healthy` so migrations don't race postgres startup.

removed `init.sql` copy from postgres Dockerfile since migrations handle schema now.