### PR TITLE
docs: rewrite README with accurate setup instructions and curl examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,102 +1,199 @@
 # Datastream
 
-A service to serve and build financial time-series data. See [SPEC.md](dev-docs/SPEC.md) for the full technical spec.
+A service to serve and build financial time-series data. Datastream implements a **builder server** (Python/FastAPI), a **Postgres database**, a **Caddy reverse proxy** with automatic HTTPS, example builder scripts, a **Svelte frontend**, and a **CLI trigger** to kick off builds.
 
-Datastream implements the **builder server** (Python/FastAPI), a **Postgres database**, example builder scripts, and a **CLI trigger** to kick off builds.
+See the full technical specs: [backend](dev-docs/SPEC-backend.md) | [frontend](dev-docs/SPEC-frontend.md)
 
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/) and Docker Compose
-- Python 3.12+ with [uv](https://docs.astral.sh/uv/) and the `requests` package (for the CLI trigger only)
+- Python 3.12+ with [uv](https://docs.astral.sh/uv/)
+- [just](https://github.com/casey/just) (task runner)
+- [Bun](https://bun.sh/) (frontend package manager, only needed for frontend dev)
 
 ## Quick start
 
-### 1. Start the services
-
-From the `infra/` directory, build and start the containers in the background:
+### 1. Start the services (production mode)
 
 ```bash
-cd infra
-docker compose up --build -d
+just docker-up
 ```
 
-This starts:
-- **Postgres** on the internal Docker network (also exposed on `localhost:5432`)
-- **Builder server** on the internal Docker network (also exposed on `localhost:8000`)
-- **Postgres viewer** (pgweb) at [http://localhost:8080](http://localhost:8080)
+This starts four containers on an internal Docker network:
+- **Caddy** reverse proxy on `localhost:80` / `localhost:443` (the only externally exposed ports)
+- **Builder server** (FastAPI on port 3000, internal only)
+- **Postgres** (port 5432, internal only)
+- **pgweb** (read-only DB viewer on port 8080, internal only)
 
-To view logs:
+Caddy terminates TLS and reverse proxies all traffic to the builder server. The domain is controlled by `DOMAIN` in `infra/.env` (defaults to `localhost`).
+
+For **local development** with all internal ports exposed on the host:
 
 ```bash
-docker compose -f infra/docker-compose.yml logs -f
+just docker-up-dev
 ```
+
+This additionally exposes `localhost:3000` (builder), `localhost:5432` (Postgres), and `localhost:8080` (pgweb).
 
 ### 2. Trigger a build
 
-From the project root:
+Build mock OHLC data (root dataset):
 
 ```bash
-uv pip install requests
-python3 trigger.py <dataset_name> <dataset_version> <start> <end>
+curl -X POST "http://localhost:3000/api/v1/build/mock-ohlc/0.1.0?start=2024-01-01&end=2024-01-31"
 ```
 
-**Example — build mock OHLC data (root dataset):**
+Build a derived dataset (automatically builds `mock-ohlc` first if data is missing):
 
 ```bash
-python3 trigger.py mock-ohlc 0.1.0 2024-01-01 2024-01-31
+curl -X POST "http://localhost:3000/api/v1/build/mock-daily-close/0.1.0?start=2024-01-01&end=2024-01-31"
 ```
 
-**Example — build mock daily close (derived dataset, depends on mock-ohlc):**
+Fetch data for a dataset:
 
 ```bash
-python3 trigger.py mock-daily-close 0.1.0 2024-01-01 2024-01-31
+curl "http://localhost:3000/api/v1/data/mock-ohlc/0.1.0?start=2024-01-01&end=2024-01-31"
 ```
 
-The builder server handles dependency resolution automatically — building `mock-daily-close` will first build `mock-ohlc` if data is missing.
+These examples assume dev mode (`just docker-up-dev`) or `just backend-dev` so port 3000 is accessible. In production, use the Caddy endpoint on port 80/443 instead.
 
-### 3. Verify data in Postgres
+### 3. Verify data
+
+Via pgweb (dev mode): open [http://localhost:8080](http://localhost:8080)
+
+Via psql:
 
 ```bash
 docker compose -f infra/docker-compose.yml exec postgres \
   psql -U datastream -d datastream -c "SELECT * FROM datasets LIMIT 10;"
 ```
 
-## Stopping the services
+### 4. Stop the services
 
 ```bash
-cd infra
-docker compose down
+just docker-down      # production
+just docker-down-dev  # dev overlay
 ```
 
 To also remove the database volume (wipes all data):
 
 ```bash
-docker compose down -v
+docker compose -f infra/docker-compose.yml down -v
 ```
+
+## Local development (without full Docker stack)
+
+Run the backend server locally against just the Postgres container:
+
+```bash
+just backend-dev
+```
+
+This starts Postgres via Docker, runs Alembic migrations, and launches uvicorn on `localhost:3000` with hot reload.
+
+Run the frontend dev server (proxies `/api` to `localhost:3000`):
+
+```bash
+just frontend-dev
+```
+
+This starts the Vite dev server on `localhost:5173`.
+
+## API endpoints
+
+All endpoints are prefixed with `/api/v1`.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/status` | Health check |
+| `POST` | `/api/v1/build/{name}/{version}?start=<ts>&end=<ts>` | Trigger a build for the given time range |
+| `GET` | `/api/v1/data/{name}/{version}?start=<ts>&end=<ts>&build-data=<bool>` | Fetch data (optionally building missing data first) |
 
 ## Project structure
 
 ```
 datastream-rs/
-  infra/                      # Docker infrastructure (compose, Dockerfiles, DB init)
+  infra/                        # Docker infrastructure
+    docker-compose.yml            # production (only Caddy ports exposed)
+    docker-compose.dev.yml        # dev overlay (exposes internal ports)
+    .env                          # environment variables
+    builder/
+      Dockerfile
+      entrypoint.sh               # runs migrations, then starts uvicorn
+    caddy/
+      Caddyfile                   # reverse proxy config
+    postgres/
+      Dockerfile
   builders/
-    server/                   # Builder server (FastAPI)
-      main.py                 # entrypoint
-      api/                    # endpoint handlers
-      service/                # build orchestration and dependency resolution
-      db/                     # DB connection and queries
-      runtime/                # config loading, dynamic import, subprocess isolation, validation
-      tests/
-    scripts/                  # builder scripts, volume-mounted into the container
-      <dataset>/<version>/    # one directory per dataset version
+    server/                     # builder server (FastAPI)
+      main.py                     # entrypoint (creates app, mounts routers)
+      api/                        # endpoint handlers
+      service/                    # build orchestration, dependency resolution
+      db/                         # database connection and queries
+        migrations/               # Alembic migration scripts
+      runtime/                    # config loading, subprocess isolation, validation
+      calendars/                  # calendar definitions (everyday, weekday, nyse-daily)
+      tests/                      # unit and integration tests
+    scripts/                    # builder scripts (volume-mounted into container)
+      <dataset>/<version>/
         config.toml
         builder.py
-  trigger.py                  # CLI trigger script
+        requirements.txt          # optional per-builder Python dependencies
+        .env                      # optional env vars (gitignored)
+  frontend/                     # Svelte + Vite frontend
+  trigger.py                    # CLI trigger script (MVP)
+  justfile                      # task runner commands
+  alembic.ini                   # Alembic migration config
+  pyproject.toml                # Python project config (uv)
 ```
+
+## Mock datasets
+
+| Dataset | Version | Type | Calendar | Dependencies |
+|---------|---------|------|----------|-------------|
+| `mock-ohlc` | `0.1.0` | Root | everyday | None |
+| `mock-daily-close` | `0.1.0` | Derived | everyday | `mock-ohlc` |
+| `mock-multi-ohlc` | `0.1.0` | Root | everyday | None |
+| `mock-multi-close` | `0.1.0` | Derived | everyday | `mock-multi-ohlc` |
+| `mock-moving-avg` | `0.1.0` | Derived | everyday | `mock-daily-close` (5d lookback) |
 
 ## Adding a new dataset
 
-1. Create a directory under `builders/scripts/<dataset_name>/<version>/`.
-2. Add a `config.toml` with `name`, `version`, `calendar`, `granularity`, `[schema]`, and optionally `[dependencies]`.
-3. Add a `builder.py` with a `build(dependencies, timestamp)` function that returns a dict matching the schema.
-4. Since scripts are volume-mounted, no container rebuild is needed — just trigger a build.
+1. Create a directory at `builders/scripts/<dataset_name>/<version>/`.
+2. Add a `config.toml` with `name`, `version`, `calendar`, `granularity`, `start-date`, `[schema]`, and optionally `[dependencies]`.
+3. Add a `builder.py` with a `build(dependencies, timestamp)` function that returns a `list[dict]` matching the schema.
+4. Optionally add a `requirements.txt` for external Python dependencies (a per-builder venv is created automatically on server startup).
+5. Optionally add a `.env` file for secrets and set `env-vars = true` in `config.toml`.
+6. Scripts are volume-mounted into the container, so no rebuild is needed.
+
+Example `config.toml`:
+
+```toml
+name = "my-dataset"
+version = "0.1.0"
+builder = "builder.py"
+calendar = "everyday"
+granularity = "1d"
+start-date = "2020-01-01"
+
+[schema]
+ticker = "str"
+price = "float"
+
+[dependencies]
+some-dependency = "0.1.0"
+other-dependency = { version = "0.1.0", lookback = "5d" }
+```
+
+Example `builder.py`:
+
+```python
+from datetime import datetime
+from typing import Any
+
+
+def build(
+    dependencies: dict[str, dict[datetime, list[dict]]], timestamp: datetime
+) -> list[dict[str, Any]]:
+    return [{"ticker": "AAPL", "price": 123.45}]
+```


### PR DESCRIPTION
## Summary
- Complete rewrite of README.md to accurately reflect the current state of the codebase
- Fixed incorrect port number (was 8000, actually 3000), broken spec link, and missing `/api/v1` prefix
- Added Caddy reverse proxy, frontend, `just` commands, API endpoints table, dataset inventory, and local dev workflow
- Replaced `trigger.py` examples with `curl` commands