### PR TITLE
test: add atomicity and idempotency integration tests

### DIFF
--- a/builders/server/tests/integration/test_atomicity.py
+++ b/builders/server/tests/integration/test_atomicity.py
@@ -1,0 +1,114 @@
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def _row_count(db_conn, dataset_name=None):
+    with db_conn.cursor() as cur:
+        if dataset_name:
+            cur.execute(
+                "SELECT count(*) FROM datasets WHERE dataset_name = %s",
+                (dataset_name,),
+            )
+        else:
+            cur.execute("SELECT count(*) FROM datasets")
+        return cur.fetchone()[0]
+
+
+def test_builder_failure_midrange_no_partial_insert(
+    client, db_conn, write_temp_builder
+):
+    """builder that fails on 3rd of 5 timestamps -> 500, 0 rows."""
+    name, version = write_temp_builder(
+        "midrange-crash",
+        "0.1.0",
+        """\
+name = "midrange-crash"
+version = "0.1.0"
+builder = "builder.py"
+calendar = "everyday"
+granularity = "1d"
+start-date = "2020-01-01"
+
+[schema]
+value = "int"
+""",
+        # each timestamp runs in its own subprocess, so use
+        # the timestamp itself to decide when to crash
+        """\
+from datetime import datetime
+
+def build(dependencies, timestamp: datetime) -> list[dict]:
+    if timestamp.day >= 3:
+        raise RuntimeError("crash on day 3+")
+    return [{"value": timestamp.day}]
+""",
+    )
+    # request 5 days, builder crashes on the 3rd
+    resp = client.post(
+        f"/api/v1/build/{name}/{version}",
+        params={"start": "2024-01-01", "end": "2024-01-05"},
+    )
+    assert resp.status_code == 500
+
+    # rows are accumulated in memory and bulk-inserted at the end,
+    # so a mid-range crash means nothing gets inserted
+    assert _row_count(db_conn, name) == 0
+
+
+def test_dep_failure_blocks_parent(client, db_conn, write_temp_builder):
+    """root dep crashes -> parent not built, 0 rows for both."""
+    # create a root dep that crashes
+    write_temp_builder(
+        "crashing-root",
+        "0.1.0",
+        """\
+name = "crashing-root"
+version = "0.1.0"
+builder = "builder.py"
+calendar = "everyday"
+granularity = "1d"
+start-date = "2020-01-01"
+
+[schema]
+value = "int"
+""",
+        """\
+from datetime import datetime
+
+def build(dependencies, timestamp: datetime) -> list[dict]:
+    raise RuntimeError("root crash")
+""",
+    )
+    # create a parent that depends on the crashing root
+    name, version = write_temp_builder(
+        "parent-of-crash",
+        "0.1.0",
+        """\
+name = "parent-of-crash"
+version = "0.1.0"
+builder = "builder.py"
+calendar = "everyday"
+granularity = "1d"
+start-date = "2020-01-01"
+
+[schema]
+value = "int"
+
+[dependencies]
+crashing-root = "0.1.0"
+""",
+        """\
+from datetime import datetime
+
+def build(dependencies, timestamp: datetime) -> list[dict]:
+    return [{"value": 1}]
+""",
+    )
+    resp = client.post(
+        f"/api/v1/build/{name}/{version}",
+        params={"start": "2024-01-02", "end": "2024-01-02"},
+    )
+    assert resp.status_code == 500
+    assert _row_count(db_conn, "crashing-root") == 0
+    assert _row_count(db_conn, name) == 0

--- a/builders/server/tests/integration/test_idempotency.py
+++ b/builders/server/tests/integration/test_idempotency.py
@@ -1,0 +1,96 @@
+from datetime import datetime
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def _query_rows(db_conn, dataset_name, version="0.1.0"):
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT dataset_name, dataset_version, timestamp, data, created_at "
+            "FROM datasets "
+            "WHERE dataset_name = %s AND dataset_version = %s "
+            "ORDER BY timestamp, data->>'ticker'",
+            (dataset_name, version),
+        )
+        return cur.fetchall()
+
+
+def _row_count(db_conn, dataset_name, version="0.1.0"):
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT count(*) FROM datasets "
+            "WHERE dataset_name = %s AND dataset_version = %s",
+            (dataset_name, version),
+        )
+        return cur.fetchone()[0]
+
+
+def test_rebuild_same_range_noop(client, db_conn):
+    """build then rebuild -> row count unchanged."""
+    params = {"start": "2024-01-02", "end": "2024-01-04"}
+
+    client.post("/api/v1/build/mock-ohlc/0.1.0", params=params)
+    count_first = _row_count(db_conn, "mock-ohlc")
+    rows_first = _query_rows(db_conn, "mock-ohlc")
+
+    client.post("/api/v1/build/mock-ohlc/0.1.0", params=params)
+    count_second = _row_count(db_conn, "mock-ohlc")
+    rows_second = _query_rows(db_conn, "mock-ohlc")
+
+    assert count_first == count_second == 3
+    # data and created_at should be identical
+    for r1, r2 in zip(rows_first, rows_second, strict=True):
+        assert r1[3] == r2[3]
+        assert r1[4] == r2[4]
+
+
+def test_rebuild_dep_chain_noop(client, db_conn):
+    """build mock-daily-close twice -> all row counts unchanged."""
+    params = {"start": "2024-01-02", "end": "2024-01-02"}
+
+    client.post("/api/v1/build/mock-daily-close/0.1.0", params=params)
+    ohlc_count_1 = _row_count(db_conn, "mock-ohlc")
+    close_count_1 = _row_count(db_conn, "mock-daily-close")
+
+    client.post("/api/v1/build/mock-daily-close/0.1.0", params=params)
+    ohlc_count_2 = _row_count(db_conn, "mock-ohlc")
+    close_count_2 = _row_count(db_conn, "mock-daily-close")
+
+    assert ohlc_count_1 == ohlc_count_2 == 1
+    assert close_count_1 == close_count_2 == 1
+
+
+def test_extend_range_adds_only_new(client, db_conn):
+    """build days 1-2, then build days 1-4 -> 4 rows, originals untouched."""
+    # build first two days
+    client.post(
+        "/api/v1/build/mock-ohlc/0.1.0",
+        params={"start": "2024-01-02", "end": "2024-01-03"},
+    )
+    rows_initial = _query_rows(db_conn, "mock-ohlc")
+    assert len(rows_initial) == 2
+
+    # extend to 4 days
+    client.post(
+        "/api/v1/build/mock-ohlc/0.1.0",
+        params={"start": "2024-01-02", "end": "2024-01-05"},
+    )
+    rows_extended = _query_rows(db_conn, "mock-ohlc")
+    assert len(rows_extended) == 4
+
+    # original rows should be untouched (same data + created_at)
+    originals = {r[2]: r for r in rows_initial}
+    for row in rows_extended:
+        ts = row[2]
+        if ts in originals:
+            assert row[3] == originals[ts][3]  # data unchanged
+            assert row[4] == originals[ts][4]  # created_at unchanged
+
+    # new rows should be Jan 4 and Jan 5
+    new_timestamps = [r[2] for r in rows_extended if r[2] not in originals]
+    assert sorted(new_timestamps) == [
+        datetime(2024, 1, 4),
+        datetime(2024, 1, 5),
+    ]


### PR DESCRIPTION
Add atomicity and idempotency integration tests.

**Atomicity tests (test_atomicity.py):**
- `test_builder_failure_midrange_no_partial_insert` -- builder crashes on day 3 of 5, verifies 0 rows inserted (rows accumulated in-memory before bulk insert)
- `test_dep_failure_blocks_parent` -- root dependency crashes, parent never builds, 0 rows for both

**Idempotency tests (test_idempotency.py):**
- `test_rebuild_same_range_noop` -- rebuild identical range, row count and created_at unchanged
- `test_rebuild_dep_chain_noop` -- rebuild dep chain, all counts unchanged
- `test_extend_range_adds_only_new` -- extend range from 2 to 4 days, original rows untouched, only new days added

**Why:**
These tests verify critical DB guarantees: failed builds don't leave partial data, and the overwrite policy correctly skips already-built timestamps.