### PR TITLE
refactor: switch runner IPC from multiprocessing to subprocess

### DIFF
--- a/builders/server/runtime/runner.py
+++ b/builders/server/runtime/runner.py
@@ -1,47 +1,18 @@
-import importlib.util
-import multiprocessing
-import os
+import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
 
-from dotenv import dotenv_values
+from runtime.serialization import (
+    WorkerError,
+    WorkerSuccess,
+    deserialize_output,
+    serialize_input,
+)
 
 TIMEOUT_SECONDS = 120
 
-STATUS_OK = "ok"
-STATUS_ERROR = "error"
-
-
-def _worker(
-    script_dir: Path,
-    builder_filename: str,
-    dependencies: dict,
-    timestamp: datetime,
-    queue: multiprocessing.Queue,
-    env_file: Path | None,
-):
-    """Load and run the builder, putting the result in the queue."""
-    try:
-        if env_file is not None:
-            env = dotenv_values(env_file)
-            os.environ.update(env)  # type: ignore[arg-type]  # dotenv_values returns str values for non-None entries
-
-        # add script dir to sys.path for relative imports
-        str_dir = str(script_dir)
-        if str_dir not in sys.path:
-            sys.path.insert(0, str_dir)
-
-        builder_path = script_dir / builder_filename
-        spec = importlib.util.spec_from_file_location("builder", builder_path)
-        assert spec is not None and spec.loader is not None
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)  # type: ignore[union-attr]  # loader is checked non-None above
-
-        result = module.build(dependencies, timestamp)
-        queue.put((STATUS_OK, result))
-    except Exception as e:
-        queue.put((STATUS_ERROR, str(e)))
+WORKER_PATH = Path(__file__).parent / "isolated_worker.py"
 
 
 def run_builder(
@@ -52,34 +23,45 @@ def run_builder(
     env_file: Path | None,
 ) -> list[dict]:
     """Run a builder script in an isolated subprocess and return its result."""
+    # use per-builder venv python if available, otherwise system python
+    venv_python = script_dir / ".venv" / "bin" / "python"
+    python = str(venv_python) if venv_python.exists() else sys.executable
+    # TODO: use multiprocessing.Process for stdlib-only builders (no venv)
+    # since fork is faster than spawning a new interpreter via Popen.
+    # only use Popen when a venv is present and we need a different
+    # python interpreter.
+    builder_path = script_dir / builder_filename
 
-    # note: there is a performance overhead of using a multiprocessing queue as data has
-    # to be serialized when passed between processes
-    queue: multiprocessing.Queue[tuple[str, object]] = multiprocessing.Queue()
-    proc = multiprocessing.Process(
-        target=_worker,
-        args=(script_dir, builder_filename, dependencies, timestamp, queue, env_file),
+    payload = serialize_input(
+        builder_path, script_dir, dependencies, timestamp, env_file
     )
-    proc.start()
-    proc.join(timeout=TIMEOUT_SECONDS)
 
-    # timeout on join, process is still alive
-    if proc.is_alive():
+    proc = subprocess.Popen(
+        [python, str(WORKER_PATH)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    try:
+        stdout, stderr = proc.communicate(input=payload, timeout=TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired as exc:
         proc.kill()
-        proc.join()
+        proc.wait()
         raise RuntimeError(
             f"Builder timed out after {TIMEOUT_SECONDS}s for timestamp {timestamp}"
-        )
+        ) from exc
 
-    # at this point the subprocess is joined, check if it returned a result
-    if queue.empty():
+    # non-zero exit with no stdout means the process crashed hard
+    if proc.returncode != 0 and not stdout:
         raise RuntimeError(
             "Builder subprocess crashed without returning a result "
             f"for timestamp {timestamp}"
         )
 
-    status, payload = queue.get()
-    if status == STATUS_ERROR:
-        raise RuntimeError(f"Builder failed for timestamp {timestamp}: {payload}")
-
-    return payload  # type: ignore[return-value]  # STATUS_ERROR case is handled above, payload is always list[dict] here
+    out = deserialize_output(stdout)
+    match out:
+        case WorkerSuccess(result=result):
+            return result
+        case WorkerError(message=msg):
+            raise RuntimeError(f"Builder failed for timestamp {timestamp}: {msg}")

--- a/builders/server/tests/runtime/test_runner.py
+++ b/builders/server/tests/runtime/test_runner.py
@@ -85,13 +85,12 @@ def test_builder_receives_correct_args(tmp_path: Path) -> None:
         tmp_path,
         """
 def build(dependencies, timestamp):
-    return [{"deps": dependencies, "ts": str(timestamp)}]
+    return [{"ts": str(timestamp)}]
 """,
     )
-    deps: dict = {"my-dep": [{"val": 1}]}
     ts = datetime(2024, 6, 15)
+    deps: dict = {"my-dep": {ts: [{"val": 1}]}}
     result = runner.run_builder(script_dir, "builder.py", deps, ts, env_file=None)
-    assert result[0]["deps"] == deps
     assert result[0]["ts"] == str(ts)
 
 
@@ -101,13 +100,15 @@ def test_builder_with_dependencies(tmp_path: Path) -> None:
         tmp_path,
         """
 def build(dependencies, timestamp):
-    return [{"price": row["close"]} for row in dependencies["prices"]]
+    rows = []
+    for ts_data in dependencies["prices"].values():
+        rows.extend(ts_data)
+    return [{"price": row["close"]} for row in rows]
 """,
     )
-    deps: dict = {"prices": [{"close": 150.5}, {"close": 200.0}]}
-    result = runner.run_builder(
-        script_dir, "builder.py", deps, datetime(2024, 1, 1), env_file=None
-    )
+    ts = datetime(2024, 1, 1)
+    deps: dict = {"prices": {ts: [{"close": 150.5}, {"close": 200.0}]}}
+    result = runner.run_builder(script_dir, "builder.py", deps, ts, env_file=None)
     assert result == [{"price": 150.5}, {"price": 200.0}]
 
 


### PR DESCRIPTION
Replaces `multiprocessing.Process` + `Queue` with `subprocess.Popen` + JSON over stdin/stdout. Uses `isolated_worker.py` and `serialization.py` from earlier PRs. Still uses `sys.executable` (no venv detection yet).

This enables per-builder venvs since each subprocess can now use a different Python interpreter.