### PR TITLE
chore: add typeCheckingMode basic to gen_pyrightconfig

### DIFF
--- a/dev-tools/gen_pyrightconfig.py
+++ b/dev-tools/gen_pyrightconfig.py
@@ -54,7 +54,8 @@ def generate_config(builder_dirs: list[Path]) -> dict:
             entry["extraPaths"] = [str(site_packages.relative_to(REPO_ROOT))]
         environments.append(entry)
 
-    return {"executionEnvironments": environments}
+    # extra fields applied globally across all environments
+    return {"typeCheckingMode": "basic", "executionEnvironments": environments}
 
 
 def main() -> None:


### PR DESCRIPTION
adds `typeCheckingMode: basic` to the generated pyrightconfig.json so IDEs enable type checking by default when the config is regenerated