### PR TITLE
feat: add structlog config and request context middleware

### DIFF
--- a/builders/server/log_config.py
+++ b/builders/server/log_config.py
@@ -1,0 +1,49 @@
+"""Central structlog configuration for the builder server."""
+
+import logging
+import os
+import sys
+
+import structlog
+
+
+def setup_logging() -> None:
+    """Configure structlog and route stdlib logging through the same pipeline."""
+    json_mode = os.environ.get("LOG_FORMAT", "").lower() == "json"
+
+    shared_processors: list[structlog.types.Processor] = [
+        structlog.contextvars.merge_contextvars,
+        structlog.stdlib.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso"),
+    ]
+
+    if json_mode:
+        renderer: structlog.types.Processor = structlog.processors.JSONRenderer()
+    else:
+        renderer = structlog.dev.ConsoleRenderer()
+
+    structlog.configure(
+        processors=[
+            *shared_processors,
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+
+    formatter = structlog.stdlib.ProcessorFormatter(
+        processors=[
+            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+            renderer,
+        ],
+        foreign_pre_chain=shared_processors,
+    )
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(formatter)
+
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.addHandler(handler)
+    root.setLevel(logging.INFO)

--- a/builders/server/main.py
+++ b/builders/server/main.py
@@ -1,13 +1,15 @@
-import logging
+import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
+import structlog
 from api.routes import router
-from fastapi import FastAPI
+from fastapi import FastAPI, Request, Response
+from log_config import setup_logging as _setup_logging
 from runtime.config import SCRIPTS_DIR
 from runtime.venv_management import setup_builder_venvs
 
-logging.basicConfig(level=logging.INFO)
+_setup_logging()
 
 
 @asynccontextmanager
@@ -19,3 +21,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
 app = FastAPI(lifespan=lifespan)
 app.include_router(router, prefix="/api/v1")
+
+
+@app.middleware("http")
+async def request_context_middleware(request: Request, call_next) -> Response:  # type: ignore[no-untyped-def]
+    """Bind a unique request_id to structlog context for each request."""
+    structlog.contextvars.clear_contextvars()
+    structlog.contextvars.bind_contextvars(request_id=str(uuid.uuid4()))
+    return await call_next(request)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "uvicorn>=0.41.0",
     "exchange-calendars>=4.13",
     "python-dotenv>=1.0.0",
+    "structlog>=24.0.0",
 ]
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -66,6 +66,7 @@ dependencies = [
     { name = "psycopg2-binary" },
     { name = "python-dotenv" },
     { name = "requests" },
+    { name = "structlog" },
     { name = "uvicorn" },
 ]
 
@@ -88,6 +89,7 @@ requires-dist = [
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "requests", specifier = ">=2.32.5" },
+    { name = "structlog", specifier = ">=24.0.0" },
     { name = "uvicorn", specifier = ">=0.41.0" },
 ]
 
@@ -1068,6 +1070,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272 },
+]
+
+[[package]]
+name = "structlog"
+version = "25.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510 },
 ]
 
 [[package]]


### PR DESCRIPTION
adds structlog as a dependency and creates a central logging config module (`log_config.py`). replaces `logging.basicConfig()` in `main.py` with structlog setup. adds request context middleware that binds a unique `request_id` per request via contextvars.

supports dev (console) and prod (json) output via `LOG_FORMAT` env var. stdlib logging (uvicorn etc) is routed through structlog so all logs are unified.