### PR TITLE
feat: add AlwaysOpenCalendar

### DIFF
--- a/builders/server/calendars/definitions.py
+++ b/builders/server/calendars/definitions.py
@@ -4,6 +4,21 @@ from calendars.interface import Calendar
 from calendars.utils import is_midnight
 
 
+class AlwaysOpenCalendar(Calendar):
+    """Calendar that accepts any timestamp without restriction."""
+
+    @property
+    def name(self) -> str:
+        return "always-open"
+
+    @property
+    def granularity(self) -> timedelta:
+        return timedelta(seconds=1)
+
+    def is_open(self, timestamp: datetime) -> bool:
+        return True
+
+
 class EverydayCalendar(Calendar):
     """Calendar where every day is valid."""
 

--- a/builders/server/calendars/registry.py
+++ b/builders/server/calendars/registry.py
@@ -1,8 +1,9 @@
-from calendars.definitions import EverydayCalendar, WeekdayCalendar
+from calendars.definitions import AlwaysOpenCalendar, EverydayCalendar, WeekdayCalendar
 from calendars.interface import Calendar
 
 # registry mapping calendar name -> Calendar instance
 CALENDARS_MAP: dict[str, Calendar] = {
     "everyday": EverydayCalendar(),
     "weekday": WeekdayCalendar(),
+    "always-open": AlwaysOpenCalendar(),
 }

--- a/builders/server/tests/calendars/test_always_open.py
+++ b/builders/server/tests/calendars/test_always_open.py
@@ -1,0 +1,28 @@
+from datetime import datetime, timedelta
+
+from calendars.definitions import AlwaysOpenCalendar
+from calendars.registry import CALENDARS_MAP
+
+
+def test_always_open_is_open_always_true() -> None:
+    """AlwaysOpenCalendar.is_open returns True for any timestamp."""
+    cal = AlwaysOpenCalendar()
+    assert cal.is_open(datetime(2024, 1, 1))  # midnight
+    assert cal.is_open(datetime(2024, 1, 1, 12, 30, 45))  # mid-day
+    assert cal.is_open(datetime(2024, 1, 6))  # saturday
+    assert cal.is_open(datetime(2024, 1, 7, 23, 59, 59))  # sunday, non-midnight
+
+
+def test_always_open_name() -> None:
+    cal = AlwaysOpenCalendar()
+    assert cal.name == "always-open"
+
+
+def test_always_open_granularity() -> None:
+    cal = AlwaysOpenCalendar()
+    assert cal.granularity == timedelta(seconds=1)
+
+
+def test_always_open_in_registry() -> None:
+    assert "always-open" in CALENDARS_MAP
+    assert isinstance(CALENDARS_MAP["always-open"], AlwaysOpenCalendar)

--- a/builders/server/tests/service/test_builder.py
+++ b/builders/server/tests/service/test_builder.py
@@ -2,8 +2,7 @@ from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
-from calendars.definitions import EverydayCalendar, WeekdayCalendar
-from calendars.interface import Calendar
+from calendars.definitions import AlwaysOpenCalendar, EverydayCalendar, WeekdayCalendar
 from calendars.registry import CALENDARS_MAP
 from runtime.config import (
     DEFAULT_BUILDER,
@@ -26,22 +25,7 @@ _DEFAULT_START = datetime(2020, 1, 1)
 _EVERYDAY = EverydayCalendar()
 
 
-class _AlwaysOpenCalendar(Calendar):
-    """Test-only calendar that accepts any timestamp."""
-
-    @property
-    def name(self) -> str:
-        return "always-open"
-
-    @property
-    def granularity(self) -> timedelta:
-        return timedelta(seconds=1)
-
-    def is_open(self, timestamp: datetime) -> bool:
-        return True
-
-
-_ALWAYS_OPEN = _AlwaysOpenCalendar()
+_ALWAYS_OPEN = AlwaysOpenCalendar()
 
 
 def _cfg(


### PR DESCRIPTION
Promotes the test-only `_AlwaysOpenCalendar` helper into a first-class calendar. Adds `AlwaysOpenCalendar` (name: `always-open`, granularity: 1s, always returns `True`) to definitions and registers it in `CALENDARS_MAP`. Removes the duplicate local class from `test_builder.py` and adds a dedicated test file.

Benefit: the calendar is now usable in `config.toml` and tests no longer need to define their own stub.