### PR TITLE
feat: convert venv_management to structlog

### DIFF
--- a/builders/server/runtime/venv_management.py
+++ b/builders/server/runtime/venv_management.py
@@ -4,12 +4,13 @@ Scans builder directories for requirements.txt and creates/updates venvs
 using uv. Venvs are cached based on a hash of requirements.txt.
 """
 
-import logging
 import subprocess
 import zlib
 from pathlib import Path
 
-logger = logging.getLogger(__name__)
+import structlog
+
+logger = structlog.get_logger()
 
 REQUIREMENTS_FILE = "requirements.txt"
 VENV_DIR = ".venv"
@@ -35,10 +36,10 @@ def _ensure_venv(builder_dir: Path) -> None:
 
     # skip if hash matches
     if hash_path.exists() and hash_path.read_text().strip() == current_hash:
-        logger.info(f"venv up to date: {builder_dir}")
+        logger.info("venv up to date", builder_dir=str(builder_dir))
         return
 
-    logger.info(f"creating venv: {builder_dir}")
+    logger.info("creating venv", builder_dir=str(builder_dir))
 
     # create venv
     subprocess.run(
@@ -65,7 +66,7 @@ def _ensure_venv(builder_dir: Path) -> None:
     # write hash (venv_path created by `uv venv` above)
     venv_path.mkdir(parents=True, exist_ok=True)
     hash_path.write_text(current_hash)
-    logger.info(f"venv ready: {builder_dir}")
+    logger.info("venv ready", builder_dir=str(builder_dir))
 
 
 def setup_builder_venvs(scripts_dir: Path) -> None:
@@ -74,7 +75,7 @@ def setup_builder_venvs(scripts_dir: Path) -> None:
     skipped = 0
 
     if not scripts_dir.is_dir():
-        logger.warning(f"scripts directory not found: {scripts_dir}")
+        logger.warning("scripts directory not found", path=str(scripts_dir))
         return
 
     for dataset_dir in sorted(scripts_dir.iterdir()):
@@ -91,9 +92,10 @@ def setup_builder_venvs(scripts_dir: Path) -> None:
                 _ensure_venv(version_dir)
                 created += 1
             except Exception:
-                logger.exception(f"failed to create venv for {version_dir}")
+                logger.exception("failed to create venv", builder_dir=str(version_dir))
 
     logger.info(
-        f"venv setup complete: {created} created/updated, "
-        f"{skipped} skipped (no requirements.txt)"
+        "venv setup complete",
+        created_or_updated=created,
+        skipped=skipped,
     )


### PR DESCRIPTION
converts venv_management from stdlib logging to structlog with key-value args for builder_dir, created/skipped counts.