### PR TITLE
chore: add builder healthcheck and curl dep

### DIFF
--- a/infra/builder/Dockerfile
+++ b/infra/builder/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.12-slim
 
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -25,6 +25,11 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:3000/api/v1/ping || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
     networks:
       - internal
 
@@ -36,7 +41,7 @@ services:
     ports:
       - "8080:8080"
     depends_on:
-      postgres:
+      builder:
         condition: service_healthy
     networks:
       - internal


### PR DESCRIPTION
install curl in the builder image so the docker healthcheck can use it

healthcheck pings /api/v1/ping on the builder; frontend now waits for builder to be healthy instead of just postgres