### PR TITLE
feat: prefix all API endpoints with /api/v1

### DIFF
--- a/builders/server/main.py
+++ b/builders/server/main.py
@@ -6,4 +6,4 @@ from fastapi import FastAPI
 logging.basicConfig(level=logging.INFO)
 
 app = FastAPI()
-app.include_router(router)
+app.include_router(router, prefix="/api/v1")

--- a/builders/server/tests/api/test_routes.py
+++ b/builders/server/tests/api/test_routes.py
@@ -11,27 +11,27 @@ client: TestClient = TestClient(app)
 def test_build_endpoint_success(mock_build: MagicMock) -> None:
     """POST returns 200 with status ok."""
     mock_build.return_value = None
-    resp = client.post("/build/ds/0.1.0?start=2024-01-01&end=2024-01-31")
+    resp = client.post("/api/v1/build/ds/0.1.0?start=2024-01-01&end=2024-01-31")
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok"}
 
 
 def test_build_endpoint_invalid_version() -> None:
     """Bad version returns 400."""
-    resp = client.post("/build/ds/bad-version?start=2024-01-01&end=2024-01-31")
+    resp = client.post("/api/v1/build/ds/bad-version?start=2024-01-01&end=2024-01-31")
     assert resp.status_code == 400
 
 
 def test_build_endpoint_invalid_timestamp() -> None:
     """Bad timestamp returns 400."""
-    resp = client.post("/build/ds/0.1.0?start=not-a-date&end=2024-01-31")
+    resp = client.post("/api/v1/build/ds/0.1.0?start=not-a-date&end=2024-01-31")
     assert resp.status_code == 400
 
 
 @patch("api.routes.build_dataset", side_effect=FileNotFoundError("config not found"))
 def test_build_endpoint_internal_error(mock_build: MagicMock) -> None:
     """Config not found returns 500."""
-    resp = client.post("/build/ds/0.1.0?start=2024-01-01&end=2024-01-31")
+    resp = client.post("/api/v1/build/ds/0.1.0?start=2024-01-01&end=2024-01-31")
     assert resp.status_code == 500
 
 
@@ -41,6 +41,6 @@ def test_build_endpoint_internal_error(mock_build: MagicMock) -> None:
 )
 def test_build_endpoint_no_valid_timestamps(mock_build: MagicMock) -> None:
     """No valid calendar timestamps returns 422."""
-    resp = client.post("/build/ds/0.1.0?start=2024-01-06&end=2024-01-07")
+    resp = client.post("/api/v1/build/ds/0.1.0?start=2024-01-06&end=2024-01-07")
     assert resp.status_code == 422
     assert "no valid timestamps in range" in resp.json()["detail"]

--- a/builders/server/tests/test_trigger.py
+++ b/builders/server/tests/test_trigger.py
@@ -95,4 +95,4 @@ def test_trigger_correct_url_format(
 
     trigger_module.main()
     called_url = mock_post.call_args[0][0]
-    assert called_url == "http://localhost:3000/build/my-ds/1.2.3"
+    assert called_url == "http://localhost:3000/api/v1/build/my-ds/1.2.3"

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -4,7 +4,7 @@
   async function ping() {
     status = '...';
     try {
-      const res = await fetch('/ping');
+      const res = await fetch('/api/v1/ping');
       status = res.ok ? 'OK' : `Error (${res.status})`;
     } catch {
       status = 'Error (network)';

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [svelte()],
   server: {
     proxy: {
-      '/ping': 'http://localhost:3000',
+      '/api': 'http://localhost:3000',
     },
   },
 })

--- a/trigger.py
+++ b/trigger.py
@@ -18,7 +18,7 @@ def main():
         sys.exit(1)
 
     dataset_name, dataset_version, start, end = sys.argv[1:]
-    url = f"http://localhost:3000/build/{dataset_name}/{dataset_version}"
+    url = f"http://localhost:3000/api/v1/build/{dataset_name}/{dataset_version}"
 
     print(f"Triggering build: {dataset_name}/{dataset_version} [{start}, {end}]")  # noqa: T201 -- cli output
     resp = requests.post(url, params={"start": start, "end": end})


### PR DESCRIPTION
## Summary

- Adds `/api/v1` prefix to all API endpoints (`/ping`, `/build/...`)
- Updates trigger CLI, frontend fetch, Vite proxy, and all tests to match

## Why

Standard API versioning so we can evolve the API without breaking existing clients.

## Test plan

- [x] All 191 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)