### PR TITLE
feat: add next_open to Calendar ABC and concrete calendars

### DIFF
--- a/builders/server/calendars/definitions.py
+++ b/builders/server/calendars/definitions.py
@@ -18,6 +18,10 @@ class AlwaysOpenCalendar(Calendar):
     def is_open(self, timestamp: datetime) -> bool:
         return True
 
+    def next_open(self, timestamp: datetime) -> datetime | None:
+        """Every timestamp is open, so return timestamp as-is."""
+        return timestamp
+
 
 class EverydayCalendar(Calendar):
     """Calendar where every day is valid."""
@@ -32,6 +36,13 @@ class EverydayCalendar(Calendar):
 
     def is_open(self, timestamp: datetime) -> bool:
         return is_midnight(timestamp)
+
+    def next_open(self, timestamp: datetime) -> datetime | None:
+        """Return timestamp if already midnight, else advance to next midnight."""
+        midnight = timestamp.replace(hour=0, minute=0, second=0, microsecond=0)
+        if midnight < timestamp:
+            midnight += timedelta(days=1)
+        return midnight
 
 
 class WeekdayCalendar(Calendar):
@@ -48,3 +59,12 @@ class WeekdayCalendar(Calendar):
     def is_open(self, timestamp: datetime) -> bool:
         # weekday() returns 0=Mon ... 4=Fri, 5=Sat, 6=Sun
         return is_midnight(timestamp) and timestamp.weekday() < 5
+
+    def next_open(self, timestamp: datetime) -> datetime | None:
+        """Return next weekday midnight >= timestamp."""
+        midnight = timestamp.replace(hour=0, minute=0, second=0, microsecond=0)
+        if midnight < timestamp:
+            midnight += timedelta(days=1)
+        while midnight.weekday() >= 5:
+            midnight += timedelta(days=1)
+        return midnight

--- a/builders/server/calendars/interface.py
+++ b/builders/server/calendars/interface.py
@@ -18,3 +18,7 @@ class Calendar(ABC):
     @abstractmethod
     def is_open(self, timestamp: datetime) -> bool:
         """Return True if the given timestamp is a valid data point."""
+
+    @abstractmethod
+    def next_open(self, timestamp: datetime) -> datetime | None:
+        """Return the next open datetime >= timestamp, or None if never open again."""


### PR DESCRIPTION
Adds  as an abstract method on the  ABC and implements it in all three concrete calendars.

- : returns timestamp as-is (always open)
- : returns timestamp if midnight, else next midnight
- : returns next weekday midnight >= timestamp

Useful for callers that need to advance to the next valid slot without iterating manually.