### PR TITLE
refactor: pass script_dir to runner instead of callable

### DIFF
--- a/builders/server/service/builder.py
+++ b/builders/server/service/builder.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import db.datasets
 from calendars.interface import Calendar
-from runtime import config, loader, runner, validator
+from runtime import config, runner, validator
 from utils.semver import SemVer
 
 logger = logging.getLogger(__name__)
@@ -172,8 +172,7 @@ def _build_recursive(
                 f"but {env_file} does not exist"
             )
 
-    # load the builder function
-    build_fn = loader.load_builder(dataset_name, dataset_version)
+    script_dir = config.SCRIPTS_DIR / dataset_name / str(cfg.version)
 
     # TODO (bryan): this spawns builder processes sequentially, one for each timestamp.
     # we then sync wait for that process to be done before moving on.
@@ -203,7 +202,7 @@ def _build_recursive(
             dep_data[dep_name] = dep_rows
 
         # run builder in subprocess
-        result = runner.run_builder(build_fn, dep_data, ts, env_file=env_file)
+        result = runner.run_builder(script_dir, dep_data, ts, env_file=env_file)
 
         # validate output against schema
         validator.validate_rows(result, cfg.schema)

--- a/builders/server/tests/service/test_builder.py
+++ b/builders/server/tests/service/test_builder.py
@@ -182,20 +182,17 @@ def test_build_dataset_skips_existing(
 
 @patch("service.builder.validator")
 @patch("service.builder.runner")
-@patch("service.builder.loader")
 @patch("service.builder.db.datasets")
 @patch("service.builder.config")
 def test_build_dataset_builds_missing(
     mock_config: MagicMock,
     mock_db: MagicMock,
-    mock_loader: MagicMock,
     mock_runner: MagicMock,
     mock_validator: MagicMock,
 ) -> None:
     """Missing timestamps trigger runner + insert."""
     mock_config.load_config.return_value = _cfg()
     mock_db.get_existing_timestamps.return_value = [datetime(2024, 1, 1)]
-    mock_loader.load_builder.return_value = lambda d, t: [{"val": 1}]
     mock_runner.run_builder.return_value = [{"val": 1}]
 
     build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 2))
@@ -211,13 +208,11 @@ def test_build_dataset_builds_missing(
 
 @patch("service.builder.validator")
 @patch("service.builder.runner")
-@patch("service.builder.loader")
 @patch("service.builder.db.datasets")
 @patch("service.builder.config")
 def test_build_dataset_recursive_dependencies(
     mock_config: MagicMock,
     mock_db: MagicMock,
-    mock_loader: MagicMock,
     mock_runner: MagicMock,
     mock_validator: MagicMock,
 ) -> None:
@@ -245,13 +240,11 @@ def test_build_dataset_recursive_dependencies(
 
 
 @patch("service.builder.runner")
-@patch("service.builder.loader")
 @patch("service.builder.db.datasets")
 @patch("service.builder.config")
 def test_build_dataset_missing_dependency_data_raises(
     mock_config: MagicMock,
     mock_db: MagicMock,
-    mock_loader: MagicMock,
     mock_runner: MagicMock,
 ) -> None:
     """Missing dep data raises RuntimeError."""
@@ -269,7 +262,6 @@ def test_build_dataset_missing_dependency_data_raises(
     mock_db.get_existing_timestamps.return_value = []
     # dep has no data for the timestamp (after dep build completes with no inserts)
     mock_db.get_rows.return_value = {}
-    mock_loader.load_builder.return_value = lambda d, t: []
     mock_runner.run_builder.return_value = []
 
     with pytest.raises(RuntimeError, match="missing data for timestamp"):
@@ -278,13 +270,11 @@ def test_build_dataset_missing_dependency_data_raises(
 
 @patch("service.builder.validator")
 @patch("service.builder.runner")
-@patch("service.builder.loader")
 @patch("service.builder.db.datasets")
 @patch("service.builder.config")
 def test_build_dataset_passes_dep_data_as_dict_of_timestamps(
     mock_config: MagicMock,
     mock_db: MagicMock,
-    mock_loader: MagicMock,
     mock_runner: MagicMock,
     mock_validator: MagicMock,
 ) -> None:
@@ -307,7 +297,6 @@ def test_build_dataset_passes_dep_data_as_dict_of_timestamps(
     ts = datetime(2024, 1, 1)
     dep_rows = [{"ticker": "AAPL", "close": 150}, {"ticker": "MSFT", "close": 200}]
     mock_db.get_rows.return_value = {ts: dep_rows}
-    mock_loader.load_builder.return_value = lambda d, t: [{"val": 1}]
     mock_runner.run_builder.return_value = [{"val": 1}]
 
     build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 1))
@@ -335,20 +324,17 @@ def test_build_dataset_end_before_start_date_raises(
 
 @patch("service.builder.validator")
 @patch("service.builder.runner")
-@patch("service.builder.loader")
 @patch("service.builder.db.datasets")
 @patch("service.builder.config")
 def test_build_dataset_start_before_start_date_clamps(
     mock_config: MagicMock,
     mock_db: MagicMock,
-    mock_loader: MagicMock,
     mock_runner: MagicMock,
     mock_validator: MagicMock,
 ) -> None:
     """Start date before dataset start-date gets clamped."""
     mock_config.load_config.return_value = _cfg(start_date=datetime(2024, 1, 3))
     mock_db.get_existing_timestamps.return_value = []
-    mock_loader.load_builder.return_value = lambda d, t: [{"val": 1}]
     mock_runner.run_builder.return_value = [{"val": 1}]
 
     # request starts on Jan 1 but start-date is Jan 3
@@ -364,20 +350,17 @@ def test_build_dataset_start_before_start_date_clamps(
 
 @patch("service.builder.validator")
 @patch("service.builder.runner")
-@patch("service.builder.loader")
 @patch("service.builder.db.datasets")
 @patch("service.builder.config")
 def test_build_dataset_after_start_date_proceeds_normally(
     mock_config: MagicMock,
     mock_db: MagicMock,
-    mock_loader: MagicMock,
     mock_runner: MagicMock,
     mock_validator: MagicMock,
 ) -> None:
     """Both dates after start-date proceeds without clamping."""
     mock_config.load_config.return_value = _cfg()
     mock_db.get_existing_timestamps.return_value = []
-    mock_loader.load_builder.return_value = lambda d, t: [{"val": 1}]
     mock_runner.run_builder.return_value = [{"val": 1}]
 
     build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 3))
@@ -648,13 +631,11 @@ def test_build_dataset_valid_range_all_built_does_not_raise(
 
 @patch("service.builder.validator")
 @patch("service.builder.runner")
-@patch("service.builder.loader")
 @patch("service.builder.db.datasets")
 @patch("service.builder.config")
 def test_build_dataset_lookback_expands_dep_build_range(
     mock_config: MagicMock,
     mock_db: MagicMock,
-    mock_loader: MagicMock,
     mock_runner: MagicMock,
     mock_validator: MagicMock,
 ) -> None:
@@ -688,13 +669,11 @@ def test_build_dataset_lookback_expands_dep_build_range(
 
 @patch("service.builder.validator")
 @patch("service.builder.runner")
-@patch("service.builder.loader")
 @patch("service.builder.db.datasets")
 @patch("service.builder.config")
 def test_build_dataset_lookback_fetches_range(
     mock_config: MagicMock,
     mock_db: MagicMock,
-    mock_loader: MagicMock,
     mock_runner: MagicMock,
     mock_validator: MagicMock,
 ) -> None:
@@ -723,7 +702,6 @@ def test_build_dataset_lookback_fetches_range(
         datetime(2024, 1, 3): [{"val": 30}],
     }
     mock_db.get_rows_range.return_value = range_data
-    mock_loader.load_builder.return_value = lambda d, t: [{"avg": 20}]
     mock_runner.run_builder.return_value = [{"avg": 20}]
 
     build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 3))
@@ -744,13 +722,11 @@ def test_build_dataset_lookback_fetches_range(
 
 @patch("service.builder.validator")
 @patch("service.builder.runner")
-@patch("service.builder.loader")
 @patch("service.builder.db.datasets")
 @patch("service.builder.config")
 def test_build_dataset_no_lookback_uses_get_rows(
     mock_config: MagicMock,
     mock_db: MagicMock,
-    mock_loader: MagicMock,
     mock_runner: MagicMock,
     mock_validator: MagicMock,
 ) -> None:
@@ -770,7 +746,6 @@ def test_build_dataset_no_lookback_uses_get_rows(
     ]
     ts = datetime(2024, 1, 1)
     mock_db.get_rows.return_value = {ts: [{"val": 1}]}
-    mock_loader.load_builder.return_value = lambda d, t: [{"val": 1}]
     mock_runner.run_builder.return_value = [{"val": 1}]
 
     build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 1))


### PR DESCRIPTION
Updates the service layer to pass `script_dir` to the runner instead of loading a callable via `loader.load_builder()`. Small wiring change, removes the `loader` import from `service/builder.py`.

Also updates service-level tests to remove `loader` mock patches.