### PR TITLE
chore: allow just test to accept optional path/specifier

### DIFF
--- a/justfile
+++ b/justfile
@@ -7,8 +7,8 @@ docker-down:
 fix:
     uv run ruff check --fix && uv run ruff format
 
-test:
-    uv run pytest
+test PATH="":
+    uv run pytest {{PATH}}
 
 precommit:
     uv run pre-commit run --all-files


### PR DESCRIPTION
adds an optional PATH param to the `just test` recipe so you can run a specific file or test function without running the whole suite

usage: `just test builders/server/tests/api/` or `just test "path/to/test.py::test_fn"`