### PR TITLE
test: add next_open tests for all calendar types

### DIFF
--- a/builders/server/tests/calendars/test_always_open.py
+++ b/builders/server/tests/calendars/test_always_open.py
@@ -26,3 +26,22 @@ def test_always_open_granularity() -> None:
 def test_always_open_in_registry() -> None:
     assert "always-open" in CALENDARS_MAP
     assert isinstance(CALENDARS_MAP["always-open"], AlwaysOpenCalendar)
+
+
+def test_always_open_next_open_returns_same_timestamp() -> None:
+    """next_open returns the timestamp itself since everything is open."""
+    cal = AlwaysOpenCalendar()
+    ts = datetime(2024, 1, 1, 12, 30, 45)
+    assert cal.next_open(ts) == ts
+
+
+def test_always_open_next_open_midnight() -> None:
+    cal = AlwaysOpenCalendar()
+    ts = datetime(2024, 1, 1)
+    assert cal.next_open(ts) == ts
+
+
+def test_always_open_next_open_weekend() -> None:
+    cal = AlwaysOpenCalendar()
+    ts = datetime(2024, 1, 6, 15, 0, 0)  # saturday afternoon
+    assert cal.next_open(ts) == ts

--- a/builders/server/tests/calendars/test_everyday.py
+++ b/builders/server/tests/calendars/test_everyday.py
@@ -35,3 +35,23 @@ def test_everyday_rejects_nonmidnight_timestamps() -> None:
 def test_everyday_in_registry() -> None:
     assert "everyday" in CALENDARS_MAP
     assert isinstance(CALENDARS_MAP["everyday"], EverydayCalendar)
+
+
+def test_everyday_next_open_already_midnight() -> None:
+    """next_open returns the same timestamp when already at midnight."""
+    cal = EverydayCalendar()
+    ts = datetime(2024, 1, 1)
+    assert cal.next_open(ts) == ts
+
+
+def test_everyday_next_open_non_midnight() -> None:
+    """next_open advances to next midnight when timestamp is not midnight."""
+    cal = EverydayCalendar()
+    ts = datetime(2024, 1, 1, 12, 30, 45)
+    assert cal.next_open(ts) == datetime(2024, 1, 2)
+
+
+def test_everyday_next_open_one_second_past_midnight() -> None:
+    cal = EverydayCalendar()
+    ts = datetime(2024, 1, 1, 0, 0, 1)
+    assert cal.next_open(ts) == datetime(2024, 1, 2)

--- a/builders/server/tests/calendars/test_weekday.py
+++ b/builders/server/tests/calendars/test_weekday.py
@@ -41,3 +41,30 @@ def test_weekday_rejects_nonmidnight_timestamps() -> None:
 def test_weekday_in_registry() -> None:
     assert "weekday" in CALENDARS_MAP
     assert isinstance(CALENDARS_MAP["weekday"], WeekdayCalendar)
+
+
+def test_weekday_next_open_already_weekday_midnight() -> None:
+    """next_open returns the same timestamp when already at a weekday midnight."""
+    cal = WeekdayCalendar()
+    ts = datetime(2024, 1, 1)  # monday midnight
+    assert cal.next_open(ts) == ts
+
+
+def test_weekday_next_open_non_midnight_friday() -> None:
+    """next_open on non-midnight friday advances to next monday midnight."""
+    cal = WeekdayCalendar()
+    ts = datetime(2024, 1, 5, 9, 30, 0)  # friday 9:30am
+    assert cal.next_open(ts) == datetime(2024, 1, 8)  # monday
+
+
+def test_weekday_next_open_saturday_midnight() -> None:
+    """next_open on saturday midnight advances to monday midnight."""
+    cal = WeekdayCalendar()
+    ts = datetime(2024, 1, 6)  # saturday midnight
+    assert cal.next_open(ts) == datetime(2024, 1, 8)  # monday
+
+
+def test_weekday_next_open_sunday_midnight() -> None:
+    cal = WeekdayCalendar()
+    ts = datetime(2024, 1, 7)  # sunday midnight
+    assert cal.next_open(ts) == datetime(2024, 1, 8)  # monday


### PR DESCRIPTION
Adds next_open tests for all three calendar types.

Covers: already-open timestamps returning as-is, non-open timestamps advancing to the next valid slot, and WeekdayCalendar edge cases (non-midnight Friday, Saturday/Sunday midnight all advancing to Monday).