### PR TITLE
feat: add advisory lock helpers to db layer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
 
       - id: pytest
         name: pytest
-        entry: bash -c 'uv run pytest'
+        entry: bash -c 'uv run pytest --ignore=builders/server/tests/integration'
         language: system
         files: ^builders/server/
         pass_filenames: false

--- a/builders/server/db/connection.py
+++ b/builders/server/db/connection.py
@@ -27,3 +27,10 @@ def get_conn():
     if _pool is None:
         raise RuntimeError("connection pool not initialized, call open_pool() first")
     return _pool.connection()
+
+
+def get_pool() -> ConnectionPool:
+    """Return the connection pool, raising if not initialized."""
+    if _pool is None:
+        raise RuntimeError("connection pool not initialized, call open_pool() first")
+    return _pool

--- a/builders/server/db/locks.py
+++ b/builders/server/db/locks.py
@@ -1,0 +1,64 @@
+import zlib
+from contextlib import contextmanager
+
+import psycopg
+import structlog
+
+from db.connection import get_pool
+
+logger = structlog.get_logger()
+
+# namespace for build advisory locks, arbitrary fixed value
+_LOCK_NAMESPACE = 1
+
+
+def _lock_key(dataset_name: str, dataset_version: str) -> int:
+    """Compute a stable int32 key from dataset name and version."""
+    raw = zlib.crc32(f"{dataset_name}/{dataset_version}".encode())
+    # pg_advisory_lock takes int4, crc32 returns unsigned 32-bit;
+    # convert to signed range to avoid overflow
+    if raw >= 0x80000000:
+        raw -= 0x100000000
+    return raw
+
+
+@contextmanager
+def build_lock(dataset_name: str, dataset_version: str):
+    """Context manager that holds a session-level advisory lock for a dataset build.
+
+    Opens a dedicated connection (not from the pool) so the lock connection
+    never interferes with pool-managed query connections.
+    """
+    key = _lock_key(dataset_name, dataset_version)
+
+    # get conninfo from pool to open a dedicated connection
+    pool = get_pool()
+    conn = psycopg.connect(pool.conninfo, autocommit=True)
+    try:
+        conn.execute("SELECT pg_advisory_lock(%s, %s)", (_LOCK_NAMESPACE, key))
+        logger.debug(
+            "advisory lock acquired",
+            dataset=dataset_name,
+            version=dataset_version,
+            key=key,
+        )
+        yield conn
+    finally:
+        try:
+            conn.execute(
+                "SELECT pg_advisory_unlock(%s, %s)",
+                (_LOCK_NAMESPACE, key),
+            )
+            logger.debug(
+                "advisory lock released",
+                dataset=dataset_name,
+                version=dataset_version,
+                key=key,
+            )
+        except Exception:
+            logger.warning(
+                "failed to release advisory lock",
+                dataset=dataset_name,
+                version=dataset_version,
+            )
+        conn.close()

--- a/builders/server/tests/integration/concurrency/conftest.py
+++ b/builders/server/tests/integration/concurrency/conftest.py
@@ -1,0 +1,127 @@
+from pathlib import Path
+
+import psycopg
+import pytest
+from testcontainers.postgres import PostgresContainer
+
+# DDL matching the main integration conftest
+CREATE_TABLE = """
+    CREATE TABLE datasets (
+        id BIGSERIAL PRIMARY KEY,
+        created_at TIMESTAMP(6) NOT NULL DEFAULT now(),
+        dataset_name TEXT NOT NULL,
+        dataset_version TEXT NOT NULL,
+        timestamp TIMESTAMP(6) NOT NULL,
+        data JSONB NOT NULL
+    )
+"""
+CREATE_INDEX = """
+    CREATE INDEX idx_datasets_name_version_ts
+    ON datasets (dataset_name, dataset_version, timestamp)
+"""
+
+# real builder scripts
+REAL_SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent.parent / "scripts"
+
+
+def _conninfo(container: PostgresContainer) -> str:
+    """Build a libpq conninfo string from the testcontainer."""
+    host = container.get_container_host_ip()
+    port = container.get_exposed_port(5432)
+    return (
+        f"host={host} port={port} "
+        f"dbname={container.dbname} "
+        f"user={container.username} "
+        f"password={container.password}"
+    )
+
+
+@pytest.fixture(scope="session")
+def postgres_container():
+    """Start a fresh postgres container for the concurrency test session."""
+    with PostgresContainer("postgres:16") as pg:
+        conn = psycopg.connect(_conninfo(pg), autocommit=True)
+        with conn.cursor() as cur:
+            cur.execute(CREATE_TABLE)
+            cur.execute(CREATE_INDEX)
+        conn.close()
+        yield pg
+
+
+@pytest.fixture(scope="session")
+def conninfo(postgres_container):
+    """Connection info string for the test container."""
+    return _conninfo(postgres_container)
+
+
+@pytest.fixture(autouse=True)
+def patch_build_lock():
+    """Override parent conftest no-op; use real advisory locks."""
+    yield
+
+
+@pytest.fixture(autouse=True)
+def patch_db_conn():
+    """Override parent conftest; use real pool connections."""
+    yield
+
+
+@pytest.fixture(autouse=True)
+def pool_lifecycle(conninfo):
+    """Open a real connection pool for each test, close after."""
+    import db.connection
+
+    db.connection.open_pool(conninfo, min_size=4, max_size=10)
+    yield
+    db.connection.close_pool()
+
+
+@pytest.fixture(autouse=True)
+def clean_db(conninfo):
+    """Truncate datasets table before each test."""
+    conn = psycopg.connect(conninfo, autocommit=True)
+    conn.execute("TRUNCATE datasets RESTART IDENTITY")
+    conn.close()
+
+
+@pytest.fixture(autouse=True)
+def real_scripts_dir(monkeypatch):
+    """Point SCRIPTS_DIR to real builders/scripts/."""
+    from runtime import config, loader
+
+    monkeypatch.setattr(config, "SCRIPTS_DIR", REAL_SCRIPTS_DIR)
+    monkeypatch.setattr(loader, "SCRIPTS_DIR", REAL_SCRIPTS_DIR)
+
+
+@pytest.fixture()
+def client():
+    """FastAPI test client (no lifespan)."""
+    from fastapi.testclient import TestClient
+    from main import app
+
+    return TestClient(app)
+
+
+@pytest.fixture()
+def write_temp_builder(tmp_path, monkeypatch):
+    """Factory for creating temp builder scripts + configs.
+
+    Monkeypatches SCRIPTS_DIR to the temp dir. Returns a callable:
+        (dataset_name, version, config_toml, builder_py) -> (name, version)
+    """
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+
+    from runtime import config, loader
+
+    monkeypatch.setattr(config, "SCRIPTS_DIR", scripts_dir)
+    monkeypatch.setattr(loader, "SCRIPTS_DIR", scripts_dir)
+
+    def _write(dataset_name, version, config_toml, builder_py):
+        d = scripts_dir / dataset_name / version
+        d.mkdir(parents=True)
+        (d / "config.toml").write_text(config_toml)
+        (d / "builder.py").write_text(builder_py)
+        return dataset_name, version
+
+    return _write

--- a/builders/server/tests/integration/concurrency/test_build_races.py
+++ b/builders/server/tests/integration/concurrency/test_build_races.py
@@ -1,0 +1,271 @@
+"""Concurrency race detection tests.
+
+These tests use a real connection pool and advisory locks to verify
+that concurrent build requests do not produce duplicate rows.
+"""
+
+import textwrap
+from concurrent.futures import ThreadPoolExecutor
+
+import psycopg
+import pytest
+
+# slow builder script: sleeps to widen the race window
+SLOW_BUILDER_PY = textwrap.dedent("""\
+    import time
+    from datetime import datetime
+    from typing import Any
+
+    def build(
+        dependencies: dict[str, dict[datetime, list[dict]]],
+        timestamp: datetime,
+    ) -> list[dict[str, Any]]:
+        time.sleep(0.5)
+        return [{"ticker": "TEST", "price": 100}]
+""")
+
+SLOW_BUILDER_CONFIG = textwrap.dedent("""\
+    name = "slow-builder"
+    version = "0.1.0"
+    builder = "builder.py"
+    calendar = "everyday"
+    granularity = "1d"
+    start-date = "2024-01-01"
+
+    [schema]
+    ticker = "str"
+    price = "int"
+""")
+
+# slow root for dependency chain tests
+SLOW_ROOT_CONFIG = textwrap.dedent("""\
+    name = "slow-root"
+    version = "0.1.0"
+    builder = "builder.py"
+    calendar = "everyday"
+    granularity = "1d"
+    start-date = "2024-01-01"
+
+    [schema]
+    ticker = "str"
+    price = "int"
+""")
+
+CHILD_BUILDER_PY = textwrap.dedent("""\
+    from datetime import datetime
+    from typing import Any
+
+    def build(
+        dependencies: dict[str, dict[datetime, list[dict]]],
+        timestamp: datetime,
+    ) -> list[dict[str, Any]]:
+        root_data = dependencies["slow-root"]
+        rows = root_data[timestamp]
+        return [{
+            "ticker": rows[0]["ticker"],
+            "derived": rows[0]["price"] * 2,
+        }]
+""")
+
+CHILD_CONFIG = textwrap.dedent("""\
+    name = "child-of-slow"
+    version = "0.1.0"
+    builder = "builder.py"
+    calendar = "everyday"
+    granularity = "1d"
+    start-date = "2024-01-01"
+
+    [schema]
+    ticker = "str"
+    derived = "int"
+
+    [dependencies]
+    slow-root = "0.1.0"
+""")
+
+
+def _count_duplicates(
+    conninfo: str,
+    dataset_name: str,
+    version: str,
+    expected_per_ts: int,
+) -> list:
+    """Return timestamps with more rows than expected."""
+    conn = psycopg.connect(conninfo, autocommit=True)
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT timestamp, count(*) FROM datasets
+            WHERE dataset_name = %s
+              AND dataset_version = %s
+            GROUP BY timestamp HAVING count(*) > %s
+            """,
+            (dataset_name, version, expected_per_ts),
+        )
+        dupes = cur.fetchall()
+    conn.close()
+    return dupes
+
+
+def _count_rows(conninfo: str, dataset_name: str, version: str) -> int:
+    """Return total row count for a dataset."""
+    conn = psycopg.connect(conninfo, autocommit=True)
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT count(*) FROM datasets "
+            "WHERE dataset_name = %s "
+            "AND dataset_version = %s",
+            (dataset_name, version),
+        )
+        count = cur.fetchone()[0]
+    conn.close()
+    return count
+
+
+@pytest.mark.integration
+def test_concurrent_same_range_no_duplicates(client, write_temp_builder, conninfo):
+    """3 threads build same (dataset, range). No duplicates."""
+    write_temp_builder(
+        "slow-builder",
+        "0.1.0",
+        SLOW_BUILDER_CONFIG,
+        SLOW_BUILDER_PY,
+    )
+
+    def do_build(_):
+        return client.post(
+            "/api/v1/build/slow-builder/0.1.0",
+            params={
+                "start": "2024-01-01",
+                "end": "2024-01-03",
+            },
+        )
+
+    with ThreadPoolExecutor(max_workers=3) as pool:
+        results = list(pool.map(do_build, range(3)))
+
+    # all requests should succeed
+    for r in results:
+        assert r.status_code == 200, r.text
+
+    # exactly 3 rows (1 per day, 3 days), no duplicates
+    dupes = _count_duplicates(conninfo, "slow-builder", "0.1.0", 1)
+    assert dupes == [], f"duplicate timestamps: {dupes}"
+
+    total = _count_rows(conninfo, "slow-builder", "0.1.0")
+    assert total == 3
+
+
+@pytest.mark.integration
+def test_concurrent_overlapping_ranges_no_duplicates(
+    client, write_temp_builder, conninfo
+):
+    """2 threads build overlapping ranges. No duplicates."""
+    write_temp_builder(
+        "slow-builder",
+        "0.1.0",
+        SLOW_BUILDER_CONFIG,
+        SLOW_BUILDER_PY,
+    )
+
+    def build_range_a(_):
+        return client.post(
+            "/api/v1/build/slow-builder/0.1.0",
+            params={
+                "start": "2024-01-01",
+                "end": "2024-01-03",
+            },
+        )
+
+    def build_range_b(_):
+        return client.post(
+            "/api/v1/build/slow-builder/0.1.0",
+            params={
+                "start": "2024-01-02",
+                "end": "2024-01-04",
+            },
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        fut_a = pool.submit(build_range_a, None)
+        fut_b = pool.submit(build_range_b, None)
+        resp_a = fut_a.result()
+        resp_b = fut_b.result()
+
+    assert resp_a.status_code == 200, resp_a.text
+    assert resp_b.status_code == 200, resp_b.text
+
+    dupes = _count_duplicates(conninfo, "slow-builder", "0.1.0", 1)
+    assert dupes == [], f"duplicate timestamps: {dupes}"
+
+    # should have exactly 4 rows (Jan 1-4)
+    total = _count_rows(conninfo, "slow-builder", "0.1.0")
+    assert total == 4
+
+
+@pytest.mark.integration
+def test_concurrent_dependency_chain_no_duplicates(
+    client, write_temp_builder, conninfo
+):
+    """2 threads build child depending on slow root. No dupes."""
+    write_temp_builder(
+        "slow-root",
+        "0.1.0",
+        SLOW_ROOT_CONFIG,
+        SLOW_BUILDER_PY,
+    )
+    write_temp_builder(
+        "child-of-slow",
+        "0.1.0",
+        CHILD_CONFIG,
+        CHILD_BUILDER_PY,
+    )
+
+    def do_build(_):
+        return client.post(
+            "/api/v1/build/child-of-slow/0.1.0",
+            params={
+                "start": "2024-01-01",
+                "end": "2024-01-02",
+            },
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(do_build, range(2)))
+
+    for r in results:
+        assert r.status_code == 200, r.text
+
+    # no duplicates on root
+    dupes = _count_duplicates(conninfo, "slow-root", "0.1.0", 1)
+    assert dupes == [], f"duplicate root timestamps: {dupes}"
+
+    # no duplicates on child
+    dupes = _count_duplicates(conninfo, "child-of-slow", "0.1.0", 1)
+    assert dupes == [], f"duplicate child timestamps: {dupes}"
+
+
+@pytest.mark.integration
+def test_concurrent_builds_all_return_200(client, write_temp_builder):
+    """All concurrent requests succeed (no 500s)."""
+    write_temp_builder(
+        "slow-builder",
+        "0.1.0",
+        SLOW_BUILDER_CONFIG,
+        SLOW_BUILDER_PY,
+    )
+
+    def do_build(_):
+        return client.post(
+            "/api/v1/build/slow-builder/0.1.0",
+            params={
+                "start": "2024-01-01",
+                "end": "2024-01-02",
+            },
+        )
+
+    with ThreadPoolExecutor(max_workers=5) as pool:
+        results = list(pool.map(do_build, range(5)))
+
+    statuses = [r.status_code for r in results]
+    assert all(s == 200 for s in statuses), f"unexpected status codes: {statuses}"

--- a/dev-docs/concurrency-analysis.md
+++ b/dev-docs/concurrency-analysis.md
@@ -1,0 +1,152 @@
+# Concurrency analysis: concurrent build requests
+
+## The problem
+
+The current build flow has a check-then-act race condition. Two concurrent requests for the same (dataset_name, dataset_version) with overlapping timestamp ranges can both see timestamps as missing and both insert data, producing duplicate rows.
+
+```
+Request A: get_existing_timestamps() -> sees T as missing
+Request B: get_existing_timestamps() -> sees T as missing
+Request A: builds T, inserts
+Request B: builds T, inserts  (DUPLICATE)
+```
+
+Beyond duplicates, this also wastes compute (building the same data twice in subprocesses).
+
+## Current architecture context
+
+- single FastAPI process, async endpoints, builders run in sync subprocesses
+- psycopg v3 connection pool (min=2, max=10)
+- each DB function (`get_existing_timestamps`, `insert_rows`, etc.) checks out its own connection from the pool
+- recursive dependency builds each invoke `_build_recursive()` independently
+- no existing locks or concurrency primitives anywhere in the codebase
+- the (dataset_name, dataset_version, timestamp) triple is non-unique by design (multi-row datasets like mock-multi-ohlc produce multiple rows per timestamp)
+
+## Approaches considered
+
+### 1. Coarse PostgreSQL advisory lock on (dataset_name, dataset_version)
+
+Lock the entire dataset for the duration of a build using `pg_advisory_lock(hash)` where the hash is derived from (name, version).
+
+Before `_build_recursive()` does the check-build-insert, acquire an advisory lock on a dedicated pool connection. Any other request for the same dataset blocks until the first finishes. Release explicitly in a `finally` block.
+
+**Pros:**
+- simple to implement (~15 lines, no schema changes)
+- eliminates both duplicates and wasted compute
+- advisory locks auto-release if the connection/session drops (crash-safe)
+- works well at current scale (single service, low concurrency)
+- if we ever move to multiple service instances, advisory locks still work (same DB)
+- easy to reason about correctness: one build at a time per dataset
+
+**Cons:**
+- serializes ALL builds for a dataset, even non-overlapping time ranges (e.g. Jan and July block each other)
+- builds can be slow (subprocess execution) -- the second caller blocks for the full duration
+- holds one pool connection per in-flight dataset build just for the lock (idle during subprocess execution)
+- coarse granularity wastes potential parallelism
+
+### 2. Fine-grained advisory lock on (dataset_name, dataset_version, timestamp)
+
+Lock individual timestamps rather than entire datasets. For each missing timestamp, acquire `pg_advisory_lock(hash(name, version, timestamp))` before building it.
+
+**Pros:**
+- maximizes parallelism -- non-overlapping ranges don't block each other
+- no schema changes needed
+- more fair under concurrent load
+
+**Cons:**
+- many more lock acquisitions (one per timestamp per dependency level)
+- lock management complexity: must acquire/release many locks, handle partial failures
+- risk of deadlocks if two requests build overlapping ranges in different orders (mitigated by always sorting timestamps, but adds a constraint)
+- recursive builds compound the lock count
+- harder to reason about correctness
+- per-timestamp overhead may be significant for large ranges (e.g. 252 NYSE trading days in a year = 252 lock round-trips)
+
+### 3. Database build status table (optimistic claim approach)
+
+Add a `build_status` table that tracks which (dataset, version, timestamp) combinations are currently being built or have been built. Use `INSERT ... ON CONFLICT DO NOTHING` with a unique constraint to "claim" timestamps.
+
+```sql
+CREATE TABLE build_status (
+    dataset_name TEXT NOT NULL,
+    dataset_version TEXT NOT NULL,
+    timestamp TIMESTAMP(6) NOT NULL,
+    status TEXT NOT NULL DEFAULT 'building',  -- 'building' | 'complete' | 'failed'
+    claimed_at TIMESTAMP(6) NOT NULL DEFAULT now(),
+    UNIQUE (dataset_name, dataset_version, timestamp)
+);
+```
+
+**Pros:**
+- fine-grained without advisory lock overhead
+- naturally idempotent -- retries work cleanly
+- provides observability: query what's currently being built
+- works across multiple service instances
+- can be extended to track build history, timing, etc.
+
+**Cons:**
+- requires a schema migration (new table)
+- must handle cleanup of stale 'building' rows from crashed processes (needs a TTL or reaper)
+- two tables to keep in sync (`build_status` and `datasets`)
+- adds latency: extra DB round-trips per timestamp
+- more moving parts (new table, cleanup logic, status transitions)
+- the unique constraint on (name, version, timestamp) only works because status is per-timestamp, but the `datasets` table allows multiple rows per timestamp (multi-row datasets) -- so the "claim" table and the data table have fundamentally different cardinality
+
+### 4. Application-level in-memory lock (asyncio.Lock per dataset)
+
+Maintain a `dict[tuple[str, str], asyncio.Lock]` in the service layer. Acquire before building, release after.
+
+**Pros:**
+- zero DB overhead, fastest option
+- simple to implement
+- no schema changes
+
+**Cons:**
+- only works within a single process -- breaks immediately with multiple workers or instances
+- builders run in sync subprocesses, so the lock must be held across `run_in_executor` calls
+- no persistence -- if the process restarts mid-build, there's no record of in-flight work
+- doesn't protect against DB-level races if another writer is ever added
+
+### 5. Hybrid: coarse advisory lock + duplicate-prevention insert guard
+
+Use the coarse advisory lock (approach 1) plus a secondary safeguard at the insert level (e.g. a check-before-insert query or a partial unique index).
+
+**Pros:**
+- defense in depth -- even if the lock is somehow bypassed, no duplicates
+
+**Cons:**
+- the secondary guard is hard to define because (name, version, timestamp) is intentionally non-unique (multi-row datasets produce multiple rows per timestamp)
+- a unique index on (name, version, timestamp) would break multi-row datasets
+- hashing the full `data` JSONB is fragile and expensive
+- adds complexity for a scenario (lock bypass) that shouldn't happen
+
+## Decision
+
+**Approach 1: coarse advisory lock on (dataset_name, dataset_version).**
+
+Rationale:
+1. **matches current reality** -- single-service deployment with low concurrency. serializing builds per dataset is not a real bottleneck; subprocess execution is
+2. **simplicity** -- ~15 lines of code, no migrations, no cleanup logic
+3. **correctness is easy to verify** -- one build at a time per dataset means no races, no duplicates, no wasted compute
+4. **clear upgrade path** -- if serialization becomes a bottleneck, can move to approach 2 or 3 without changing the external API
+
+### Implementation detail: dedicated lock connection
+
+The advisory lock is acquired on a **dedicated pool connection** separate from the connections used by `get_existing_timestamps()` and `insert_rows()`. This works because PostgreSQL advisory locks are cluster-wide: any connection calling `pg_advisory_lock(key)` blocks until the lock is available, regardless of which connection holds it.
+
+This means we don't need to refactor the DB layer to thread connections through. The existing functions keep working as-is.
+
+### Implementation detail: lock release during recursive builds
+
+The advisory lock for a dataset is **released before recursing into dependencies** and **re-acquired after** dependencies finish building. This avoids holding one idle lock connection per level of the dependency tree, which could exhaust the pool under concurrent load.
+
+The flow for `_build_recursive(A)` where A depends on B:
+
+1. Acquire lock(A), check which timestamps are missing, determine B needs building, release lock(A)
+2. Recurse: acquire lock(B), build B, release lock(B)
+3. Re-acquire lock(A), re-check missing timestamps, build A, release lock(A)
+
+The re-check in step 3 is necessary because another concurrent request may have built some of A's timestamps while the lock was released. This is just one extra `get_existing_timestamps` call per dependency level.
+
+**Tradeoff:** two concurrent requests for A could both independently decide B needs building and both recurse into B. But lock(B) serializes them, so one builds and the other sees everything already built and skips. No duplicates, just a redundant check -- much better than risking pool exhaustion.
+
+**Pool impact:** at most 1 lock connection per in-flight dataset build (not per dependency depth level). With N concurrent requests, worst case = N lock connections. Current pool max is 10, so this is comfortable.


### PR DESCRIPTION
## Summary

- Add `db/locks.py` with advisory lock helpers for build concurrency control
- `acquire_build_lock` / `release_build_lock` use `pg_advisory_lock` (session-level) with `crc32(name/version)` as the lock key
- `build_lock` context manager wraps acquire/release in try/finally for crash safety
- Add `get_pool()` helper to `db/connection.py` to expose the pool for lock connections

## Test plan

- [ ] `just test` passes (no behavior change yet)
- [ ] Lock helpers will be exercised by integration tests in PR 3