### PR TITLE
feat: [stateless calendar] add weekday calendar

### DIFF
--- a/builders/server/calendars/definitions.py
+++ b/builders/server/calendars/definitions.py
@@ -3,6 +3,16 @@ from datetime import datetime, timedelta
 from calendars.interface import Calendar
 
 
+def _is_midnight(timestamp: datetime) -> bool:
+    """Check if a timestamp is aligned to midnight."""
+    return (
+        timestamp.hour == 0
+        and timestamp.minute == 0
+        and timestamp.second == 0
+        and timestamp.microsecond == 0
+    )
+
+
 class EverydayCalendar(Calendar):
     """Calendar where every day is valid."""
 
@@ -15,10 +25,20 @@ class EverydayCalendar(Calendar):
         return timedelta(days=1)
 
     def is_open(self, timestamp: datetime) -> bool:
-        # reject timestamps that aren't aligned to midnight
-        return (
-            timestamp.hour == 0
-            and timestamp.minute == 0
-            and timestamp.second == 0
-            and timestamp.microsecond == 0
-        )
+        return _is_midnight(timestamp)
+
+
+class WeekdayCalendar(Calendar):
+    """Calendar where only Monday-Friday are valid."""
+
+    @property
+    def name(self) -> str:
+        return "weekday"
+
+    @property
+    def granularity(self) -> timedelta:
+        return timedelta(days=1)
+
+    def is_open(self, timestamp: datetime) -> bool:
+        # weekday() returns 0=Mon ... 4=Fri, 5=Sat, 6=Sun
+        return _is_midnight(timestamp) and timestamp.weekday() < 5

--- a/builders/server/calendars/registry.py
+++ b/builders/server/calendars/registry.py
@@ -1,7 +1,8 @@
-from calendars.definitions import EverydayCalendar
+from calendars.definitions import EverydayCalendar, WeekdayCalendar
 from calendars.interface import Calendar
 
 # registry mapping calendar name -> Calendar instance
 CALENDARS_MAP: dict[str, Calendar] = {
     "everyday": EverydayCalendar(),
+    "weekday": WeekdayCalendar(),
 }

--- a/builders/server/tests/calendars/test_weekday.py
+++ b/builders/server/tests/calendars/test_weekday.py
@@ -1,0 +1,43 @@
+from datetime import datetime, timedelta
+
+from calendars.definitions import WeekdayCalendar
+from calendars.registry import CALENDARS_MAP
+
+
+def test_weekday_open_on_weekdays() -> None:
+    """WeekdayCalendar.is_open returns True for Mon-Fri."""
+    cal = WeekdayCalendar()
+    # 2024-01-01 is a Monday
+    for i in range(5):
+        assert cal.is_open(datetime(2024, 1, 1 + i))
+
+
+def test_weekday_closed_on_weekends() -> None:
+    """WeekdayCalendar.is_open returns False for Sat-Sun."""
+    cal = WeekdayCalendar()
+    # 2024-01-06 is Saturday, 2024-01-07 is Sunday
+    assert not cal.is_open(datetime(2024, 1, 6))
+    assert not cal.is_open(datetime(2024, 1, 7))
+
+
+def test_weekday_name() -> None:
+    cal = WeekdayCalendar()
+    assert cal.name == "weekday"
+
+
+def test_weekday_granularity() -> None:
+    cal = WeekdayCalendar()
+    assert cal.granularity == timedelta(days=1)
+
+
+def test_weekday_rejects_nonmidnight_timestamps() -> None:
+    """WeekdayCalendar.is_open returns False for non-midnight weekdays."""
+    cal = WeekdayCalendar()
+    # 2024-01-01 is a Monday but not at midnight
+    assert not cal.is_open(datetime(2024, 1, 1, 9, 30, 0))
+    assert not cal.is_open(datetime(2024, 1, 1, 0, 0, 1))
+
+
+def test_weekday_in_registry() -> None:
+    assert "weekday" in CALENDARS_MAP
+    assert isinstance(CALENDARS_MAP["weekday"], WeekdayCalendar)


### PR DESCRIPTION
Add WeekdayCalendar (is_open True for Mon-Fri, False for Sat-Sun) and register it in CALENDARS.

Tests cover weekday/weekend behavior, name, granularity, and registry presence.