### PR TITLE
feat: return 422 for NoValidTimestampsError in build endpoint

### DIFF
--- a/builders/server/api/routes.py
+++ b/builders/server/api/routes.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime
 
 from fastapi import APIRouter, HTTPException, Query
-from service.builder import build_dataset
+from service.builder import NoValidTimestampsError, build_dataset
 from utils.semver import SemVer
 
 logger = logging.getLogger(__name__)
@@ -41,6 +41,8 @@ def build(
 
     try:
         build_dataset(dataset_name, version, start_ts, end_ts)
+    except NoValidTimestampsError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
     except Exception as e:
         logger.exception(f"Build failed for {dataset_name}/{version}")
         raise HTTPException(status_code=500, detail=str(e)) from e

--- a/builders/server/tests/api/test_routes.py
+++ b/builders/server/tests/api/test_routes.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient
 from main import app
+from service.builder import NoValidTimestampsError
 
 client: TestClient = TestClient(app)
 
@@ -32,3 +33,14 @@ def test_build_endpoint_internal_error(mock_build: MagicMock) -> None:
     """Config not found returns 500."""
     resp = client.post("/build/ds/0.1.0?start=2024-01-01&end=2024-01-31")
     assert resp.status_code == 500
+
+
+@patch(
+    "api.routes.build_dataset",
+    side_effect=NoValidTimestampsError("no valid timestamps in range"),
+)
+def test_build_endpoint_no_valid_timestamps(mock_build: MagicMock) -> None:
+    """No valid calendar timestamps returns 422."""
+    resp = client.post("/build/ds/0.1.0?start=2024-01-06&end=2024-01-07")
+    assert resp.status_code == 422
+    assert "no valid timestamps in range" in resp.json()["detail"]


### PR DESCRIPTION
catch NoValidTimestampsError in the build endpoint and return 422 instead of letting it fall through to the 500 handler. no logger.exception — this is a predictable client error, not a server fault.

adds 1 test covering the 422 response and detail message.