### PR TITLE
feat: [stateless calendar] update DatasetConfig.calendar to type Calendar

### DIFF
--- a/builders/scripts/mock-daily-close/0.1.0/config.toml
+++ b/builders/scripts/mock-daily-close/0.1.0/config.toml
@@ -1,7 +1,7 @@
 name = "mock-daily-close"
 version = "0.1.0"
 builder = "builder.py"
-calendar = "NYSE"
+calendar = "everyday"
 granularity = "1d"
 start-date = "2020-01-01"
 

--- a/builders/scripts/mock-moving-avg/0.1.0/config.toml
+++ b/builders/scripts/mock-moving-avg/0.1.0/config.toml
@@ -1,7 +1,7 @@
 name = "mock-moving-avg"
 version = "0.1.0"
 builder = "builder.py"
-calendar = "NYSE"
+calendar = "everyday"
 granularity = "1d"
 start-date = "2020-01-01"
 

--- a/builders/scripts/mock-multi-close/0.1.0/config.toml
+++ b/builders/scripts/mock-multi-close/0.1.0/config.toml
@@ -1,7 +1,7 @@
 name = "mock-multi-close"
 version = "0.1.0"
 builder = "builder.py"
-calendar = "NYSE"
+calendar = "everyday"
 granularity = "1d"
 start-date = "2020-01-01"
 

--- a/builders/scripts/mock-multi-ohlc/0.1.0/config.toml
+++ b/builders/scripts/mock-multi-ohlc/0.1.0/config.toml
@@ -1,7 +1,7 @@
 name = "mock-multi-ohlc"
 version = "0.1.0"
 builder = "builder.py"
-calendar = "NYSE"
+calendar = "everyday"
 granularity = "1d"
 start-date = "2020-01-01"
 

--- a/builders/scripts/mock-ohlc/0.1.0/config.toml
+++ b/builders/scripts/mock-ohlc/0.1.0/config.toml
@@ -1,7 +1,7 @@
 name = "mock-ohlc"
 version = "0.1.0"
 builder = "builder.py"
-calendar = "NYSE"
+calendar = "everyday"
 granularity = "1d"
 start-date = "2020-01-01"
 

--- a/builders/server/runtime/config.py
+++ b/builders/server/runtime/config.py
@@ -5,6 +5,8 @@ from datetime import datetime, timedelta
 from enum import StrEnum
 from pathlib import Path
 
+from calendars.interface import Calendar
+from calendars.registry import CALENDARS_MAP
 from utils.semver import SemVer
 
 
@@ -47,7 +49,7 @@ class DatasetConfig:
     name: str
     version: SemVer
     builder: str
-    calendar: str
+    calendar: Calendar
     granularity: timedelta
     start_date: datetime
     schema: dict[str, SchemaType]
@@ -56,7 +58,6 @@ class DatasetConfig:
 
 # defaults for optional TOML fields
 DEFAULT_BUILDER = "builder.py"
-DEFAULT_CALENDAR = "NYSE"
 
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
 
@@ -182,6 +183,23 @@ def _validate_start_date(
         ) from err
 
 
+def _validate_calendar(
+    config: dict, dataset_name: str, dataset_version: SemVer
+) -> None:
+    """Validate that the calendar field is present and refers to a known calendar."""
+    if "calendar" not in config:
+        raise ValueError(
+            f"config.toml for {dataset_name}/{dataset_version} "
+            "is missing 'calendar' field"
+        )
+    calendar_name = config["calendar"]
+    if calendar_name not in CALENDARS_MAP:
+        raise ValueError(
+            f"config.toml for {dataset_name}/{dataset_version} has unknown "
+            f"calendar '{calendar_name}'"
+        )
+
+
 def _validate_dependencies(
     config: dict, dataset_name: str, dataset_version: SemVer
 ) -> None:
@@ -227,12 +245,11 @@ def _validate_dependencies(
 def validate_config(config: dict, dataset_name: str, dataset_version: SemVer) -> None:
     """Validate that a parsed config dict has required fields and matches
     the dataset path."""
-    # TODO (bryan): validate the existence of other fields in the config
-    # toml such as builder, calender
     _validate_name_version(config, dataset_name, dataset_version)
     _validate_schema(config, dataset_name, dataset_version)
     _validate_granularity(config, dataset_name, dataset_version)
     _validate_start_date(config, dataset_name, dataset_version)
+    _validate_calendar(config, dataset_name, dataset_version)
     _validate_dependencies(config, dataset_name, dataset_version)
 
 
@@ -271,7 +288,7 @@ def load_config(dataset_name: str, dataset_version: SemVer) -> DatasetConfig:
         name=raw["name"],
         version=SemVer.parse(raw["version"]),
         builder=raw.get("builder", DEFAULT_BUILDER),
-        calendar=raw.get("calendar", DEFAULT_CALENDAR),
+        calendar=CALENDARS_MAP[raw["calendar"]],
         granularity=GRANULARITY_MAP[raw["granularity"]],
         start_date=datetime.strptime(raw["start-date"], "%Y-%m-%d"),
         schema=raw["schema"],

--- a/builders/server/tests/runtime/test_config.py
+++ b/builders/server/tests/runtime/test_config.py
@@ -79,6 +79,7 @@ version = "0.1.0"
 builder = "builder.py"
 granularity = "1d"
 start-date = "2020-01-01"
+calendar = "everyday"
 
 [schema]
 price = "int"
@@ -176,6 +177,7 @@ name = "ds"
 version = "0.1.0"
 granularity = "1d"
 start-date = "2020-01-01"
+calendar = "everyday"
 
 [schema]
 price = "int"
@@ -261,6 +263,7 @@ name = "ds"
 version = "0.1.0"
 granularity = "1d"
 start-date = "2020-01-01"
+calendar = "everyday"
 
 [schema]
 ticker = "str"
@@ -390,6 +393,7 @@ name = "ds"
 version = "0.1.0"
 granularity = "1d"
 start-date = "2024-06-15"
+calendar = "everyday"
 
 [schema]
 price = "int"
@@ -397,6 +401,77 @@ price = "int"
     )
     cfg = config.load_config("ds", V010)
     assert cfg.start_date == datetime(2024, 6, 15)
+
+
+# --- calendar validation tests ---
+
+
+def test_load_config_valid_calendar(
+    mock_scripts_dir: Path, write_config: Callable
+) -> None:
+    """Config with a known calendar resolves to a Calendar instance."""
+    write_config(
+        mock_scripts_dir,
+        "ds",
+        "0.1.0",
+        """
+name = "ds"
+version = "0.1.0"
+granularity = "1d"
+start-date = "2020-01-01"
+calendar = "everyday"
+
+[schema]
+price = "int"
+""",
+    )
+    cfg = config.load_config("ds", V010)
+    assert cfg.calendar.name == "everyday"
+
+
+def test_load_config_unknown_calendar_raises(
+    mock_scripts_dir: Path, write_config: Callable
+) -> None:
+    """Config with unknown calendar raises ValueError."""
+    write_config(
+        mock_scripts_dir,
+        "ds",
+        "0.1.0",
+        """
+name = "ds"
+version = "0.1.0"
+granularity = "1d"
+start-date = "2020-01-01"
+calendar = "DOES_NOT_EXIST"
+
+[schema]
+price = "int"
+""",
+    )
+    with pytest.raises(ValueError, match="unknown calendar"):
+        config.load_config("ds", V010)
+
+
+def test_load_config_missing_calendar_raises(
+    mock_scripts_dir: Path, write_config: Callable
+) -> None:
+    """Config without calendar field raises ValueError."""
+    write_config(
+        mock_scripts_dir,
+        "ds",
+        "0.1.0",
+        """
+name = "ds"
+version = "0.1.0"
+granularity = "1d"
+start-date = "2020-01-01"
+
+[schema]
+price = "int"
+""",
+    )
+    with pytest.raises(ValueError, match="missing 'calendar' field"):
+        config.load_config("ds", V010)
 
 
 # --- parse_lookback tests ---
@@ -462,6 +537,7 @@ name = "ds"
 version = "0.1.0"
 granularity = "1d"
 start-date = "2020-01-01"
+calendar = "everyday"
 
 [schema]
 price = "int"
@@ -489,6 +565,7 @@ name = "ds"
 version = "0.1.0"
 granularity = "1d"
 start-date = "2020-01-01"
+calendar = "everyday"
 
 [schema]
 price = "int"
@@ -516,6 +593,7 @@ name = "ds"
 version = "0.1.0"
 granularity = "1d"
 start-date = "2020-01-01"
+calendar = "everyday"
 
 [schema]
 price = "int"
@@ -541,6 +619,7 @@ name = "ds"
 version = "0.1.0"
 granularity = "1d"
 start-date = "2020-01-01"
+calendar = "everyday"
 
 [schema]
 price = "int"
@@ -566,6 +645,7 @@ name = "ds"
 version = "0.1.0"
 granularity = "1d"
 start-date = "2020-01-01"
+calendar = "everyday"
 
 [schema]
 price = "int"

--- a/builders/server/tests/service/test_builder.py
+++ b/builders/server/tests/service/test_builder.py
@@ -2,9 +2,9 @@ from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
+from calendars.registry import CALENDARS_MAP
 from runtime.config import (
     DEFAULT_BUILDER,
-    DEFAULT_CALENDAR,
     DatasetConfig,
     DependencyInfo,
     SchemaType,
@@ -36,7 +36,7 @@ def _cfg(
         name=name,
         version=version,
         builder=DEFAULT_BUILDER,
-        calendar=DEFAULT_CALENDAR,
+        calendar=CALENDARS_MAP["everyday"],
         granularity=granularity,
         start_date=start_date,
         schema=schema or {},


### PR DESCRIPTION
Change DatasetConfig.calendar from str to Calendar instance.

- Add _validate_calendar() to check calendar string against CALENDARS registry
- Resolve calendar string to Calendar instance in load_config()
- Update DEFAULT_CALENDAR from "NYSE" to "everyday"
- Update all mock builder config.toml files to use calendar = "everyday"
- Add tests for valid, unknown, and default calendar handling