### PR TITLE
refactor: change runner interface from callable to path

### DIFF
--- a/builders/server/runtime/runner.py
+++ b/builders/server/runtime/runner.py
@@ -1,6 +1,7 @@
+import importlib.util
 import multiprocessing
 import os
-from collections.abc import Callable
+import sys
 from datetime import datetime
 from pathlib import Path
 
@@ -13,36 +14,51 @@ STATUS_ERROR = "error"
 
 
 def _worker(
-    build_fn: Callable,
+    script_dir: Path,
+    builder_filename: str,
     dependencies: dict,
     timestamp: datetime,
     queue: multiprocessing.Queue,
     env_file: Path | None,
 ):
-    """Subprocess target that runs the builder and puts the result in the queue."""
+    """Load and run the builder, putting the result in the queue."""
     try:
         if env_file is not None:
             env = dotenv_values(env_file)
             os.environ.update(env)  # type: ignore[arg-type]  # dotenv_values returns str values for non-None entries
-        result = build_fn(dependencies, timestamp)
+
+        # add script dir to sys.path for relative imports
+        str_dir = str(script_dir)
+        if str_dir not in sys.path:
+            sys.path.insert(0, str_dir)
+
+        builder_path = script_dir / builder_filename
+        spec = importlib.util.spec_from_file_location("builder", builder_path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)  # type: ignore[union-attr]  # loader is checked non-None above
+
+        result = module.build(dependencies, timestamp)
         queue.put((STATUS_OK, result))
     except Exception as e:
         queue.put((STATUS_ERROR, str(e)))
 
 
 def run_builder(
-    build_fn: Callable,
+    script_dir: Path,
+    builder_filename: str,
     dependencies: dict,
     timestamp: datetime,
     env_file: Path | None,
 ) -> list[dict]:
-    """Run a builder function in an isolated subprocess and return its result."""
+    """Run a builder script in an isolated subprocess and return its result."""
 
     # note: there is a performance overhead of using a multiprocessing queue as data has
     # to be serialized when passed between processes
     queue: multiprocessing.Queue[tuple[str, object]] = multiprocessing.Queue()
     proc = multiprocessing.Process(
-        target=_worker, args=(build_fn, dependencies, timestamp, queue, env_file)
+        target=_worker,
+        args=(script_dir, builder_filename, dependencies, timestamp, queue, env_file),
     )
     proc.start()
     proc.join(timeout=TIMEOUT_SECONDS)

--- a/builders/server/service/builder.py
+++ b/builders/server/service/builder.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import db.datasets
 from calendars.interface import Calendar
-from runtime import config, loader, runner, validator
+from runtime import config, runner, validator
 from utils.semver import SemVer
 
 logger = logging.getLogger(__name__)
@@ -172,8 +172,7 @@ def _build_recursive(
                 f"but {env_file} does not exist"
             )
 
-    # load the builder function
-    build_fn = loader.load_builder(dataset_name, dataset_version)
+    script_dir = config.SCRIPTS_DIR / dataset_name / str(cfg.version)
 
     # TODO (bryan): this spawns builder processes sequentially, one for each timestamp.
     # we then sync wait for that process to be done before moving on.
@@ -203,7 +202,9 @@ def _build_recursive(
             dep_data[dep_name] = dep_rows
 
         # run builder in subprocess
-        result = runner.run_builder(build_fn, dep_data, ts, env_file=env_file)
+        result = runner.run_builder(
+            script_dir, cfg.builder, dep_data, ts, env_file=env_file
+        )
 
         # validate output against schema
         validator.validate_rows(result, cfg.schema)

--- a/builders/server/tests/runtime/test_runner.py
+++ b/builders/server/tests/runtime/test_runner.py
@@ -1,111 +1,112 @@
 import os
-import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any
 
 import pytest
 from runtime import runner
 
-# Top-level functions so they are picklable for multiprocessing
+
+def _write_builder(tmp_path: Path, code: str) -> Path:
+    """Write a builder.py to tmp_path and return the directory."""
+    builder_file = tmp_path / "builder.py"
+    builder_file.write_text(code)
+    return tmp_path
 
 
-def _simple_build(
-    dependencies: dict[str, list[dict]], timestamp: datetime
-) -> list[dict[str, Any]]:
-    """Return a simple list of dicts."""
+def test_successful_build(tmp_path: Path) -> None:
+    """Simple builder returns expected list."""
+    script_dir = _write_builder(
+        tmp_path,
+        """
+def build(dependencies, timestamp):
     return [{"value": 42}]
-
-
-def _raising_build(
-    dependencies: dict[str, list[dict]], timestamp: datetime
-) -> list[dict[str, Any]]:
-    """Raise an exception."""
-    raise ValueError("something went wrong")
-
-
-def _sleeping_build(
-    dependencies: dict[str, list[dict]], timestamp: datetime
-) -> list[dict[str, Any]]:
-    """Sleep longer than the timeout."""
-    time.sleep(10)
-    return []
-
-
-def _crashing_build(
-    dependencies: dict[str, list[dict]], timestamp: datetime
-) -> list[dict[str, Any]]:
-    """Hard-crash the subprocess."""
-    os._exit(1)
-
-
-def _echo_build(
-    dependencies: dict[str, list[dict]], timestamp: datetime
-) -> list[dict[str, Any]]:
-    """Echo back args to verify they are passed correctly."""
-    return [{"deps": dependencies, "ts": str(timestamp)}]
-
-
-def _env_read_build(
-    dependencies: dict[str, list[dict]], timestamp: datetime
-) -> list[dict[str, Any]]:
-    """Read env vars set by dotenv injection."""
-    return [
-        {
-            "api_key": os.environ.get("TEST_API_KEY", ""),
-            "secret": os.environ.get("TEST_SECRET", ""),
-        }
-    ]
-
-
-def _dep_read_build(
-    dependencies: dict[str, list[dict]], timestamp: datetime
-) -> list[dict[str, Any]]:
-    """Read from dependencies dict (multi-row)."""
-    return [{"price": row["close"]} for row in dependencies["prices"]]
-
-
-def test_successful_build() -> None:
-    """Simple function returns expected list."""
-    result = runner.run_builder(_simple_build, {}, datetime(2024, 1, 1), env_file=None)
+""",
+    )
+    result = runner.run_builder(
+        script_dir, "builder.py", {}, datetime(2024, 1, 1), env_file=None
+    )
     assert result == [{"value": 42}]
 
 
-def test_builder_exception_raises_runtime_error() -> None:
-    """Function that raises propagates as RuntimeError."""
+def test_builder_exception_raises_runtime_error(tmp_path: Path) -> None:
+    """Builder that raises propagates as RuntimeError."""
+    script_dir = _write_builder(
+        tmp_path,
+        """
+def build(dependencies, timestamp):
+    raise ValueError("something went wrong")
+""",
+    )
     with pytest.raises(RuntimeError, match="something went wrong"):
-        runner.run_builder(_raising_build, {}, datetime(2024, 1, 1), env_file=None)
+        runner.run_builder(
+            script_dir, "builder.py", {}, datetime(2024, 1, 1), env_file=None
+        )
 
 
 def test_builder_timeout_raises_runtime_error(
-    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Function that sleeps too long raises timeout error."""
+    """Builder that sleeps too long raises timeout error."""
+    script_dir = _write_builder(
+        tmp_path,
+        """
+import time
+def build(dependencies, timestamp):
+    time.sleep(10)
+    return []
+""",
+    )
     monkeypatch.setattr(runner, "TIMEOUT_SECONDS", 1)
     with pytest.raises(RuntimeError, match="timed out"):
-        runner.run_builder(_sleeping_build, {}, datetime(2024, 1, 1), env_file=None)
+        runner.run_builder(
+            script_dir, "builder.py", {}, datetime(2024, 1, 1), env_file=None
+        )
 
 
-def test_builder_crash_raises_runtime_error() -> None:
-    """Function that calls os._exit(1) raises crash error."""
+def test_builder_crash_raises_runtime_error(tmp_path: Path) -> None:
+    """Builder that calls os._exit(1) raises crash error."""
+    script_dir = _write_builder(
+        tmp_path,
+        """
+import os
+def build(dependencies, timestamp):
+    os._exit(1)
+""",
+    )
     with pytest.raises(RuntimeError, match="crashed"):
-        runner.run_builder(_crashing_build, {}, datetime(2024, 1, 1), env_file=None)
+        runner.run_builder(
+            script_dir, "builder.py", {}, datetime(2024, 1, 1), env_file=None
+        )
 
 
-def test_builder_receives_correct_args() -> None:
+def test_builder_receives_correct_args(tmp_path: Path) -> None:
     """Verify dependencies and timestamp are passed through correctly."""
-    deps: dict[str, list[dict]] = {"my-dep": [{"val": 1}]}
+    script_dir = _write_builder(
+        tmp_path,
+        """
+def build(dependencies, timestamp):
+    return [{"deps": dependencies, "ts": str(timestamp)}]
+""",
+    )
+    deps: dict = {"my-dep": [{"val": 1}]}
     ts = datetime(2024, 6, 15)
-    result = runner.run_builder(_echo_build, deps, ts, env_file=None)
+    result = runner.run_builder(script_dir, "builder.py", deps, ts, env_file=None)
     assert result[0]["deps"] == deps
     assert result[0]["ts"] == str(ts)
 
 
-def test_builder_with_dependencies() -> None:
-    """Function that reads from multi-row dependencies works."""
-    deps: dict[str, list[dict]] = {"prices": [{"close": 150.5}, {"close": 200.0}]}
+def test_builder_with_dependencies(tmp_path: Path) -> None:
+    """Builder that reads from multi-row dependencies works."""
+    script_dir = _write_builder(
+        tmp_path,
+        """
+def build(dependencies, timestamp):
+    return [{"price": row["close"]} for row in dependencies["prices"]]
+""",
+    )
+    deps: dict = {"prices": [{"close": 150.5}, {"close": 200.0}]}
     result = runner.run_builder(
-        _dep_read_build, deps, datetime(2024, 1, 1), env_file=None
+        script_dir, "builder.py", deps, datetime(2024, 1, 1), env_file=None
     )
     assert result == [{"price": 150.5}, {"price": 200.0}]
 
@@ -115,23 +116,52 @@ def test_builder_with_dependencies() -> None:
 
 def test_builder_env_vars_injected(tmp_path: Path) -> None:
     """Builder subprocess receives env vars from .env file."""
+    script_dir = _write_builder(
+        tmp_path,
+        """
+import os
+def build(dependencies, timestamp):
+    return [{
+        "api_key": os.environ.get("TEST_API_KEY", ""),
+        "secret": os.environ.get("TEST_SECRET", ""),
+    }]
+""",
+    )
     env_file = tmp_path / ".env"
     env_file.write_text("TEST_API_KEY=abc123\nTEST_SECRET=s3cret\n")
     result = runner.run_builder(
-        _env_read_build, {}, datetime(2024, 1, 1), env_file=env_file
+        script_dir, "builder.py", {}, datetime(2024, 1, 1), env_file=env_file
     )
     assert result == [{"api_key": "abc123", "secret": "s3cret"}]
 
 
-def test_builder_env_file_none_is_noop() -> None:
+def test_builder_env_file_none_is_noop(tmp_path: Path) -> None:
     """Passing env_file=None does not affect the build."""
-    result = runner.run_builder(_simple_build, {}, datetime(2024, 1, 1), env_file=None)
+    script_dir = _write_builder(
+        tmp_path,
+        """
+def build(dependencies, timestamp):
+    return [{"value": 42}]
+""",
+    )
+    result = runner.run_builder(
+        script_dir, "builder.py", {}, datetime(2024, 1, 1), env_file=None
+    )
     assert result == [{"value": 42}]
 
 
 def test_builder_env_vars_dont_leak_to_parent(tmp_path: Path) -> None:
     """Env vars loaded in subprocess don't appear in the parent process."""
+    script_dir = _write_builder(
+        tmp_path,
+        """
+def build(dependencies, timestamp):
+    return [{"value": 1}]
+""",
+    )
     env_file = tmp_path / ".env"
     env_file.write_text("TEST_LEAK_CHECK=should_not_leak\n")
-    runner.run_builder(_simple_build, {}, datetime(2024, 1, 1), env_file=env_file)
+    runner.run_builder(
+        script_dir, "builder.py", {}, datetime(2024, 1, 1), env_file=env_file
+    )
     assert "TEST_LEAK_CHECK" not in os.environ

--- a/builders/server/tests/service/test_builder.py
+++ b/builders/server/tests/service/test_builder.py
@@ -182,20 +182,17 @@ def test_build_dataset_skips_existing(
 
 @patch("service.builder.validator")
 @patch("service.builder.runner")
-@patch("service.builder.loader")
 @patch("service.builder.db.datasets")
 @patch("service.builder.config")
 def test_build_dataset_builds_missing(
     mock_config: MagicMock,
     mock_db: MagicMock,
-    mock_loader: MagicMock,
     mock_runner: MagicMock,
     mock_validator: MagicMock,
 ) -> None:
     """Missing timestamps trigger runner + insert."""
     mock_config.load_config.return_value = _cfg()
     mock_db.get_existing_timestamps.return_value = [datetime(2024, 1, 1)]
-    mock_loader.load_builder.return_value = lambda d, t: [{"val": 1}]
     mock_runner.run_builder.return_value = [{"val": 1}]
 
     build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 2))
@@ -211,13 +208,11 @@ def test_build_dataset_builds_missing(
 
 @patch("service.builder.validator")
 @patch("service.builder.runner")
-@patch("service.builder.loader")
 @patch("service.builder.db.datasets")
 @patch("service.builder.config")
 def test_build_dataset_recursive_dependencies(
     mock_config: MagicMock,
     mock_db: MagicMock,
-    mock_loader: MagicMock,
     mock_runner: MagicMock,
     mock_validator: MagicMock,
 ) -> None:
@@ -245,13 +240,11 @@ def test_build_dataset_recursive_dependencies(
 
 
 @patch("service.builder.runner")
-@patch("service.builder.loader")
 @patch("service.builder.db.datasets")
 @patch("service.builder.config")
 def test_build_dataset_missing_dependency_data_raises(
     mock_config: MagicMock,
     mock_db: MagicMock,
-    mock_loader: MagicMock,
     mock_runner: MagicMock,
 ) -> None:
     """Missing dep data raises RuntimeError."""
@@ -269,7 +262,6 @@ def test_build_dataset_missing_dependency_data_raises(
     mock_db.get_existing_timestamps.return_value = []
     # dep has no data for the timestamp (after dep build completes with no inserts)
     mock_db.get_rows.return_value = {}
-    mock_loader.load_builder.return_value = lambda d, t: []
     mock_runner.run_builder.return_value = []
 
     with pytest.raises(RuntimeError, match="missing data for timestamp"):
@@ -278,13 +270,11 @@ def test_build_dataset_missing_dependency_data_raises(
 
 @patch("service.builder.validator")
 @patch("service.builder.runner")
-@patch("service.builder.loader")
 @patch("service.builder.db.datasets")
 @patch("service.builder.config")
 def test_build_dataset_passes_dep_data_as_dict_of_timestamps(
     mock_config: MagicMock,
     mock_db: MagicMock,
-    mock_loader: MagicMock,
     mock_runner: MagicMock,
     mock_validator: MagicMock,
 ) -> None:
@@ -307,14 +297,13 @@ def test_build_dataset_passes_dep_data_as_dict_of_timestamps(
     ts = datetime(2024, 1, 1)
     dep_rows = [{"ticker": "AAPL", "close": 150}, {"ticker": "MSFT", "close": 200}]
     mock_db.get_rows.return_value = {ts: dep_rows}
-    mock_loader.load_builder.return_value = lambda d, t: [{"val": 1}]
     mock_runner.run_builder.return_value = [{"val": 1}]
 
     build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 1))
 
     # verify dep_data passed to runner is dict[datetime, list[dict]]
     runner_call = mock_runner.run_builder.call_args
-    passed_deps = runner_call[0][1]
+    passed_deps = runner_call[0][2]
     assert passed_deps["dep"] == {ts: dep_rows}
 
 
@@ -335,20 +324,17 @@ def test_build_dataset_end_before_start_date_raises(
 
 @patch("service.builder.validator")
 @patch("service.builder.runner")
-@patch("service.builder.loader")
 @patch("service.builder.db.datasets")
 @patch("service.builder.config")
 def test_build_dataset_start_before_start_date_clamps(
     mock_config: MagicMock,
     mock_db: MagicMock,
-    mock_loader: MagicMock,
     mock_runner: MagicMock,
     mock_validator: MagicMock,
 ) -> None:
     """Start date before dataset start-date gets clamped."""
     mock_config.load_config.return_value = _cfg(start_date=datetime(2024, 1, 3))
     mock_db.get_existing_timestamps.return_value = []
-    mock_loader.load_builder.return_value = lambda d, t: [{"val": 1}]
     mock_runner.run_builder.return_value = [{"val": 1}]
 
     # request starts on Jan 1 but start-date is Jan 3
@@ -364,20 +350,17 @@ def test_build_dataset_start_before_start_date_clamps(
 
 @patch("service.builder.validator")
 @patch("service.builder.runner")
-@patch("service.builder.loader")
 @patch("service.builder.db.datasets")
 @patch("service.builder.config")
 def test_build_dataset_after_start_date_proceeds_normally(
     mock_config: MagicMock,
     mock_db: MagicMock,
-    mock_loader: MagicMock,
     mock_runner: MagicMock,
     mock_validator: MagicMock,
 ) -> None:
     """Both dates after start-date proceeds without clamping."""
     mock_config.load_config.return_value = _cfg()
     mock_db.get_existing_timestamps.return_value = []
-    mock_loader.load_builder.return_value = lambda d, t: [{"val": 1}]
     mock_runner.run_builder.return_value = [{"val": 1}]
 
     build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 3))
@@ -648,13 +631,11 @@ def test_build_dataset_valid_range_all_built_does_not_raise(
 
 @patch("service.builder.validator")
 @patch("service.builder.runner")
-@patch("service.builder.loader")
 @patch("service.builder.db.datasets")
 @patch("service.builder.config")
 def test_build_dataset_lookback_expands_dep_build_range(
     mock_config: MagicMock,
     mock_db: MagicMock,
-    mock_loader: MagicMock,
     mock_runner: MagicMock,
     mock_validator: MagicMock,
 ) -> None:
@@ -688,13 +669,11 @@ def test_build_dataset_lookback_expands_dep_build_range(
 
 @patch("service.builder.validator")
 @patch("service.builder.runner")
-@patch("service.builder.loader")
 @patch("service.builder.db.datasets")
 @patch("service.builder.config")
 def test_build_dataset_lookback_fetches_range(
     mock_config: MagicMock,
     mock_db: MagicMock,
-    mock_loader: MagicMock,
     mock_runner: MagicMock,
     mock_validator: MagicMock,
 ) -> None:
@@ -723,7 +702,6 @@ def test_build_dataset_lookback_fetches_range(
         datetime(2024, 1, 3): [{"val": 30}],
     }
     mock_db.get_rows_range.return_value = range_data
-    mock_loader.load_builder.return_value = lambda d, t: [{"avg": 20}]
     mock_runner.run_builder.return_value = [{"avg": 20}]
 
     build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 3))
@@ -738,19 +716,17 @@ def test_build_dataset_lookback_fetches_range(
 
     # verify the dict was passed to runner
     runner_call = mock_runner.run_builder.call_args
-    passed_deps = runner_call[0][1]
+    passed_deps = runner_call[0][2]
     assert passed_deps["dep"] == range_data
 
 
 @patch("service.builder.validator")
 @patch("service.builder.runner")
-@patch("service.builder.loader")
 @patch("service.builder.db.datasets")
 @patch("service.builder.config")
 def test_build_dataset_no_lookback_uses_get_rows(
     mock_config: MagicMock,
     mock_db: MagicMock,
-    mock_loader: MagicMock,
     mock_runner: MagicMock,
     mock_validator: MagicMock,
 ) -> None:
@@ -770,7 +746,6 @@ def test_build_dataset_no_lookback_uses_get_rows(
     ]
     ts = datetime(2024, 1, 1)
     mock_db.get_rows.return_value = {ts: [{"val": 1}]}
-    mock_loader.load_builder.return_value = lambda d, t: [{"val": 1}]
     mock_runner.run_builder.return_value = [{"val": 1}]
 
     build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 1))


### PR DESCRIPTION
Changes `run_builder` to accept `script_dir: Path` instead of a `Callable`. The worker function now loads the builder from the path internally. This decouples the interface change from the IPC mechanism change.

Test suite rewritten to use file-based builders in `tmp_path` instead of top-level picklable functions.