### PR TITLE
feat: create per-builder venvs on server startup

### DIFF
--- a/builders/scripts/.gitignore
+++ b/builders/scripts/.gitignore
@@ -1,1 +1,2 @@
 .env
+.venv

--- a/builders/server/main.py
+++ b/builders/server/main.py
@@ -1,9 +1,21 @@
 import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
 from api.routes import router
 from fastapi import FastAPI
+from runtime.config import SCRIPTS_DIR
+from runtime.venv_management import setup_builder_venvs
 
 logging.basicConfig(level=logging.INFO)
 
-app = FastAPI()
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """Startup: create per-builder venvs."""
+    setup_builder_venvs(SCRIPTS_DIR)
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 app.include_router(router, prefix="/api/v1")

--- a/builders/server/runtime/venv_management.py
+++ b/builders/server/runtime/venv_management.py
@@ -1,0 +1,99 @@
+"""Per-builder virtual environment management.
+
+Scans builder directories for requirements.txt and creates/updates venvs
+using uv. Venvs are cached based on a hash of requirements.txt.
+"""
+
+import logging
+import subprocess
+import zlib
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+REQUIREMENTS_FILE = "requirements.txt"
+VENV_DIR = ".venv"
+HASH_FILE = ".requirements_hash"
+
+
+def _compute_hash(path: Path) -> str:
+    """Compute crc32 hash of a file's contents."""
+    data = path.read_bytes()
+    return str(zlib.crc32(data))
+
+
+def _ensure_venv(builder_dir: Path) -> None:
+    """Create or update a venv for a builder directory.
+
+    Skips if .venv/.requirements_hash matches the current requirements.txt hash.
+    """
+    requirements = builder_dir / REQUIREMENTS_FILE
+    venv_path = builder_dir / VENV_DIR
+    hash_path = venv_path / HASH_FILE
+
+    current_hash = _compute_hash(requirements)
+
+    # skip if hash matches
+    if hash_path.exists() and hash_path.read_text().strip() == current_hash:
+        logger.info(f"venv up to date: {builder_dir}")
+        return
+
+    logger.info(f"creating venv: {builder_dir}")
+
+    # create venv
+    subprocess.run(
+        ["uv", "venv", str(venv_path)],
+        check=True,
+        capture_output=True,
+    )
+
+    # install dependencies
+    subprocess.run(
+        [
+            "uv",
+            "pip",
+            "install",
+            "-r",
+            str(requirements),
+            "-p",
+            str(venv_path / "bin" / "python"),
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+    # write hash (venv_path created by `uv venv` above)
+    venv_path.mkdir(parents=True, exist_ok=True)
+    hash_path.write_text(current_hash)
+    logger.info(f"venv ready: {builder_dir}")
+
+
+def setup_builder_venvs(scripts_dir: Path) -> None:
+    """Scan all builder directories and create venvs where needed."""
+    created = 0
+    skipped = 0
+
+    if not scripts_dir.is_dir():
+        logger.warning(f"scripts directory not found: {scripts_dir}")
+        return
+
+    for dataset_dir in sorted(scripts_dir.iterdir()):
+        if not dataset_dir.is_dir():
+            continue
+        for version_dir in sorted(dataset_dir.iterdir()):
+            if not version_dir.is_dir():
+                continue
+            requirements = version_dir / REQUIREMENTS_FILE
+            if not requirements.exists():
+                skipped += 1
+                continue
+            try:
+                _ensure_venv(version_dir)
+                created += 1
+            except Exception:
+                logger.exception(f"failed to create venv for {version_dir}")
+
+    logger.info(
+        f"venv setup complete: {created} created/updated, "
+        f"{skipped} skipped (no requirements.txt)"
+    )

--- a/builders/server/tests/runtime/test_venv_management.py
+++ b/builders/server/tests/runtime/test_venv_management.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from runtime.venv_management import _ensure_venv, setup_builder_venvs
+
+
+def _make_builder(tmp_path: Path, name: str, version: str, reqs: str) -> Path:
+    """Create a builder directory with requirements.txt."""
+    d = tmp_path / name / version
+    d.mkdir(parents=True)
+    (d / "requirements.txt").write_text(reqs)
+    (d / "builder.py").write_text("def build(d, t): return []")
+    return d
+
+
+@patch("runtime.venv_management.subprocess.run")
+def test_ensure_venv_creates_venv(mock_run, tmp_path: Path):
+    """First run creates venv and writes hash file."""
+    builder_dir = _make_builder(tmp_path, "ds", "0.1.0", "requests==2.32.0\n")
+    _ensure_venv(builder_dir)
+
+    # uv venv and uv pip install both called
+    assert mock_run.call_count == 2
+    assert "venv" in mock_run.call_args_list[0][0][0]
+    assert "install" in mock_run.call_args_list[1][0][0]
+
+    # hash file written
+    hash_file = builder_dir / ".venv" / ".requirements_hash"
+    assert hash_file.exists()
+
+
+@patch("runtime.venv_management.subprocess.run")
+def test_ensure_venv_skips_when_hash_matches(mock_run, tmp_path: Path):
+    """Second run with same requirements skips venv creation."""
+    builder_dir = _make_builder(tmp_path, "ds", "0.1.0", "requests==2.32.0\n")
+
+    # first run
+    _ensure_venv(builder_dir)
+    mock_run.reset_mock()
+
+    # second run, same requirements
+    _ensure_venv(builder_dir)
+    mock_run.assert_not_called()
+
+
+@patch("runtime.venv_management.subprocess.run")
+def test_ensure_venv_rebuilds_on_requirements_change(mock_run, tmp_path: Path):
+    """Changing requirements.txt triggers rebuild."""
+    builder_dir = _make_builder(tmp_path, "ds", "0.1.0", "requests==2.32.0\n")
+    _ensure_venv(builder_dir)
+    mock_run.reset_mock()
+
+    # change requirements
+    (builder_dir / "requirements.txt").write_text("requests==2.33.0\n")
+    _ensure_venv(builder_dir)
+
+    # venv recreated
+    assert mock_run.call_count == 2
+
+
+@patch("runtime.venv_management._ensure_venv")
+def test_setup_skips_dirs_without_requirements(mock_ensure, tmp_path: Path):
+    """Directories without requirements.txt are skipped."""
+    # builder with no requirements.txt
+    d = tmp_path / "ds" / "0.1.0"
+    d.mkdir(parents=True)
+    (d / "builder.py").write_text("def build(d, t): return []")
+
+    setup_builder_venvs(tmp_path)
+    mock_ensure.assert_not_called()
+
+
+@patch("runtime.venv_management._ensure_venv")
+def test_setup_continues_on_error(mock_ensure, tmp_path: Path):
+    """One builder's venv failure doesn't block others."""
+    _make_builder(tmp_path, "ds1", "0.1.0", "bad\n")
+    _make_builder(tmp_path, "ds2", "0.1.0", "good\n")
+
+    mock_ensure.side_effect = [RuntimeError("fail"), None]
+    # should not raise
+    setup_builder_venvs(tmp_path)
+    assert mock_ensure.call_count == 2


### PR DESCRIPTION
Adds startup logic to scan builder directories and create/install per-builder venvs using `uv`. Wired into FastAPI lifespan.

- Scans `scripts_dir` for `requirements.txt` files
- Creates `.venv/` in each builder directory using `uv venv` + `uv pip install`
- Caches via crc32 hash of `requirements.txt` to skip unnecessary rebuilds
- Builders without `requirements.txt` are skipped (no overhead)
- Runner detects `.venv/bin/python` and uses it if present, otherwise falls back to system python
- `.venv` added to `builders/scripts/.gitignore`