### PR TITLE
chore: add backend-dev just command for local dev

### DIFF
--- a/justfile
+++ b/justfile
@@ -16,6 +16,14 @@ test-integration:
 precommit:
     uv run pre-commit run --all-files
 
+# run the builder service locally against the postgres docker container
+# postgres is exposed on localhost:5432, so DATABASE_URL uses localhost instead of the docker-internal hostname
+# --reload enables hot reload on file changes
+backend-dev:
+    docker compose -f infra/docker-compose.yml up postgres -d
+    DATABASE_URL=postgresql://datastream:changeme@localhost:5432/datastream uv run alembic upgrade head
+    DATABASE_URL=postgresql://datastream:changeme@localhost:5432/datastream uv run uvicorn main:app --host 0.0.0.0 --port 3000 --app-dir builders/server --reload
+
 frontend-dev:
     cd frontend && bun install && bun run dev
 


### PR DESCRIPTION
adds `just backend-dev` for running the builder service locally. starts only the postgres container, runs migrations against localhost, then starts uvicorn with hot reload. avoids rebuilding the full docker image on every code change.