### PR TITLE
fix: patch alembic config for container layout in entrypoint

### DIFF
--- a/infra/builder/entrypoint.sh
+++ b/infra/builder/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 set -e
 
-alembic upgrade head
+# fix script_location for container layout
+# (alembic.ini uses repo-relative paths, but server code is at /app/)
+sed -i 's|builders/server/db/migrations|db/migrations|' /app/alembic.ini
+uv run alembic upgrade head
 exec uv run uvicorn main:app --host 0.0.0.0 --port 3000


### PR DESCRIPTION
fix alembic.ini script_location path for the container layout (repo uses `builders/server/db/migrations` but the container's workdir is `/app/` so it needs `db/migrations`). also run alembic through `uv run` to match the rest of the entrypoint.