### PR TITLE
refactor: optimize builder dockerfile for cache and build performance

### DIFF
--- a/infra/builder/Dockerfile
+++ b/infra/builder/Dockerfile
@@ -1,18 +1,34 @@
 FROM python:3.12-slim
 
+# Install system dependencies and uv
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+# Configure environment early (static metadata)
+ENV PATH="/app/.venv/bin:$PATH"
+ENV UV_COMPILE_BYTECODE=1
+ENV UV_LINK_MODE=copy
 
-COPY pyproject.toml uv.lock /app/
-RUN uv sync --no-dev
+# Install dependencies (Medium frequency change)
+# This layer is only invalidated if pyproject.toml or uv.lock changes.
+COPY pyproject.toml uv.lock ./
+# - --mount=type=cache: Persist uv's package cache across builds.
+# - --frozen: strict sync from uv.lock (no updates).
+# - --no-install-project: Do not attempt to install the project package itself (source not yet present).
+# - --no-dev: Skip dev dependencies.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-install-project --no-dev
 
-COPY alembic.ini /app/
-COPY builders/server/ /app/
+# Copy configuration and scripts (Low frequency change)
+# Moving these above the app code ensures they stay cached even if source code changes.
+# Using --chmod saves an extra layer compared to a separate RUN command.
+COPY --chmod=755 infra/builder/entrypoint.sh ./entrypoint.sh
+COPY alembic.ini ./
 
-COPY infra/builder/entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
+# Copy application source code (High frequency change)
+# This changes almost every build, so it sits at the very bottom.
+COPY builders/server/ ./
 
 ENTRYPOINT ["/app/entrypoint.sh"]


### PR DESCRIPTION
  This PR refactors the infra/builder/Dockerfile to significantly improve build
  times and leverage Docker layer caching more effectively.


  Key Changes:
   * Layer Reordering: Moved frequently changed application source code
     (builders/server/) to the very bottom. Metadata, environment variables, and
     rare configuration files (like alembic.ini and entrypoint.sh) are now
     higher in the stack, ensuring they stay cached even when Python files are
     edited.
   * UV Cache Mounts: Integrated --mount=type=cache,target=/root/.cache/uv into
     the uv sync step. This persists downloaded packages across builds, allowing
     uv to skip redundant downloads when uv.lock is updated.
   * Separated Dependencies: Used uv sync --no-install-project to install
     third-party packages in a dedicated layer before copying the source code.
     This creates a "cache moat" that is only invalidated when dependencies
     actually change.
   * Reduced Layer Count: Consolidated the chmod +x operation into the COPY
     --chmod=755 instruction for the entrypoint script.
   * Performance Tuning:
       * Enabled UV_COMPILE_BYTECODE=1 for faster container startup.
       * Set UV_LINK_MODE=copy to ensure compatibility with Docker cache mounts.
   * Documentation: Added detailed comments to the dependency installation step
     to explain the specific uv flags used.


  Benefits:
   * Faster Development Cycle: Source code changes now only invalidate the final
     layer, resulting in near-instant rebuilds.
   * Efficient Dependency Updates: Adding a single package to pyproject.toml no
     longer requires re-downloading the entire environment.
   * Cleaner Image History: Fewer layers and better organization.