### PR TITLE
chore: lock down internal service ports

### DIFF
--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -1,0 +1,12 @@
+services:
+  postgres:
+    ports:
+      - "5432:5432"
+
+  builder:
+    ports:
+      - "3000:3000"
+
+  pgweb:
+    ports:
+      - "8080:8080"

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -3,8 +3,6 @@ services:
     build:
       context: ./postgres
     env_file: .env
-    ports:
-      - "5432:5432"
     networks:
       - internal
     healthcheck:
@@ -20,8 +18,6 @@ services:
     env_file: .env
     volumes:
       - ../builders/scripts:/app/scripts
-    ports:
-      - "3000:3000"
     depends_on:
       postgres:
         condition: service_healthy
@@ -38,8 +34,6 @@ services:
     command: ["--readonly", "--bind=0.0.0.0", "--listen=8080"]
     environment:
       PGWEB_DATABASE_URL: postgresql://datastream_readonly:readonly@postgres:5432/datastream?sslmode=disable
-    ports:
-      - "8080:8080"
     depends_on:
       builder:
         condition: service_healthy

--- a/justfile
+++ b/justfile
@@ -1,10 +1,18 @@
-# build all docker images and start containers in detached mode
+# build all docker images and start containers in detached mode (production, no exposed internal ports)
 docker-up:
     docker compose -f infra/docker-compose.yml up --build -d
+
+# build and start containers with all ports exposed for local development
+docker-up-dev:
+    docker compose -f infra/docker-compose.yml -f infra/docker-compose.dev.yml up --build -d
 
 # stop and remove all docker containers
 docker-down:
     docker compose -f infra/docker-compose.yml down
+
+# stop and remove all docker containers (dev overlay)
+docker-down-dev:
+    docker compose -f infra/docker-compose.yml -f infra/docker-compose.dev.yml down
 
 # run ruff linter with autofix and formatter
 fix:
@@ -30,7 +38,7 @@ gen-pyright:
 # postgres is exposed on localhost:5432, so DATABASE_URL uses localhost instead of the docker-internal hostname
 # --reload enables hot reload on file changes
 backend-dev:
-    docker compose -f infra/docker-compose.yml up postgres -d --wait
+    docker compose -f infra/docker-compose.yml -f infra/docker-compose.dev.yml up postgres -d --wait
     DATABASE_URL=postgresql://datastream:changeme@localhost:5432/datastream uv run alembic upgrade head
     python dev-tools/gen_pyrightconfig.py
     SCRIPTS_DIR={{justfile_directory()}}/builders/scripts DATABASE_URL=postgresql://datastream:changeme@localhost:5432/datastream uv run uvicorn main:app --host 0.0.0.0 --port 3000 --app-dir builders/server --reload


### PR DESCRIPTION
Remove host port mappings from postgres, builder, and pgweb in docker-compose.yml so internal services are not directly reachable from the host. Add a `docker-compose.dev.yml` overlay that re-exposes all ports for local development.

**Changes:**
- `infra/docker-compose.yml`: removed `ports` from postgres, builder, and pgweb
- `infra/docker-compose.dev.yml` (new): dev overlay re-exposing postgres:5432, builder:3000, pgweb:8080
- `Justfile`: `backend-dev` uses dev overlay to access postgres; added `docker-up-dev` / `docker-down-dev` recipes

`docker-up` is now production-safe (no exposed internal ports). `docker-up-dev` exposes everything for local dev.