### PR TITLE
docs: update specs with HTTPS reverse proxy architecture

### DIFF
--- a/dev-docs/SPEC-backend.md
+++ b/dev-docs/SPEC-backend.md
@@ -146,18 +146,46 @@ The server uses `structlog` for structured logging. Configuration lives in `log_
 
 ## Containers
 
-- The service and the Postgres database run in their own Docker containers.
-- Containers communicate over a Docker-managed internal network — no public ports are exposed except where necessary.
+- The service, Postgres database, and Caddy reverse proxy each run in their own Docker containers.
+- Containers communicate over a Docker-managed internal network. Only Caddy exposes host ports (80/443). Internal services (postgres, builder, pgweb) have no host port mappings in production.
 - `builders/scripts/` is mounted as a volume into the builder container at runtime, so scripts can be updated without rebuilding the image.
 
-The `infra/` directory is laid out as follows:
+### Network topology
+
+```
+Internet --> [Caddy :80/:443] --internal--> [builder:3000]
+                                            [postgres:5432]  (no host port)
+                                            [pgweb:8080]     (no host port)
+```
+
+Caddy terminates TLS and reverse proxies to the builder over the Docker bridge network. Internal traffic stays plain HTTP.
+
+### Caddy reverse proxy
+
+Caddy provides automatic HTTPS via Let's Encrypt with minimal configuration. The domain is set via the `DOMAIN` env var in `infra/.env`.
+
+- **Production**: set `DOMAIN=datastream.yourdomain.com`, Caddy auto-provisions a Let's Encrypt certificate
+- **Local Docker**: `DOMAIN=localhost` uses Caddy's internal CA (self-signed), or `DOMAIN=:80` for plain HTTP
+- **Local dev** (`just backend-dev`): unaffected, hits uvicorn on localhost:3000 directly via the dev overlay
+
+### Dev overlay
+
+`infra/docker-compose.dev.yml` re-exposes internal service ports for local development:
+- postgres:5432, builder:3000, pgweb:8080
+
+Use `just docker-up-dev` to start with the overlay, or `just docker-up` for production mode.
+
+### Infra directory layout
 
 ```
 infra/
-  docker-compose.yml
-  .env              # global environment variables (DB credentials, connection strings, etc.)
+  docker-compose.yml      # production compose (only Caddy ports exposed)
+  docker-compose.dev.yml  # dev overlay (re-exposes internal ports)
+  .env                    # environment variables (DB credentials, DOMAIN, etc.)
   builder/
     Dockerfile
+  caddy/
+    Caddyfile             # Caddy reverse proxy config
   postgres/
     Dockerfile
     init.sql


### PR DESCRIPTION
Update SPEC-backend.md to document the new HTTPS reverse proxy architecture.

**Changes:**
- Rewrote Containers section to reflect Caddy as the public-facing entry point
- Added Network topology diagram showing traffic flow
- Documented Caddy reverse proxy config and DOMAIN env var usage (production, local Docker, local dev)
- Documented dev overlay (\`docker-compose.dev.yml\`) and its purpose
- Updated infra directory layout to include \`caddy/\` and \`docker-compose.dev.yml\`