### PR TITLE
chore: add IDE reload reminder to gen_pyrightconfig

### DIFF
--- a/dev-tools/gen_pyrightconfig.py
+++ b/dev-tools/gen_pyrightconfig.py
@@ -64,6 +64,7 @@ def main() -> None:
     print(f"wrote {OUTPUT} with {len(builder_dirs)} builder environment(s)")  # noqa: T201
     for d in builder_dirs:
         print(f"  - {d.relative_to(REPO_ROOT)}")  # noqa: T201
+    print("If you're in an IDE, please reload it to pick up the changes.")  # noqa: T201
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add a print statement at the end of gen_pyrightconfig to remind users to reload their IDE if they're in one.

This improves UX by making it immediately clear that the IDE needs to be reloaded after pyrightconfig.json is regenerated.