### PR TITLE
refactor: make get_conn a context manager

### DIFF
--- a/builders/server/db/connection.py
+++ b/builders/server/db/connection.py
@@ -1,4 +1,5 @@
 import os
+from contextlib import contextmanager
 
 import psycopg2
 import structlog
@@ -8,10 +9,11 @@ logger = structlog.get_logger()
 _pool = None
 
 
+@contextmanager
 def get_conn():
     """Get a database connection (simple single-connection approach)."""
     global _pool
     if _pool is None or _pool.closed:
         logger.debug("creating new database connection")
         _pool = psycopg2.connect(os.environ["DATABASE_URL"])
-    return _pool
+    yield _pool

--- a/builders/server/db/datasets.py
+++ b/builders/server/db/datasets.py
@@ -23,8 +23,7 @@ def get_existing_timestamps(
         dataset=dataset_name,
         version=str(dataset_version),
     )
-    conn = get_conn()
-    with conn.cursor() as cur:
+    with get_conn() as conn, conn.cursor() as cur:
         cur.execute(
             """
             SELECT DISTINCT timestamp FROM datasets
@@ -53,26 +52,26 @@ def insert_rows(
         return
 
     dataset_version_str = str(dataset_version)
-    conn = get_conn()
-    with conn.cursor() as cur:
-        execute_values(
-            cur,
-            """
-            INSERT INTO datasets (dataset_name, dataset_version, timestamp, data)
-            VALUES %s
-            """,
-            [
-                (
-                    dataset_name,
-                    dataset_version_str,
-                    ts,
-                    psycopg2.extras.Json(data),
-                )
-                for ts, data_list in rows
-                for data in data_list
-            ],
-        )
-    conn.commit()
+    with get_conn() as conn:  # noqa: SIM117 -- commit must be after cursor closes
+        with conn.cursor() as cur:
+            execute_values(
+                cur,
+                """
+                INSERT INTO datasets (dataset_name, dataset_version, timestamp, data)
+                VALUES %s
+                """,
+                [
+                    (
+                        dataset_name,
+                        dataset_version_str,
+                        ts,
+                        psycopg2.extras.Json(data),
+                    )
+                    for ts, data_list in rows
+                    for data in data_list
+                ],
+            )
+        conn.commit()
 
     total = sum(len(data_list) for _, data_list in rows)
     logger.info(
@@ -95,8 +94,7 @@ def get_rows_range(
         dataset=dataset_name,
         version=str(dataset_version),
     )
-    conn = get_conn()
-    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+    with get_conn() as conn, conn.cursor(cursor_factory=RealDictCursor) as cur:
         cur.execute(
             """
             SELECT timestamp, data FROM datasets
@@ -129,8 +127,7 @@ def get_rows_timestamps(
         dataset=dataset_name,
         version=dataset_version_str,
     )
-    conn = get_conn()
-    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+    with get_conn() as conn, conn.cursor(cursor_factory=RealDictCursor) as cur:
         cur.execute(
             """
             SELECT timestamp, data FROM datasets

--- a/builders/server/tests/db/test_connection.py
+++ b/builders/server/tests/db/test_connection.py
@@ -23,9 +23,9 @@ def test_get_conn_reads_database_url(
     mock_conn.closed = False
     mock_connect.return_value = mock_conn
 
-    conn = connection.get_conn()
-    mock_connect.assert_called_once_with("postgresql://test:test@localhost/test")
-    assert conn is mock_conn
+    with connection.get_conn() as conn:
+        mock_connect.assert_called_once_with("postgresql://test:test@localhost/test")
+        assert conn is mock_conn
 
 
 @patch("db.connection.psycopg2.connect")
@@ -38,8 +38,10 @@ def test_get_conn_reuses_connection(
     mock_conn.closed = False
     mock_connect.return_value = mock_conn
 
-    connection.get_conn()
-    connection.get_conn()
+    with connection.get_conn():
+        pass
+    with connection.get_conn():
+        pass
     mock_connect.assert_called_once()
 
 
@@ -55,9 +57,10 @@ def test_get_conn_reconnects_when_closed(
     mock_conn2.closed = False
     mock_connect.side_effect = [mock_conn1, mock_conn2]
 
-    connection.get_conn()
-    # Simulate closed connection
+    with connection.get_conn():
+        pass
+    # simulate closed connection
     mock_conn1.closed = True
-    conn2 = connection.get_conn()
-    assert mock_connect.call_count == 2
-    assert conn2 is mock_conn2
+    with connection.get_conn() as conn2:
+        assert mock_connect.call_count == 2
+        assert conn2 is mock_conn2

--- a/builders/server/tests/db/test_datasets.py
+++ b/builders/server/tests/db/test_datasets.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
@@ -5,6 +6,16 @@ from db import datasets
 from utils.semver import SemVer
 
 V010 = SemVer.parse("0.1.0")
+
+
+def _mock_get_conn(mock_conn):
+    """Create a context-manager mock for get_conn that yields mock_conn."""
+
+    @contextmanager
+    def _get_conn():
+        yield mock_conn
+
+    return _get_conn
 
 
 @patch("db.datasets.get_conn")
@@ -18,7 +29,7 @@ def test_get_existing_timestamps(mock_get_conn: MagicMock) -> None:
     mock_conn = MagicMock()
     mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
     mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
-    mock_get_conn.return_value = mock_conn
+    mock_get_conn.side_effect = _mock_get_conn(mock_conn)
 
     result = datasets.get_existing_timestamps(
         "ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 31)
@@ -40,7 +51,7 @@ def test_get_existing_timestamps_empty(mock_get_conn: MagicMock) -> None:
     mock_conn = MagicMock()
     mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
     mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
-    mock_get_conn.return_value = mock_conn
+    mock_get_conn.side_effect = _mock_get_conn(mock_conn)
 
     result = datasets.get_existing_timestamps(
         "ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 31)
@@ -65,7 +76,7 @@ def test_insert_rows_calls_execute_values(
     mock_conn = MagicMock()
     mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
     mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
-    mock_get_conn.return_value = mock_conn
+    mock_get_conn.side_effect = _mock_get_conn(mock_conn)
 
     rows: list[tuple[datetime, list[dict]]] = [
         (datetime(2024, 1, 1), [{"ticker": "AAPL"}, {"ticker": "MSFT"}])
@@ -104,7 +115,7 @@ def test_get_rows_timestamps_returns_list_per_timestamp(
     mock_conn = MagicMock()
     mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
     mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
-    mock_get_conn.return_value = mock_conn
+    mock_get_conn.side_effect = _mock_get_conn(mock_conn)
 
     result = datasets.get_rows_timestamps("ds", V010, [ts])
     assert ts in result
@@ -127,7 +138,7 @@ def test_get_rows_range_returns_dict_by_timestamp(mock_get_conn: MagicMock) -> N
     mock_conn = MagicMock()
     mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
     mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
-    mock_get_conn.return_value = mock_conn
+    mock_get_conn.side_effect = _mock_get_conn(mock_conn)
 
     result = datasets.get_rows_range("ds", V010, ts1, ts2)
     assert len(result) == 2

--- a/builders/server/tests/integration/conftest.py
+++ b/builders/server/tests/integration/conftest.py
@@ -73,9 +73,17 @@ def clean_db(db_conn):
 @pytest.fixture(autouse=True)
 def patch_db_conn(db_conn, monkeypatch):
     """Redirect all production DB calls to the test database."""
-    import db.connection
+    from contextlib import contextmanager
 
-    monkeypatch.setattr(db.connection, "_pool", db_conn)
+    import db.connection
+    import db.datasets
+
+    @contextmanager
+    def _test_conn():
+        yield db_conn
+
+    monkeypatch.setattr(db.connection, "get_conn", _test_conn)
+    monkeypatch.setattr(db.datasets, "get_conn", _test_conn)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Pure refactor to prepare all callsites for connection pooling. No behavior change.

- Wrap `get_conn()` with `@contextmanager` so it yields the connection
- Update all 4 functions in `datasets.py` to use `with get_conn() as conn:`
- Update unit tests and integration test fixtures for context manager usage

Part 1 of 3 in the psycopg2 -> psycopg v3 connection pool migration.