### PR TITLE
feat: add GET /api/v1/data endpoint

### DIFF
--- a/builders/server/api/routes.py
+++ b/builders/server/api/routes.py
@@ -2,7 +2,8 @@ from datetime import datetime
 
 import structlog
 from fastapi import APIRouter, HTTPException, Query
-from service.builder import NoValidTimestampsError, build_dataset
+from fastapi.responses import JSONResponse
+from service.builder import NoValidTimestampsError, build_dataset, get_data
 from utils.semver import SemVer
 
 logger = structlog.get_logger()
@@ -52,3 +53,64 @@ def build(
         raise HTTPException(status_code=500, detail=str(e)) from e
 
     return {"status": "ok"}
+
+
+@router.get("/data/{dataset_name}/{dataset_version}")
+def data(
+    dataset_name: str,
+    dataset_version: str,
+    start: str = Query(...),
+    end: str = Query(...),
+    build_data: bool = Query(True, alias="build-data"),
+):
+    """Fetch data for a dataset, optionally building missing data first."""
+    try:
+        version = SemVer.parse(dataset_version)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400, detail=f"Invalid version: {dataset_version}"
+        ) from exc
+
+    try:
+        start_ts = datetime.fromisoformat(start)
+        end_ts = datetime.fromisoformat(end)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=400, detail="Invalid start/end timestamp"
+        ) from exc
+
+    structlog.contextvars.bind_contextvars(
+        dataset_name=dataset_name, version=str(version)
+    )
+
+    try:
+        result = get_data(
+            dataset_name, version, start_ts, end_ts, build_data=build_data
+        )
+    except NoValidTimestampsError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+    except Exception as e:
+        logger.exception("data fetch failed")
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+    rows = [
+        {
+            "timestamp": ts.isoformat(),
+            "data": data_list,
+        }
+        for ts, data_list in sorted(result.data.items())
+    ]
+
+    body = {
+        "dataset_name": dataset_name,
+        "dataset_version": str(version),
+        "total_timestamps": result.total_timestamps,
+        "returned_timestamps": result.returned_timestamps,
+        "rows": rows,
+    }
+
+    # return 206 when caller opted out of building and data is incomplete
+    if not build_data and result.returned_timestamps < result.total_timestamps:
+        return JSONResponse(content=body, status_code=206)
+
+    return body

--- a/builders/server/service/builder.py
+++ b/builders/server/service/builder.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -12,6 +13,15 @@ logger = structlog.get_logger()
 
 class NoValidTimestampsError(Exception):
     """raised when generate_timestamps returns no valid calendar dates for the range."""
+
+
+@dataclass
+class DataResult:
+    """Result of a data fetch, including completeness metadata."""
+
+    data: dict[datetime, list[dict]]
+    total_timestamps: int
+    returned_timestamps: int
 
 
 # TODO (bryan): benchmark this, and optimize if needed
@@ -231,4 +241,44 @@ def _build_recursive(
         dataset=dataset_name,
         version=str(dataset_version),
         count=len(rows),
+    )
+
+
+def get_data(
+    dataset_name: str,
+    dataset_version: SemVer,
+    start: datetime,
+    end: datetime,
+    *,
+    build_data: bool,
+) -> DataResult:
+    """Fetch data for a dataset, optionally building missing data first."""
+    cfg = config.load_config(dataset_name, dataset_version)
+
+    if build_data:
+        logger.info(
+            "triggering build after get_data call",
+            dataset=dataset_name,
+            version=str(dataset_version),
+            start=start.isoformat(),
+            end=end.isoformat(),
+        )
+        build_dataset(dataset_name, dataset_version, start, end)
+
+    total_num_rows = len(generate_timestamps(start, end, cfg.granularity, cfg.calendar))
+    data = db.datasets.get_rows_range(dataset_name, dataset_version, start, end)
+
+    logger.info(
+        "data fetched",
+        dataset=dataset_name,
+        version=str(dataset_version),
+        build_data=build_data,
+        total_timestamps=total_num_rows,
+        returned_timestamps=len(data),
+    )
+
+    return DataResult(
+        data=data,
+        total_timestamps=total_num_rows,
+        returned_timestamps=len(data),
     )

--- a/builders/server/tests/api/test_routes.py
+++ b/builders/server/tests/api/test_routes.py
@@ -1,8 +1,9 @@
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient
 from main import app
-from service.builder import NoValidTimestampsError
+from service.builder import DataResult, NoValidTimestampsError
 
 client: TestClient = TestClient(app)
 
@@ -42,5 +43,121 @@ def test_build_endpoint_internal_error(mock_build: MagicMock) -> None:
 def test_build_endpoint_no_valid_timestamps(mock_build: MagicMock) -> None:
     """No valid calendar timestamps returns 422."""
     resp = client.post("/api/v1/build/ds/0.1.0?start=2024-01-06&end=2024-01-07")
+    assert resp.status_code == 422
+    assert "no valid timestamps in range" in resp.json()["detail"]
+
+
+# --- GET /data tests ---
+
+
+@patch("api.routes.get_data")
+def test_data_endpoint_default_build_200(mock_get_data: MagicMock) -> None:
+    """GET with default build-data=true returns 200 with metadata."""
+    ts = datetime(2024, 1, 2)
+    mock_get_data.return_value = DataResult(
+        data={ts: [{"ticker": "AAPL", "close": 150}]},
+        total_timestamps=1,
+        returned_timestamps=1,
+    )
+
+    resp = client.get("/api/v1/data/ds/0.1.0?start=2024-01-02&end=2024-01-02")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["dataset_name"] == "ds"
+    assert body["dataset_version"] == "0.1.0"
+    assert body["total_timestamps"] == 1
+    assert body["returned_timestamps"] == 1
+    assert len(body["rows"]) == 1
+    assert body["rows"][0]["timestamp"] == "2024-01-02T00:00:00"
+    assert body["rows"][0]["data"] == [{"ticker": "AAPL", "close": 150}]
+    # verify build_data=True was passed through
+    mock_get_data.assert_called_once()
+    assert mock_get_data.call_args.kwargs["build_data"] is True
+
+
+@patch("api.routes.get_data")
+def test_data_endpoint_no_build_complete_200(mock_get_data: MagicMock) -> None:
+    """GET with build-data=false and complete data returns 200."""
+    ts = datetime(2024, 1, 2)
+    mock_get_data.return_value = DataResult(
+        data={ts: [{"val": 1}]},
+        total_timestamps=1,
+        returned_timestamps=1,
+    )
+
+    resp = client.get(
+        "/api/v1/data/ds/0.1.0?start=2024-01-02&end=2024-01-02&build-data=false"
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["total_timestamps"] == 1
+    assert resp.json()["returned_timestamps"] == 1
+
+
+@patch("api.routes.get_data")
+def test_data_endpoint_no_build_incomplete_206(mock_get_data: MagicMock) -> None:
+    """GET with build-data=false and missing data returns 206."""
+    mock_get_data.return_value = DataResult(
+        data={},
+        total_timestamps=3,
+        returned_timestamps=0,
+    )
+
+    resp = client.get(
+        "/api/v1/data/ds/0.1.0?start=2024-01-01&end=2024-01-03&build-data=false"
+    )
+
+    assert resp.status_code == 206
+    body = resp.json()
+    assert body["total_timestamps"] == 3
+    assert body["returned_timestamps"] == 0
+    assert body["rows"] == []
+
+
+@patch("api.routes.get_data")
+def test_data_endpoint_no_build_partial_206(mock_get_data: MagicMock) -> None:
+    """GET with build-data=false and partial data returns 206."""
+    ts = datetime(2024, 1, 1)
+    mock_get_data.return_value = DataResult(
+        data={ts: [{"val": 1}]},
+        total_timestamps=3,
+        returned_timestamps=1,
+    )
+
+    resp = client.get(
+        "/api/v1/data/ds/0.1.0?start=2024-01-01&end=2024-01-03&build-data=false"
+    )
+
+    assert resp.status_code == 206
+    assert resp.json()["returned_timestamps"] == 1
+
+
+def test_data_endpoint_invalid_version() -> None:
+    """Bad version returns 400."""
+    resp = client.get("/api/v1/data/ds/bad-version?start=2024-01-01&end=2024-01-31")
+    assert resp.status_code == 400
+
+
+def test_data_endpoint_invalid_timestamp() -> None:
+    """Bad timestamp returns 400."""
+    resp = client.get("/api/v1/data/ds/0.1.0?start=not-a-date&end=2024-01-31")
+    assert resp.status_code == 400
+
+
+@patch("api.routes.get_data", side_effect=FileNotFoundError("config not found"))
+def test_data_endpoint_internal_error(mock_get_data: MagicMock) -> None:
+    """Config not found returns 500."""
+    resp = client.get("/api/v1/data/ds/0.1.0?start=2024-01-01&end=2024-01-31")
+    assert resp.status_code == 500
+
+
+@patch(
+    "api.routes.get_data",
+    side_effect=NoValidTimestampsError("no valid timestamps in range"),
+)
+def test_data_endpoint_no_valid_timestamps_422(mock_get_data: MagicMock) -> None:
+    """No valid calendar timestamps returns 422."""
+    resp = client.get("/api/v1/data/ds/0.1.0?start=2024-01-06&end=2024-01-07")
     assert resp.status_code == 422
     assert "no valid timestamps in range" in resp.json()["detail"]

--- a/builders/server/tests/service/test_builder.py
+++ b/builders/server/tests/service/test_builder.py
@@ -17,6 +17,7 @@ from service.builder import (
     NoValidTimestampsError,
     build_dataset,
     generate_timestamps,
+    get_data,
     validate_dependency_graph,
 )
 from utils.semver import SemVer
@@ -757,3 +758,112 @@ def test_build_dataset_no_lookback_uses_get_rows_timestamps(
 
     mock_db.get_rows_timestamps.assert_called_once()
     mock_db.get_rows_range.assert_not_called()
+
+
+# --- get_data tests ---
+
+
+@patch("service.builder.db.datasets")
+@patch("service.builder.config")
+def test_get_data_no_build_returns_data(
+    mock_config: MagicMock, mock_db: MagicMock
+) -> None:
+    """get_data with build_data=False returns data and metadata."""
+    mock_config.load_config.return_value = _cfg()
+    ts = datetime(2024, 1, 1)
+    db_data = {ts: [{"ticker": "AAPL", "close": 150}]}
+    mock_db.get_rows_range.return_value = db_data
+
+    start = datetime(2024, 1, 1)
+    end = datetime(2024, 1, 2)
+    result = get_data("ds", V010, start, end, build_data=False)
+
+    assert result.data == db_data
+    assert result.returned_timestamps == 1
+    assert result.total_timestamps == 2
+    mock_config.load_config.assert_called_once_with("ds", V010)
+    mock_db.get_rows_range.assert_called_once_with("ds", V010, start, end)
+
+
+@patch("service.builder.db.datasets")
+@patch("service.builder.config")
+def test_get_data_no_build_empty_result(
+    mock_config: MagicMock, mock_db: MagicMock
+) -> None:
+    """get_data with build_data=False and no data returns empty with metadata."""
+    mock_config.load_config.return_value = _cfg()
+    mock_db.get_rows_range.return_value = {}
+
+    result = get_data(
+        "ds",
+        V010,
+        datetime(2024, 1, 1),
+        datetime(2024, 1, 2),
+        build_data=False,
+    )
+
+    assert result.data == {}
+    assert result.returned_timestamps == 0
+    assert result.total_timestamps == 2
+
+
+@patch("service.builder.build_dataset")
+@patch("service.builder.db.datasets")
+@patch("service.builder.config")
+def test_get_data_with_build_calls_build_dataset(
+    mock_config: MagicMock,
+    mock_db: MagicMock,
+    mock_build: MagicMock,
+) -> None:
+    """get_data with build_data=True calls build_dataset before fetching."""
+    mock_config.load_config.return_value = _cfg()
+    ts = datetime(2024, 1, 1)
+    mock_db.get_rows_range.return_value = {ts: [{"val": 1}]}
+
+    result = get_data(
+        "ds",
+        V010,
+        ts,
+        ts,
+        build_data=True,
+    )
+
+    mock_build.assert_called_once_with("ds", V010, ts, ts)
+    assert result.data == {ts: [{"val": 1}]}
+    assert result.total_timestamps == 1
+    assert result.returned_timestamps == 1
+
+
+@patch("service.builder.build_dataset")
+@patch("service.builder.config")
+def test_get_data_with_build_no_valid_timestamps_raises(
+    mock_config: MagicMock,
+    mock_build: MagicMock,
+) -> None:
+    """get_data with build_data=True propagates NoValidTimestampsError."""
+    mock_config.load_config.return_value = _cfg()
+    mock_build.side_effect = NoValidTimestampsError("no valid timestamps")
+
+    with pytest.raises(NoValidTimestampsError, match="no valid timestamps"):
+        get_data(
+            "ds",
+            V010,
+            datetime(2024, 1, 1),
+            datetime(2024, 1, 2),
+            build_data=True,
+        )
+
+
+@patch("service.builder.config")
+def test_get_data_config_not_found_raises(mock_config: MagicMock) -> None:
+    """get_data raises when dataset config doesn't exist."""
+    mock_config.load_config.side_effect = FileNotFoundError("config not found")
+
+    with pytest.raises(FileNotFoundError, match="config not found"):
+        get_data(
+            "nonexistent",
+            V010,
+            datetime(2024, 1, 1),
+            datetime(2024, 1, 2),
+            build_data=True,
+        )


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/data/{dataset_name}/{dataset_version}?start=...&end=...&build-data=...` endpoint
- By default (`build-data=true`), builds missing data before returning -- ensures complete results
- With `build-data=false`, returns only existing data; returns 206 if data is incomplete
- Response includes `total_timestamps` and `returned_timestamps` metadata fields
- Add `DataResult` dataclass and `get_data()` service function

## Test plan
- [x] Unit tests for `get_data()` (no-build, with-build, empty, config not found, no valid timestamps)
- [x] Unit tests for GET route (200 default build, 200 no-build complete, 206 no-build incomplete, 206 partial, 400 bad input, 422 no valid timestamps, 500 error)
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)