### PR TITLE
chore: enable ruff FIX and TD rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ target-version = "py312"
 line-length = 88
 
 [tool.ruff.lint]
-select = ["B", "E", "F", "I", "PIE", "SIM", "T20", "UP"]
+select = ["B", "E", "F", "I", "PIE", "SIM", "T20", "UP", "FIX", "TD"]
 
 [tool.mypy]
 python_version = "3.12"


### PR DESCRIPTION
Enable Ruff's FIX and TD rules to flag TODOs and FIXMEs as warnings.