### PR TITLE
feat: auto-generate pyrightconfig.json for builder venvs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,8 @@ infra/.env
 .DS_Store
 Thumbs.db
 
+# Generated
+pyrightconfig.json
+
 # Claude Code
 **/.claude/settings.local.json

--- a/dev-tools/gen_pyrightconfig.py
+++ b/dev-tools/gen_pyrightconfig.py
@@ -1,0 +1,70 @@
+"""Generate a root pyrightconfig.json with per-builder execution environments.
+
+Scans builders/scripts/<name>/<version>/ for directories with requirements.txt
+and generates executionEnvironments entries pointing to each builder's .venv.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "builders" / "scripts"
+OUTPUT = REPO_ROOT / "pyrightconfig.json"
+
+
+def find_builder_dirs(scripts_dir: Path) -> list[Path]:
+    """Find all builder directories that have a requirements.txt."""
+    builder_dirs = []
+    if not scripts_dir.is_dir():
+        return builder_dirs
+
+    for dataset_dir in sorted(scripts_dir.iterdir()):
+        if not dataset_dir.is_dir():
+            continue
+        for version_dir in sorted(dataset_dir.iterdir()):
+            if not version_dir.is_dir():
+                continue
+            if (version_dir / "requirements.txt").exists():
+                builder_dirs.append(version_dir)
+
+    return builder_dirs
+
+
+def _find_site_packages(builder_dir: Path) -> Path | None:
+    """Find the site-packages directory inside a builder's .venv."""
+    lib_dir = builder_dir / ".venv" / "lib"
+    if not lib_dir.is_dir():
+        return None
+    # expect exactly one pythonX.Y directory
+    python_dirs = [d for d in lib_dir.iterdir() if d.name.startswith("python")]
+    if not python_dirs:
+        return None
+    return python_dirs[0] / "site-packages"
+
+
+def generate_config(builder_dirs: list[Path]) -> dict:
+    """Build the pyrightconfig.json content."""
+    environments = []
+    for builder_dir in builder_dirs:
+        rel = builder_dir.relative_to(REPO_ROOT)
+        entry: dict = {"root": str(rel)}
+        site_packages = _find_site_packages(builder_dir)
+        if site_packages and site_packages.is_dir():
+            entry["extraPaths"] = [str(site_packages.relative_to(REPO_ROOT))]
+        environments.append(entry)
+
+    return {"executionEnvironments": environments}
+
+
+def main() -> None:
+    builder_dirs = find_builder_dirs(SCRIPTS_DIR)
+    config = generate_config(builder_dirs)
+    OUTPUT.write_text(json.dumps(config, indent=2) + "\n")
+    print(f"wrote {OUTPUT} with {len(builder_dirs)} builder environment(s)")  # noqa: T201
+    for d in builder_dirs:
+        print(f"  - {d.relative_to(REPO_ROOT)}")  # noqa: T201
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/justfile
+++ b/justfile
@@ -22,12 +22,17 @@ test-integration:
 precommit:
     uv run pre-commit run --all-files
 
+# generate root pyrightconfig.json with per-builder venv environments
+gen-pyright:
+    python dev-tools/gen_pyrightconfig.py
+
 # run the builder service locally against the postgres docker container
 # postgres is exposed on localhost:5432, so DATABASE_URL uses localhost instead of the docker-internal hostname
 # --reload enables hot reload on file changes
 backend-dev:
     docker compose -f infra/docker-compose.yml up postgres -d --wait
     DATABASE_URL=postgresql://datastream:changeme@localhost:5432/datastream uv run alembic upgrade head
+    python dev-tools/gen_pyrightconfig.py
     SCRIPTS_DIR={{justfile_directory()}}/builders/scripts DATABASE_URL=postgresql://datastream:changeme@localhost:5432/datastream uv run uvicorn main:app --host 0.0.0.0 --port 3000 --app-dir builders/server --reload
 
 # install frontend deps and start the vite dev server on port 5173


### PR DESCRIPTION
## Summary
- adds `dev-tools/gen_pyrightconfig.py` that scans `builders/scripts/<name>/<version>/` for directories with `requirements.txt` and generates a root `pyrightconfig.json` with per-builder `executionEnvironments` entries
- adds `just gen-pyright` command and hooks it into `just backend-dev` so new builders are automatically picked up
- removes the per-builder `pyrightconfig.json` from `faang-daily-close/0.1.0` (superseded by the root config)
- gitignores `pyrightconfig.json` at the repo root since it's auto-generated and references local `.venv` dirs

## Why
IDE type checkers (pyright/pylance) couldn't resolve imports from per-builder venvs (e.g. `eodhd`) because the workspace-level interpreter didn't have those packages. This solves it scalably -- no manual config needed when adding new builders.