### PR TITLE
feat: add Caddy reverse proxy with automatic HTTPS

### DIFF
--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -1,0 +1,3 @@
+{$DOMAIN} {
+	reverse_proxy builder:3000
+}

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -40,6 +40,28 @@ services:
     networks:
       - internal
 
+  caddy:
+    image: caddy:2
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    environment:
+      - DOMAIN=${DOMAIN:-localhost}
+    depends_on:
+      builder:
+        condition: service_healthy
+    networks:
+      - internal
+
 networks:
   internal:
     driver: bridge
+
+volumes:
+  caddy_data:
+  caddy_config:


### PR DESCRIPTION
Add a Caddy reverse proxy container that terminates TLS and proxies traffic to the builder service. Caddy is the only container with host-bound ports (80/443), providing automatic HTTPS via Let's Encrypt in production.

**Changes:**
- `infra/caddy/Caddyfile` (new): Caddy config using \`DOMAIN\` env var, reverse proxies to builder:3000
- `infra/docker-compose.yml`: added \`caddy\` service with ports 80/443, \`caddy_data\`/\`caddy_config\` volumes
- `infra/.env`: added \`DOMAIN=localhost\` default

**Usage:**
- Production: set \`DOMAIN=datastream.yourdomain.com\` in \`infra/.env\`, Caddy auto-provisions Let's Encrypt cert
- Local Docker: \`DOMAIN=localhost\` uses Caddy's internal CA (self-signed), or \`DOMAIN=:80\` for plain HTTP
- Local dev (\`just backend-dev\`): unaffected, still hits uvicorn on localhost:3000 directly