### PR TITLE
chore: allow /root paths in no-absolute-paths pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
       - id: no-absolute-paths
         name: check for absolute paths
         language: pygrep
-        entry: '/(?:Users|home|root)/[a-zA-Z0-9_.-]+|[A-Z]:\\[A-Za-z]'
+        entry: '/(?:Users|home)/[a-zA-Z0-9_.-]+|[A-Z]:\\[A-Za-z]'
 
       - id: pytest
         name: pytest


### PR DESCRIPTION
removes `root` from the alternation in the `no-absolute-paths` pre-commit hook regex, so paths like `/root/.cache/uv` (used in the builder Dockerfile) are allowed without needing a file exclusion.