### PR TITLE
refactor: rename get_rows to get_rows_timestamps

### DIFF
--- a/builders/server/db/datasets.py
+++ b/builders/server/db/datasets.py
@@ -114,7 +114,7 @@ def get_rows_range(
         return dict(result)
 
 
-def get_rows(
+def get_rows_timestamps(
     dataset_name: str,
     dataset_version: SemVer,
     timestamps: list[datetime],

--- a/builders/server/service/builder.py
+++ b/builders/server/service/builder.py
@@ -203,7 +203,9 @@ def _build_recursive(
                 )
             else:
                 # no lookback, fetch just this timestamp
-                dep_rows = db.datasets.get_rows(dep_name, dep_info.version, [ts])
+                dep_rows = db.datasets.get_rows_timestamps(
+                    dep_name, dep_info.version, [ts]
+                )
 
             if not dep_rows:
                 raise RuntimeError(

--- a/builders/server/tests/db/test_datasets.py
+++ b/builders/server/tests/db/test_datasets.py
@@ -81,17 +81,19 @@ def test_insert_rows_calls_execute_values(
 
 
 @patch("db.datasets.get_conn")
-def test_get_rows_empty_timestamps_returns_empty_dict(
+def test_get_rows_timestamps_empty_timestamps_returns_empty_dict(
     mock_get_conn: MagicMock,
 ) -> None:
     """Empty input returns empty dict."""
-    result = datasets.get_rows("ds", V010, [])
+    result = datasets.get_rows_timestamps("ds", V010, [])
     assert result == {}
     mock_get_conn.assert_not_called()
 
 
 @patch("db.datasets.get_conn")
-def test_get_rows_returns_list_per_timestamp(mock_get_conn: MagicMock) -> None:
+def test_get_rows_timestamps_returns_list_per_timestamp(
+    mock_get_conn: MagicMock,
+) -> None:
     """Returns dict[datetime, list[dict]] with multiple rows aggregated."""
     ts = datetime(2024, 1, 1)
     mock_cursor = MagicMock()
@@ -104,7 +106,7 @@ def test_get_rows_returns_list_per_timestamp(mock_get_conn: MagicMock) -> None:
     mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
     mock_get_conn.return_value = mock_conn
 
-    result = datasets.get_rows("ds", V010, [ts])
+    result = datasets.get_rows_timestamps("ds", V010, [ts])
     assert ts in result
     assert len(result[ts]) == 2
     assert result[ts][0] == {"ticker": "AAPL", "price": 100}

--- a/builders/server/tests/service/test_builder.py
+++ b/builders/server/tests/service/test_builder.py
@@ -261,7 +261,7 @@ def test_build_dataset_missing_dependency_data_raises(
     # No existing timestamps for either dataset
     mock_db.get_existing_timestamps.return_value = []
     # dep has no data for the timestamp (after dep build completes with no inserts)
-    mock_db.get_rows.return_value = {}
+    mock_db.get_rows_timestamps.return_value = {}
     mock_runner.run_builder.return_value = []
 
     with pytest.raises(RuntimeError, match="missing data for timestamp"):
@@ -296,7 +296,7 @@ def test_build_dataset_passes_dep_data_as_dict_of_timestamps(
     # dep returns multi-row data keyed by timestamp
     ts = datetime(2024, 1, 1)
     dep_rows = [{"ticker": "AAPL", "close": 150}, {"ticker": "MSFT", "close": 200}]
-    mock_db.get_rows.return_value = {ts: dep_rows}
+    mock_db.get_rows_timestamps.return_value = {ts: dep_rows}
     mock_runner.run_builder.return_value = [{"val": 1}]
 
     build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 1))
@@ -711,7 +711,7 @@ def test_build_dataset_lookback_fetches_range(
 
     build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 3))
 
-    # get_rows_range should be called (not get_rows)
+    # get_rows_range should be called (not get_rows_timestamps)
     mock_db.get_rows_range.assert_called_once()
     call_args = mock_db.get_rows_range.call_args[0]
     assert call_args[0] == "dep"
@@ -729,13 +729,13 @@ def test_build_dataset_lookback_fetches_range(
 @patch("service.builder.runner")
 @patch("service.builder.db.datasets")
 @patch("service.builder.config")
-def test_build_dataset_no_lookback_uses_get_rows(
+def test_build_dataset_no_lookback_uses_get_rows_timestamps(
     mock_config: MagicMock,
     mock_db: MagicMock,
     mock_runner: MagicMock,
     mock_validator: MagicMock,
 ) -> None:
-    """Without lookback, get_rows is used (not get_rows_range)."""
+    """Without lookback, get_rows_timestamps is used (not get_rows_range)."""
 
     def fake_load_config(name, version):
         if name == "ds":
@@ -750,10 +750,10 @@ def test_build_dataset_no_lookback_uses_get_rows(
         [],  # ds
     ]
     ts = datetime(2024, 1, 1)
-    mock_db.get_rows.return_value = {ts: [{"val": 1}]}
+    mock_db.get_rows_timestamps.return_value = {ts: [{"val": 1}]}
     mock_runner.run_builder.return_value = [{"val": 1}]
 
     build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 1))
 
-    mock_db.get_rows.assert_called_once()
+    mock_db.get_rows_timestamps.assert_called_once()
     mock_db.get_rows_range.assert_not_called()


### PR DESCRIPTION
Rename `get_rows` to `get_rows_timestamps` for clarity, since it fetches rows by a list of specific timestamps (as opposed to `get_rows_range` which fetches by a time range).

Updated the function definition, its call site in `service/builder.py`, and all test references.