### PR TITLE
docs: Use python3 in README example commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ python3 trigger.py mock-ohlc 0.1.0 2024-01-01 2024-01-31
 **Example — build mock daily close (derived dataset, depends on mock-ohlc):**
 
 ```bash
-python trigger.py mock-daily-close 0.1.0 2024-01-01 2024-01-31
+python3 trigger.py mock-daily-close 0.1.0 2024-01-01 2024-01-31
 ```
 
 The builder server handles dependency resolution automatically — building `mock-daily-close` will first build `mock-ohlc` if data is missing.


### PR DESCRIPTION
## Summary
Updated README.md to consistently use `python3` instead of `python` in all example commands.

## What changed
Fixed one Python command example in the mock-daily-close section to use `python3` for consistency with other commands in the README.

## Benefit
Ensures users follow best practices and have consistent command examples throughout the documentation.