### PR TITLE
fix: clean up sys.path after builder import and validate directory exists

### DIFF
--- a/builders/server/runtime/loader.py
+++ b/builders/server/runtime/loader.py
@@ -14,16 +14,27 @@ def load_builder(dataset_name: str, dataset_version: SemVer) -> Callable:
     script_dir = SCRIPTS_DIR / dataset_name / str(dataset_version)
     builder_path = script_dir / BUILDER_FILENAME
 
-    # Add the script's directory to sys.path so relative imports work
+    if not script_dir.is_dir():
+        raise FileNotFoundError(f"dataset directory not found: {script_dir}")
+    if not builder_path.is_file():
+        raise FileNotFoundError(f"builder script not found: {builder_path}")
+
+    # temporarily add script dir to sys.path so relative imports work
     str_dir = str(script_dir)
-    if str_dir not in sys.path:
+    added_to_path = str_dir not in sys.path
+    if added_to_path:
+        # insert at start for fast lookup when importing
         sys.path.insert(0, str_dir)
 
-    spec = importlib.util.spec_from_file_location(
-        f"builder_{dataset_name}_{dataset_version}", builder_path
-    )
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)  # type: ignore[union-attr]  # loader is checked non-None above
+    try:
+        spec = importlib.util.spec_from_file_location(
+            f"builder_{dataset_name}_{dataset_version}", builder_path
+        )
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)  # type: ignore[union-attr]  # loader is checked non-None above
+    finally:
+        if added_to_path:
+            sys.path.remove(str_dir)
 
     return module.build

--- a/builders/server/tests/runtime/test_loader.py
+++ b/builders/server/tests/runtime/test_loader.py
@@ -44,10 +44,10 @@ def build(dependencies, timestamp):
     assert result == {"ticker": "AAPL", "price": 42}
 
 
-def test_load_builder_adds_to_sys_path(
+def test_load_builder_cleans_up_sys_path(
     mock_scripts_dir: Path, write_builder: Callable
 ) -> None:
-    """Script dir is added to sys.path."""
+    """Script dir is removed from sys.path after import."""
     write_builder(
         mock_scripts_dir,
         "ds",
@@ -59,7 +59,7 @@ def build(dependencies, timestamp):
     )
     loader.load_builder("ds", V010)
     script_dir = str(mock_scripts_dir / "ds" / "0.1.0")
-    assert script_dir in sys.path
+    assert script_dir not in sys.path
 
 
 def test_load_builder_missing_file_raises(mock_scripts_dir: Path) -> None:


### PR DESCRIPTION
clean up sys.path entries after builder imports so they don't accumulate in a long-running server process. also adds explicit directory/file checks before attempting the import for better error messages when called standalone.

- wrap import in try/finally to remove sys.path entry after use
- add FileNotFoundError for missing dataset directory or builder script
- update existing test to verify cleanup behavior