### PR TITLE
chore: run mypy on all files instead of changed files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,8 @@ repos:
       - id: mypy
         files: ^builders/server/
         exclude: ^builders/server/tests/
-        args: [--config-file=pyproject.toml]
+        args: [--config-file=pyproject.toml, builders/server]
+        pass_filenames: false
         additional_dependencies:
           - pandas-stubs
           - types-requests


### PR DESCRIPTION
add `pass_filenames: false` to the mypy pre-commit hook and pass `builders/server` as an explicit target so mypy scans all files on every commit, not just the changed ones