### PR TITLE
fix: strip quotes from .env values in isolated_worker

### DIFF
--- a/builders/server/runtime/isolated_worker.py
+++ b/builders/server/runtime/isolated_worker.py
@@ -61,7 +61,12 @@ def _load_env_file(env_path: str) -> None:
             key, _, value = line.partition("=")
             if not key:
                 continue
-            os.environ[key.strip()] = value.strip()
+            value = value.strip()
+
+            # strip single or double quotes from the value
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+                value = value[1:-1]
+            os.environ[key.strip()] = value
 
 
 def main() -> None:

--- a/builders/server/tests/runtime/test_isolated_worker.py
+++ b/builders/server/tests/runtime/test_isolated_worker.py
@@ -154,6 +154,19 @@ def test_load_env_file_value_with_equals(worker, tmp_path: Path):
         os.environ.pop("URL", None)
 
 
+def test_load_env_file_strips_quotes(worker, tmp_path: Path):
+    """_load_env_file strips surrounding double or single quotes from values."""
+    env = tmp_path / ".env"
+    env.write_text("DOUBLE=\"hello\"\nSINGLE='world'\n")
+    try:
+        worker._load_env_file(str(env))
+        assert os.environ.get("DOUBLE") == "hello"
+        assert os.environ.get("SINGLE") == "world"
+    finally:
+        os.environ.pop("DOUBLE", None)
+        os.environ.pop("SINGLE", None)
+
+
 # --- subprocess integration tests ---
 
 


### PR DESCRIPTION
## Summary
- Strip surrounding quotes from values in the `.env` parser in \`isolated_worker.py\`

## Why
The stdlib parser was not handling quoted values (e.g. \`KEY="value"\`), causing the literal quote characters to be included in the env var. This broke EODHD API auth when the key was stored with quotes in \`.env\`.

## Benefit
\`.env\` files now work correctly with or without quoted values, matching standard \`.env\` file conventions.