### PR TITLE
refactor: rename ping endpoint to status

### DIFF
--- a/builders/server/api/routes.py
+++ b/builders/server/api/routes.py
@@ -11,8 +11,8 @@ logger = structlog.get_logger()
 router = APIRouter()
 
 
-@router.get("/ping")
-def ping():
+@router.get("/status")
+def status():
     """Health check endpoint."""
     return {"status": "ok"}
 

--- a/builders/server/log_config.py
+++ b/builders/server/log_config.py
@@ -7,11 +7,11 @@ import sys
 import structlog
 
 
-class _PingFilter(logging.Filter):
-    """Drop uvicorn access log entries for the /ping health check endpoint."""
+class _StatusFilter(logging.Filter):
+    """Drop uvicorn access log entries for the /status health check endpoint."""
 
     def filter(self, record: logging.LogRecord) -> bool:
-        return "/ping" not in record.getMessage()
+        return "/status" not in record.getMessage()
 
 
 def setup_logging() -> None:
@@ -55,5 +55,5 @@ def setup_logging() -> None:
     root.addHandler(handler)
     root.setLevel(logging.INFO)
 
-    # suppress /ping from uvicorn access logs
-    logging.getLogger("uvicorn.access").addFilter(_PingFilter())
+    # suppress /status from uvicorn access logs
+    logging.getLogger("uvicorn.access").addFilter(_StatusFilter())

--- a/dev-docs/SPEC-backend.md
+++ b/dev-docs/SPEC-backend.md
@@ -9,7 +9,7 @@ A single Python FastAPI service handles both public API traffic and builds. It l
 ### Public endpoints
 
 ```
-GET /ping
+GET /status
 ```
 
 ```

--- a/dev-docs/SPEC-frontend.md
+++ b/dev-docs/SPEC-frontend.md
@@ -2,7 +2,7 @@
 
 A lightweight internal UI built with Svelte + Vite, using Bun as the package manager.
 
-- **Local dev**: `just frontend-dev` starts the Vite dev server on port 5173. The Vite config proxies `/ping` to `http://localhost:3000` (the Python FastAPI server) to avoid CORS issues.
-- **Docker**: the frontend is built as static files (`bun run build`) and served by nginx on port 80. nginx proxies `/ping` to `http://builder:3000` via Docker internal DNS.
-- Current functionality: a ping button that calls `GET /ping` on the Python backend and displays the status.
+- **Local dev**: `just frontend-dev` starts the Vite dev server on port 5173. The Vite config proxies `/api` to `http://localhost:3000` (the Python FastAPI server) to avoid CORS issues.
+- **Docker**: the frontend is built as static files (`bun run build`) and served by nginx on port 80. nginx proxies `/api` to `http://builder:3000` via Docker internal DNS.
+- Current functionality: a status button that calls `GET /status` on the Python backend and displays the status.
 - The frontend is not containerized — it runs locally via `just frontend-dev` and proxies to the backend container on port 3000.

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -4,7 +4,7 @@
   async function ping() {
     status = '...';
     try {
-      const res = await fetch('/api/v1/ping');
+      const res = await fetch('/api/v1/status');
       status = res.ok ? 'OK' : `Error (${res.status})`;
     } catch {
       status = 'Error (network)';

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:3000/api/v1/ping || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:3000/api/v1/status || exit 1"]
       interval: 2s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
renames the `/ping` health check endpoint to `/status` across the full stack: route definition, log filter, frontend fetch, docker healthcheck, and both spec files.