### PR TITLE
test: add generate_timestamps tests for start on closed day

### DIFF
--- a/builders/server/service/builder.py
+++ b/builders/server/service/builder.py
@@ -24,7 +24,12 @@ def generate_timestamps(
     calendar: Calendar,
 ) -> list[datetime]:
     """Generate timestamps in [start, end], filtered by calendar."""
-    timestamps, current = [], start
+    current = calendar.next_open(start)
+    if current is None:
+        # no open timestamps
+        return []
+
+    timestamps = []
     while current <= end:
         if calendar.is_open(current):
             timestamps.append(current)

--- a/builders/server/tests/service/test_builder.py
+++ b/builders/server/tests/service/test_builder.py
@@ -137,6 +137,26 @@ def test_generate_timestamps_everyday_includes_all_days() -> None:
     assert len(result) == 7
 
 
+def test_generate_timestamps_start_on_closed_day_advances_to_next_open() -> None:
+    """Start on weekend advances to next weekday via next_open."""
+    # 2024-01-06 (Sat) -> next open is 2024-01-08 (Mon)
+    cal = WeekdayCalendar()
+    result = generate_timestamps(
+        datetime(2024, 1, 6), datetime(2024, 1, 10), _1D, calendar=cal
+    )
+    assert result[0] == datetime(2024, 1, 8)
+    assert len(result) == 3  # Mon, Tue, Wed
+
+
+def test_generate_timestamps_start_on_closed_day_no_valid_range_returns_empty() -> None:
+    """Start on weekend with end before next open returns empty."""
+    cal = WeekdayCalendar()
+    result = generate_timestamps(
+        datetime(2024, 1, 6), datetime(2024, 1, 7), _1D, calendar=cal
+    )
+    assert result == []
+
+
 # --- build_dataset tests ---
 
 


### PR DESCRIPTION
adds two tests for generate_timestamps to cover the new  behavior:

- start on a closed day advances to the next open day
- start on a closed day with end before next open returns empty

these cases weren't tested since all existing tests start on open days.