### PR TITLE
chore: add trailing whitespace and end-of-file pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.4
     hooks:


### PR DESCRIPTION
adds trailing-whitespace and end-of-file-fixer hooks from pre-commit-hooks to catch trailing spaces and missing final newlines across all files