### PR TITLE
fix: resolve scripts directory path for local dev

### DIFF
--- a/builders/server/runtime/config.py
+++ b/builders/server/runtime/config.py
@@ -1,3 +1,4 @@
+import os
 import re
 import tomllib
 from dataclasses import dataclass
@@ -63,7 +64,10 @@ class DatasetConfig:
 # defaults for optional TOML fields
 DEFAULT_BUILDER = "builder.py"
 
-SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+# overridable via env var for local dev, where the scripts dir
+# is not a sibling of the server package
+_default_scripts = str(Path(__file__).resolve().parent.parent / "scripts")
+SCRIPTS_DIR = Path(os.environ.get("SCRIPTS_DIR", _default_scripts))
 
 _GRANULARITY_MAP = {
     "1s": timedelta(seconds=1),

--- a/dev-docs/SPEC-backend.md
+++ b/dev-docs/SPEC-backend.md
@@ -69,6 +69,8 @@ builders/server/
 
 `main.py` is the uvicorn entrypoint (`main:app`). It creates the `FastAPI` app, mounts routers from `api/`, and runs a `lifespan` handler that calls `setup_builder_venvs()` on startup to create per-builder virtual environments. Dependencies flow strictly downward: `api -> service -> db/runtime`. No layer imports upward.
 
+**Scripts directory resolution**: `SCRIPTS_DIR` in `runtime/config.py` defaults to a path relative to the source file (`../scripts` from the server package root). This works in Docker where scripts are volume-mounted at `/app/scripts`. For local dev, the scripts live at `builders/scripts` (a sibling of `builders/server`), so the `SCRIPTS_DIR` env var overrides the default. `just backend-dev` sets this automatically.
+
 ### Logging
 
 The server uses `structlog` for structured logging. Configuration lives in `log_config.py` and is called once at import time in `main.py`.

--- a/justfile
+++ b/justfile
@@ -22,7 +22,7 @@ precommit:
 backend-dev:
     docker compose -f infra/docker-compose.yml up postgres -d --wait
     DATABASE_URL=postgresql://datastream:changeme@localhost:5432/datastream uv run alembic upgrade head
-    DATABASE_URL=postgresql://datastream:changeme@localhost:5432/datastream uv run uvicorn main:app --host 0.0.0.0 --port 3000 --app-dir builders/server --reload
+    SCRIPTS_DIR={{justfile_directory()}}/builders/scripts DATABASE_URL=postgresql://datastream:changeme@localhost:5432/datastream uv run uvicorn main:app --host 0.0.0.0 --port 3000 --app-dir builders/server --reload
 
 frontend-dev:
     cd frontend && bun install && bun run dev


### PR DESCRIPTION
SCRIPTS_DIR in config.py was computed relative to the source file, resolving to builders/server/scripts. This works in Docker (scripts are volume-mounted at /app/scripts) but not for local dev where scripts live at builders/scripts.

Added a SCRIPTS_DIR env var override with the computed path as fallback. just backend-dev sets it automatically so both local dev and Docker produce the same startup logs.