### PR TITLE
feat: add connection pooling with psycopg2

### DIFF
--- a/builders/server/db/connection.py
+++ b/builders/server/db/connection.py
@@ -1,19 +1,36 @@
-import os
 from contextlib import contextmanager
 
-import psycopg2
 import structlog
+from psycopg2.pool import ThreadedConnectionPool
 
 logger = structlog.get_logger()
 
-_pool = None
+_pool: ThreadedConnectionPool | None = None
+
+
+def open_pool(dsn: str, minconn: int = 2, maxconn: int = 10) -> None:
+    """Initialize the connection pool."""
+    global _pool
+    logger.info("opening connection pool", minconn=minconn, maxconn=maxconn)
+    _pool = ThreadedConnectionPool(minconn, maxconn, dsn)
+
+
+def close_pool() -> None:
+    """Close the connection pool and release all connections."""
+    global _pool
+    if _pool is not None:
+        logger.info("closing connection pool")
+        _pool.closeall()
+        _pool = None
 
 
 @contextmanager
 def get_conn():
-    """Get a database connection (simple single-connection approach)."""
-    global _pool
-    if _pool is None or _pool.closed:
-        logger.debug("creating new database connection")
-        _pool = psycopg2.connect(os.environ["DATABASE_URL"])
-    yield _pool
+    """Check out a connection from the pool, return it when done."""
+    if _pool is None:
+        raise RuntimeError("connection pool not initialized, call open_pool() first")
+    conn = _pool.getconn()
+    try:
+        yield conn
+    finally:
+        _pool.putconn(conn)

--- a/builders/server/main.py
+++ b/builders/server/main.py
@@ -1,9 +1,11 @@
+import os
 import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 import structlog
 from api.routes import router
+from db.connection import close_pool, open_pool
 from fastapi import FastAPI, Request, Response
 from log_config import setup_logging as _setup_logging
 from runtime.config import SCRIPTS_DIR
@@ -14,9 +16,11 @@ _setup_logging()
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-    """Startup: create per-builder venvs."""
+    """Startup: create per-builder venvs and open DB pool. Shutdown: close pool."""
     setup_builder_venvs(SCRIPTS_DIR)
+    open_pool(os.environ["DATABASE_URL"])
     yield
+    close_pool()
 
 
 app = FastAPI(lifespan=lifespan)

--- a/builders/server/tests/db/test_connection.py
+++ b/builders/server/tests/db/test_connection.py
@@ -13,54 +13,72 @@ def reset_pool() -> Generator[None, None, None]:
     connection._pool = None
 
 
-@patch("db.connection.psycopg2.connect")
-def test_get_conn_reads_database_url(
-    mock_connect: MagicMock, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Connects using DATABASE_URL env var."""
-    monkeypatch.setenv("DATABASE_URL", "postgresql://test:test@localhost/test")
+@patch("db.connection.ThreadedConnectionPool")
+def test_open_pool_creates_pool(mock_pool_cls: MagicMock) -> None:
+    """open_pool initializes ThreadedConnectionPool."""
+    connection.open_pool("postgresql://test@localhost/test", minconn=1, maxconn=5)
+    mock_pool_cls.assert_called_once_with(1, 5, "postgresql://test@localhost/test")
+    assert connection._pool is mock_pool_cls.return_value
+
+
+@patch("db.connection.ThreadedConnectionPool")
+def test_close_pool_closes_and_clears(mock_pool_cls: MagicMock) -> None:
+    """close_pool calls closeall and sets _pool to None."""
+    connection.open_pool("postgresql://test@localhost/test")
+    mock_pool = mock_pool_cls.return_value
+
+    connection.close_pool()
+    mock_pool.closeall.assert_called_once()
+    assert connection._pool is None
+
+
+def test_close_pool_noop_when_not_initialized() -> None:
+    """close_pool does nothing if pool was never opened."""
+    connection.close_pool()
+    assert connection._pool is None
+
+
+def test_get_conn_raises_without_pool() -> None:
+    """get_conn raises RuntimeError if pool not initialized."""
+    with (
+        pytest.raises(RuntimeError, match="connection pool not initialized"),
+        connection.get_conn(),
+    ):
+        pass
+
+
+@patch("db.connection.ThreadedConnectionPool")
+def test_get_conn_checks_out_and_returns(mock_pool_cls: MagicMock) -> None:
+    """get_conn gets a connection from pool and puts it back."""
+    mock_pool = mock_pool_cls.return_value
     mock_conn = MagicMock()
-    mock_conn.closed = False
-    mock_connect.return_value = mock_conn
+    mock_pool.getconn.return_value = mock_conn
+
+    connection.open_pool("postgresql://test@localhost/test")
 
     with connection.get_conn() as conn:
-        mock_connect.assert_called_once_with("postgresql://test:test@localhost/test")
         assert conn is mock_conn
+        mock_pool.getconn.assert_called_once()
+        # not returned yet
+        mock_pool.putconn.assert_not_called()
+
+    # returned after exiting context
+    mock_pool.putconn.assert_called_once_with(mock_conn)
 
 
-@patch("db.connection.psycopg2.connect")
-def test_get_conn_reuses_connection(
-    mock_connect: MagicMock, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Second call reuses existing connection."""
-    monkeypatch.setenv("DATABASE_URL", "postgresql://test:test@localhost/test")
+@patch("db.connection.ThreadedConnectionPool")
+def test_get_conn_returns_on_exception(mock_pool_cls: MagicMock) -> None:
+    """Connection is returned to pool even if an exception occurs."""
+    mock_pool = mock_pool_cls.return_value
     mock_conn = MagicMock()
-    mock_conn.closed = False
-    mock_connect.return_value = mock_conn
+    mock_pool.getconn.return_value = mock_conn
 
-    with connection.get_conn():
-        pass
-    with connection.get_conn():
-        pass
-    mock_connect.assert_called_once()
+    connection.open_pool("postgresql://test@localhost/test")
 
+    with (
+        pytest.raises(ValueError, match="test error"),
+        connection.get_conn(),
+    ):
+        raise ValueError("test error")
 
-@patch("db.connection.psycopg2.connect")
-def test_get_conn_reconnects_when_closed(
-    mock_connect: MagicMock, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Reconnects if connection is closed."""
-    monkeypatch.setenv("DATABASE_URL", "postgresql://test:test@localhost/test")
-    mock_conn1 = MagicMock()
-    mock_conn1.closed = False
-    mock_conn2 = MagicMock()
-    mock_conn2.closed = False
-    mock_connect.side_effect = [mock_conn1, mock_conn2]
-
-    with connection.get_conn():
-        pass
-    # simulate closed connection
-    mock_conn1.closed = True
-    with connection.get_conn() as conn2:
-        assert mock_connect.call_count == 2
-        assert conn2 is mock_conn2
+    mock_pool.putconn.assert_called_once_with(mock_conn)


### PR DESCRIPTION
Replace the single cached connection with `psycopg2.pool.ThreadedConnectionPool` for proper concurrent request handling.

- Add `open_pool()` / `close_pool()` lifecycle functions in `db/connection.py`
- `get_conn()` now checks out from pool and returns on context exit
- Wire pool startup/shutdown into FastAPI lifespan in `main.py`
- Rewrite connection tests for pool-based API

Part 2 of 3 in the psycopg2 -> psycopg v3 connection pool migration.