### PR TITLE
feat: [stateless calendar] add interface and registry

### DIFF
--- a/builders/server/calendars/interface.py
+++ b/builders/server/calendars/interface.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+from datetime import datetime, timedelta
+
+
+class Calendar(ABC):
+    """Base class for calendars that determine valid timestamps for a dataset."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Unique identifier for this calendar."""
+
+    @property
+    @abstractmethod
+    def granularity(self) -> timedelta:
+        """Smallest time step this calendar operates on."""
+
+    @abstractmethod
+    def is_open(self, timestamp: datetime) -> bool:
+        """Return True if the given timestamp is a valid data point."""

--- a/builders/server/calendars/registry.py
+++ b/builders/server/calendars/registry.py
@@ -1,0 +1,4 @@
+from calendars.interface import Calendar
+
+# registry mapping calendar name -> Calendar instance
+CALENDARS_MAP: dict[str, Calendar] = {}


### PR DESCRIPTION
Add the Calendar ABC and empty CALENDARS registry.

- `calendars/interface.py`: Calendar ABC with `name`, `granularity`, `is_open()`
- `calendars/definitions.py`: empty `CALENDARS` dict for registering implementations
- `calendars/__init__.py`: empty

Foundation for concrete calendar implementations in follow-up PRs.