### PR TITLE
feat: add nyse-daily calendar

### DIFF
--- a/builders/server/calendars/definitions.py
+++ b/builders/server/calendars/definitions.py
@@ -1,5 +1,8 @@
 from datetime import datetime, timedelta
 
+import exchange_calendars as xcals
+import pandas as pd
+
 from calendars.interface import Calendar
 from calendars.utils import is_midnight
 
@@ -68,3 +71,41 @@ class WeekdayCalendar(Calendar):
         while midnight.weekday() >= 5:
             midnight += timedelta(days=1)
         return midnight
+
+
+class NyseDailyCalendar(Calendar):
+    """Calendar for NYSE trading days (excludes weekends and NYSE holidays).
+
+    Uses midnight-aligned timestamps rather than market close (4pm ET) to stay
+    consistent with all other daily calendars and avoid timezone awareness since
+    all datetimes in the system are naive. This calendar answers "is this day
+    a trading day?", not "is the market open right now?".
+    """
+
+    def __init__(self) -> None:
+        self._xcal = xcals.get_calendar("XNYS")
+
+    @property
+    def name(self) -> str:
+        return "nyse-daily"
+
+    @property
+    def granularity(self) -> timedelta:
+        return timedelta(days=1)
+
+    def is_open(self, timestamp: datetime) -> bool:
+        if not is_midnight(timestamp):
+            return False
+        return self._xcal.is_session(pd.Timestamp(timestamp))
+
+    def next_open(self, timestamp: datetime) -> datetime | None:
+        """Return next NYSE trading day midnight >= timestamp."""
+        midnight = timestamp.replace(hour=0, minute=0, second=0, microsecond=0)
+        if midnight < timestamp:
+            midnight += timedelta(days=1)
+        ts = pd.Timestamp(midnight)
+        if self._xcal.is_session(ts):
+            return midnight
+        # date_to_session with direction="next" finds the next valid session
+        next_session = self._xcal.date_to_session(ts, direction="next")
+        return next_session.to_pydatetime().replace(tzinfo=None)

--- a/builders/server/calendars/registry.py
+++ b/builders/server/calendars/registry.py
@@ -1,4 +1,9 @@
-from calendars.definitions import AlwaysOpenCalendar, EverydayCalendar, WeekdayCalendar
+from calendars.definitions import (
+    AlwaysOpenCalendar,
+    EverydayCalendar,
+    NyseDailyCalendar,
+    WeekdayCalendar,
+)
 from calendars.interface import Calendar
 
 # registry mapping calendar name -> Calendar instance
@@ -6,4 +11,5 @@ CALENDARS_MAP: dict[str, Calendar] = {
     "everyday": EverydayCalendar(),
     "weekday": WeekdayCalendar(),
     "always-open": AlwaysOpenCalendar(),
+    "nyse-daily": NyseDailyCalendar(),
 }

--- a/builders/server/tests/calendars/test_nyse_daily.py
+++ b/builders/server/tests/calendars/test_nyse_daily.py
@@ -1,0 +1,105 @@
+from datetime import datetime, timedelta
+
+from calendars.definitions import NyseDailyCalendar
+from calendars.registry import CALENDARS_MAP
+
+
+def test_nyse_daily_name() -> None:
+    cal = NyseDailyCalendar()
+    assert cal.name == "nyse-daily"
+
+
+def test_nyse_daily_granularity() -> None:
+    cal = NyseDailyCalendar()
+    assert cal.granularity == timedelta(days=1)
+
+
+def test_nyse_daily_in_registry() -> None:
+    assert "nyse-daily" in CALENDARS_MAP
+    assert isinstance(CALENDARS_MAP["nyse-daily"], NyseDailyCalendar)
+
+
+def test_nyse_daily_open_regular_trading_day() -> None:
+    cal = NyseDailyCalendar()
+    # 2024-01-02 is a Tuesday, normal trading day
+    assert cal.is_open(datetime(2024, 1, 2))
+
+
+def test_nyse_daily_closed_on_weekends() -> None:
+    cal = NyseDailyCalendar()
+    # 2024-01-06 is Saturday, 2024-01-07 is Sunday
+    assert not cal.is_open(datetime(2024, 1, 6))
+    assert not cal.is_open(datetime(2024, 1, 7))
+
+
+def test_nyse_daily_closed_new_years_day() -> None:
+    cal = NyseDailyCalendar()
+    # 2024-01-01 is New Year's Day (Monday)
+    assert not cal.is_open(datetime(2024, 1, 1))
+
+
+def test_nyse_daily_closed_christmas() -> None:
+    cal = NyseDailyCalendar()
+    # 2024-12-25 is Christmas (Wednesday)
+    assert not cal.is_open(datetime(2024, 12, 25))
+
+
+def test_nyse_daily_closed_mlk_day() -> None:
+    cal = NyseDailyCalendar()
+    # 2024-01-15 is MLK Day (third Monday of January)
+    assert not cal.is_open(datetime(2024, 1, 15))
+
+
+def test_nyse_daily_closed_july_fourth() -> None:
+    cal = NyseDailyCalendar()
+    # 2024-07-04 is Independence Day (Thursday)
+    assert not cal.is_open(datetime(2024, 7, 4))
+
+
+def test_nyse_daily_closed_thanksgiving() -> None:
+    cal = NyseDailyCalendar()
+    # 2024-11-28 is Thanksgiving (fourth Thursday of November)
+    assert not cal.is_open(datetime(2024, 11, 28))
+
+
+def test_nyse_daily_rejects_nonmidnight() -> None:
+    cal = NyseDailyCalendar()
+    # 2024-01-02 is a valid trading day but not at midnight
+    assert not cal.is_open(datetime(2024, 1, 2, 9, 30, 0))
+    assert not cal.is_open(datetime(2024, 1, 2, 0, 0, 1))
+
+
+def test_nyse_daily_next_open_already_trading_day() -> None:
+    """next_open returns the same timestamp when already at a trading day midnight."""
+    cal = NyseDailyCalendar()
+    ts = datetime(2024, 1, 2)  # tuesday, normal trading day
+    assert cal.next_open(ts) == ts
+
+
+def test_nyse_daily_next_open_from_weekend() -> None:
+    """next_open from saturday skips to monday."""
+    cal = NyseDailyCalendar()
+    ts = datetime(2024, 1, 6)  # saturday
+    assert cal.next_open(ts) == datetime(2024, 1, 8)  # monday
+
+
+def test_nyse_daily_next_open_from_holiday() -> None:
+    """next_open from a holiday advances to next trading day."""
+    cal = NyseDailyCalendar()
+    ts = datetime(2024, 1, 1)  # new year's day (monday)
+    assert cal.next_open(ts) == datetime(2024, 1, 2)  # tuesday
+
+
+def test_nyse_daily_next_open_from_non_midnight() -> None:
+    """next_open from non-midnight advances to next trading day midnight."""
+    cal = NyseDailyCalendar()
+    ts = datetime(2024, 1, 2, 9, 30, 0)  # tuesday 9:30am
+    assert cal.next_open(ts) == datetime(2024, 1, 3)  # wednesday
+
+
+def test_nyse_daily_next_open_multi_day_skip() -> None:
+    """next_open from friday evening before MLK monday skips to tuesday."""
+    cal = NyseDailyCalendar()
+    # 2024-01-12 is Friday, 2024-01-15 is MLK Day (Monday)
+    ts = datetime(2024, 1, 12, 17, 0, 0)  # friday 5pm
+    assert cal.next_open(ts) == datetime(2024, 1, 16)  # tuesday

--- a/dev-docs/SPEC-backend.md
+++ b/dev-docs/SPEC-backend.md
@@ -255,6 +255,7 @@ All calendars are registered in `CALENDARS_MAP` (a `dict[str, Calendar]`) in `bu
 
 - **`everyday`** — every day is valid (`is_open` always returns `True`). This is the default calendar.
 - **`weekday`** — Monday through Friday are valid, Saturday and Sunday are not.
+- **`nyse-daily`** — NYSE trading days only (excludes weekends and all NYSE holidays). Uses `exchange_calendars` library with the XNYS exchange calendar.
 
 ### Integration with timestamp generation
 


### PR DESCRIPTION
Adds an `nyse-daily` calendar backed by the `exchange_calendars` library (XNYS exchange). Datasets can now align to actual NYSE trading days, skipping weekends and all NYSE holidays (New Year's, MLK, July 4th, Thanksgiving, Christmas, special closures, etc.).

Uses midnight-aligned timestamps to stay consistent with existing daily calendars and avoid timezone complexity.

Includes 16 tests covering properties, holidays, weekends, non-midnight rejection, and next_open edge cases. Updates SPEC-backend.md with the new calendar entry.