### PR TITLE
feat: add env-vars field to builder config

### DIFF
--- a/builders/server/runtime/config.py
+++ b/builders/server/runtime/config.py
@@ -54,6 +54,7 @@ class DatasetConfig:
     start_date: datetime
     schema: dict[str, SchemaType]
     dependencies: dict[str, DependencyInfo]
+    env_vars: bool
 
 
 # defaults for optional TOML fields
@@ -200,6 +201,17 @@ def _validate_calendar(
         )
 
 
+def _validate_env_vars(
+    config: dict, dataset_name: str, dataset_version: SemVer
+) -> None:
+    """Validate that env-vars is a bool if present."""
+    if "env-vars" in config and not isinstance(config["env-vars"], bool):
+        raise ValueError(
+            f"config.toml for {dataset_name}/{dataset_version}: "
+            f"'env-vars' must be a boolean, got {type(config['env-vars']).__name__}"
+        )
+
+
 def _validate_dependencies(
     config: dict, dataset_name: str, dataset_version: SemVer
 ) -> None:
@@ -250,6 +262,7 @@ def validate_config(config: dict, dataset_name: str, dataset_version: SemVer) ->
     _validate_granularity(config, dataset_name, dataset_version)
     _validate_start_date(config, dataset_name, dataset_version)
     _validate_calendar(config, dataset_name, dataset_version)
+    _validate_env_vars(config, dataset_name, dataset_version)
     _validate_dependencies(config, dataset_name, dataset_version)
 
 
@@ -293,4 +306,5 @@ def load_config(dataset_name: str, dataset_version: SemVer) -> DatasetConfig:
         start_date=datetime.strptime(raw["start-date"], "%Y-%m-%d"),
         schema=raw["schema"],
         dependencies=raw.get("dependencies", {}),
+        env_vars=raw.get("env-vars", False),
     )

--- a/builders/server/tests/runtime/test_config.py
+++ b/builders/server/tests/runtime/test_config.py
@@ -632,6 +632,80 @@ dep-a = {version = "0.0.2", lookback = "bad"}
         config.load_config("ds", V010)
 
 
+# --- env-vars validation tests ---
+
+
+def test_load_config_env_vars_default_false(
+    mock_scripts_dir: Path, write_config: Callable
+) -> None:
+    """env_vars defaults to False when not specified."""
+    write_config(
+        mock_scripts_dir,
+        "ds",
+        "0.1.0",
+        """
+name = "ds"
+version = "0.1.0"
+granularity = "1d"
+start-date = "2020-01-01"
+calendar = "everyday"
+
+[schema]
+price = "int"
+""",
+    )
+    cfg = config.load_config("ds", V010)
+    assert cfg.env_vars is False
+
+
+def test_load_config_env_vars_explicit_true(
+    mock_scripts_dir: Path, write_config: Callable
+) -> None:
+    """env_vars is True when set in config."""
+    write_config(
+        mock_scripts_dir,
+        "ds",
+        "0.1.0",
+        """
+name = "ds"
+version = "0.1.0"
+granularity = "1d"
+start-date = "2020-01-01"
+calendar = "everyday"
+env-vars = true
+
+[schema]
+price = "int"
+""",
+    )
+    cfg = config.load_config("ds", V010)
+    assert cfg.env_vars is True
+
+
+def test_load_config_env_vars_invalid_type_raises(
+    mock_scripts_dir: Path, write_config: Callable
+) -> None:
+    """env-vars with non-bool type raises ValueError."""
+    write_config(
+        mock_scripts_dir,
+        "ds",
+        "0.1.0",
+        """
+name = "ds"
+version = "0.1.0"
+granularity = "1d"
+start-date = "2020-01-01"
+calendar = "everyday"
+env-vars = "yes"
+
+[schema]
+price = "int"
+""",
+    )
+    with pytest.raises(ValueError, match="'env-vars' must be a boolean"):
+        config.load_config("ds", V010)
+
+
 def test_load_config_dep_invalid_type_raises(
     mock_scripts_dir: Path, write_config: Callable
 ) -> None:

--- a/builders/server/tests/service/test_builder.py
+++ b/builders/server/tests/service/test_builder.py
@@ -52,6 +52,7 @@ def _cfg(
         start_date=start_date,
         schema=schema or {},
         dependencies=dependencies or {},
+        env_vars=False,
     )
 
 


### PR DESCRIPTION
Add optional `env-vars` boolean field to `DatasetConfig`. When present in `config.toml`, it's validated as a bool. Defaults to `false` when omitted. No runtime behavior yet, just the config layer.