### PR TITLE
refactor: integrate advisory locks into _build_recursive

### DIFF
--- a/builders/server/db/datasets.py
+++ b/builders/server/db/datasets.py
@@ -57,7 +57,8 @@ def insert_rows(
         for ts, data_list in rows
         for data in data_list
     ]
-    with get_conn() as conn, conn.transaction():
+    # pool.connection() commits on clean exit, rolls back on exception
+    with get_conn() as conn:
         cur = conn.cursor()
         cur.executemany(
             """

--- a/builders/server/service/builder.py
+++ b/builders/server/service/builder.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import db.datasets
 import structlog
 from calendars.interface import Calendar
+from db.locks import build_lock
 from runtime import config, runner, validator
 from utils.semver import SemVer
 
@@ -125,8 +126,13 @@ def _build_recursive(
     start: datetime,
     end: datetime,
 ) -> None:
-    """Resolve dependencies, build missing timestamps, insert rows."""
+    """Resolve dependencies, build missing timestamps, insert rows.
+
+    Uses a lock-release-recurse-reacquire pattern to avoid deadlocks
+    while preventing duplicate inserts from concurrent requests.
+    """
     cfg = config.load_config(dataset_name, dataset_version)
+    version_str = str(dataset_version)
 
     # enforce start-date
     start_date = cfg.start_date
@@ -138,13 +144,37 @@ def _build_recursive(
         logger.warning(
             "clamping start to dataset start-date",
             dataset=dataset_name,
-            version=str(dataset_version),
+            version=version_str,
             original_start=str(start),
             start_date=str(start_date),
         )
         start = start_date
 
-    # recursively build dependencies first, expanding range for lookback
+    # first lock: check what's missing
+    with build_lock(dataset_name, version_str):
+        all_timestamps = generate_timestamps(start, end, cfg.granularity, cfg.calendar)
+
+        if not all_timestamps:
+            raise NoValidTimestampsError(
+                f"{dataset_name}/{dataset_version}: no valid calendar timestamps "
+                f"in range [{start}, {end}] for calendar '{cfg.calendar.name}'"
+            )
+
+        existing = set(
+            db.datasets.get_existing_timestamps(
+                dataset_name, dataset_version, start, end
+            )
+        )
+        missing = [ts for ts in all_timestamps if ts not in existing]
+        if not missing:
+            logger.info(
+                "all timestamps present, skipping",
+                dataset=dataset_name,
+                version=version_str,
+            )
+            return
+
+    # no lock held: recurse into dependencies
     for dep_name, dep_info in cfg.dependencies.items():
         if dep_info.lookback_subtract is not None:
             dep_start = start - dep_info.lookback_subtract
@@ -152,96 +182,88 @@ def _build_recursive(
             dep_start = start
         _build_recursive(dep_name, dep_info.version, dep_start, end)
 
-    # determine which timestamps are missing
-    all_timestamps = generate_timestamps(start, end, cfg.granularity, cfg.calendar)
-
-    if not all_timestamps:
-        raise NoValidTimestampsError(
-            f"{dataset_name}/{dataset_version}: no valid calendar timestamps "
-            f"in range [{start}, {end}] for calendar '{cfg.calendar.name}'"
+    # second lock: re-check, build, insert
+    with build_lock(dataset_name, version_str):
+        existing = set(
+            db.datasets.get_existing_timestamps(
+                dataset_name, dataset_version, start, end
+            )
         )
+        missing = [ts for ts in all_timestamps if ts not in existing]
+        if not missing:
+            logger.info(
+                "all timestamps present after re-check, skipping",
+                dataset=dataset_name,
+                version=version_str,
+            )
+            return
 
-    existing = set(
-        db.datasets.get_existing_timestamps(dataset_name, dataset_version, start, end)
-    )
-    missing = [ts for ts in all_timestamps if ts not in existing]
-
-    if not missing:
         logger.info(
-            "all timestamps present, skipping",
+            "building missing timestamps",
             dataset=dataset_name,
-            version=str(dataset_version),
+            version=version_str,
+            count=len(missing),
         )
-        return
 
-    logger.info(
-        "building missing timestamps",
-        dataset=dataset_name,
-        version=str(dataset_version),
-        count=len(missing),
-    )
+        # resolve env file if env-vars is enabled
+        env_file: Path | None = None
+        if cfg.env_vars:
+            env_file = config.SCRIPTS_DIR / dataset_name / str(cfg.version) / ".env"
+            if not env_file.exists():
+                raise FileNotFoundError(
+                    f"{dataset_name}/{dataset_version}: env-vars is enabled "
+                    f"but {env_file} does not exist"
+                )
 
-    # resolve env file if env-vars is enabled
-    env_file: Path | None = None
-    if cfg.env_vars:
-        env_file = config.SCRIPTS_DIR / dataset_name / str(cfg.version) / ".env"
-        if not env_file.exists():
-            raise FileNotFoundError(
-                f"{dataset_name}/{dataset_version}: env-vars is enabled "
-                f"but {env_file} does not exist"
+        script_dir = config.SCRIPTS_DIR / dataset_name / str(cfg.version)
+
+        # TODO (bryan): this spawns builder processes sequentially, one for each
+        # timestamp. can we spawn them all at once for builders that block on I/O?
+
+        # build each missing timestamp
+        rows = []
+        for ts in missing:
+            # fetch dependency data for this timestamp
+            dep_data: dict[str, dict[datetime, list[dict]]] = {}
+            for dep_name, dep_info in cfg.dependencies.items():
+                if dep_info.lookback_subtract is not None:
+                    dep_rows = db.datasets.get_rows_range(
+                        dep_name,
+                        dep_info.version,
+                        ts - dep_info.lookback_subtract,
+                        ts,
+                    )
+                else:
+                    # no lookback, fetch just this timestamp
+                    dep_rows = db.datasets.get_rows_timestamps(
+                        dep_name, dep_info.version, [ts]
+                    )
+
+                if not dep_rows:
+                    raise RuntimeError(
+                        f"Dependency '{dep_name}/{dep_info.version}' "
+                        f"missing data for timestamp {ts}"
+                    )
+                dep_data[dep_name] = dep_rows
+
+            # run builder in subprocess
+            result = runner.run_builder(
+                script_dir, cfg.builder, dep_data, ts, env_file=env_file
             )
 
-    script_dir = config.SCRIPTS_DIR / dataset_name / str(cfg.version)
+            # validate output against schema
+            validator.validate_rows(result, cfg.schema)
 
-    # TODO (bryan): this spawns builder processes sequentially, one for each timestamp.
-    # we then sync wait for that process to be done before moving on.
-    # can we spawn them all at the start, then launch them all at the same time?
-    # because certain builders may block (i.e. fetch from an external API)
+            rows.append((ts, result))
 
-    # build each missing timestamp
-    rows = []
-    for ts in missing:
-        # fetch dependency data for this timestamp
-        dep_data: dict[str, dict[datetime, list[dict]]] = {}
-        for dep_name, dep_info in cfg.dependencies.items():
-            if dep_info.lookback_subtract is not None:
-                dep_rows = db.datasets.get_rows_range(
-                    dep_name,
-                    dep_info.version,
-                    ts - dep_info.lookback_subtract,
-                    ts,
-                )
-            else:
-                # no lookback, fetch just this timestamp
-                dep_rows = db.datasets.get_rows_timestamps(
-                    dep_name, dep_info.version, [ts]
-                )
-
-            if not dep_rows:
-                raise RuntimeError(
-                    f"Dependency '{dep_name}/{dep_info.version}' "
-                    f"missing data for timestamp {ts}"
-                )
-            dep_data[dep_name] = dep_rows
-
-        # run builder in subprocess
-        result = runner.run_builder(
-            script_dir, cfg.builder, dep_data, ts, env_file=env_file
+        # bulk insert all rows
+        db.datasets.insert_rows(dataset_name, dataset_version, rows)
+        logger.info(
+            "inserted rows",
+            dataset=dataset_name,
+            version=version_str,
+            count=len(rows),
         )
-
-        # validate output against schema
-        validator.validate_rows(result, cfg.schema)
-
-        rows.append((ts, result))
-
-    # bulk insert all rows
-    db.datasets.insert_rows(dataset_name, dataset_version, rows)
-    logger.info(
-        "inserted rows",
-        dataset=dataset_name,
-        version=str(dataset_version),
-        count=len(rows),
-    )
 
 
 def get_data(

--- a/builders/server/tests/integration/conftest.py
+++ b/builders/server/tests/integration/conftest.py
@@ -79,6 +79,18 @@ def patch_db_conn(db_conn, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def patch_build_lock(monkeypatch):
+    """Replace advisory locks with a no-op for single-connection tests."""
+    import service.builder
+
+    @contextmanager
+    def _noop_lock(name, version):
+        yield None
+
+    monkeypatch.setattr(service.builder, "build_lock", _noop_lock)
+
+
+@pytest.fixture(autouse=True)
 def real_scripts_dir(monkeypatch):
     """Point SCRIPTS_DIR to the real builders/scripts/ directory."""
     from runtime import config, loader

--- a/builders/server/tests/service/conftest.py
+++ b/builders/server/tests/service/conftest.py
@@ -1,0 +1,16 @@
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+
+
+@contextmanager
+def _noop_lock(name, version):
+    yield None
+
+
+@pytest.fixture(autouse=True)
+def patch_build_lock():
+    """Replace advisory locks with a no-op for unit tests."""
+    with patch("service.builder.build_lock", _noop_lock):
+        yield

--- a/builders/server/tests/service/test_builder.py
+++ b/builders/server/tests/service/test_builder.py
@@ -289,10 +289,11 @@ def test_build_dataset_passes_dep_data_as_dict_of_timestamps(
         return _cfg(name="dep")
 
     mock_config.load_config.side_effect = fake_load_config
-    # dep recurses first, then ds
+    # call order: ds first lock, dep first lock (recurse), ds second lock
     mock_db.get_existing_timestamps.side_effect = [
-        [datetime(2024, 1, 1)],  # dep already built (recursive call happens first)
-        [],  # ds has no data
+        [],  # ds first lock check (missing)
+        [datetime(2024, 1, 1)],  # dep first lock check (already built, returns early)
+        [],  # ds second lock re-check (still missing)
     ]
     # dep returns multi-row data keyed by timestamp
     ts = datetime(2024, 1, 1)
@@ -655,17 +656,21 @@ def test_build_dataset_lookback_expands_dep_build_range(
         return _cfg(name="dep")
 
     mock_config.load_config.side_effect = fake_load_config
-    # everything already exists so we just check build range
-    mock_db.get_existing_timestamps.return_value = [
-        datetime(2024, 1, 1),
-        datetime(2024, 1, 2),
-        datetime(2024, 1, 3),
+    # ds must have missing timestamps so it recurses into dep
+    # call order: ds first lock, dep first lock (expanded range), ds second lock
+    mock_db.get_existing_timestamps.side_effect = [
+        # ds first lock: missing, will recurse
+        [],
+        # dep first lock: all present in expanded range [Dec 28..Jan 3]
+        [datetime(2023, 12, 28) + timedelta(days=i) for i in range(7)],
+        # ds second lock: all present now (another request filled it)
+        [datetime(2024, 1, 1), datetime(2024, 1, 2), datetime(2024, 1, 3)],
     ]
 
     build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 3))
 
-    # dep's get_existing_timestamps should be called with expanded range
-    dep_call = mock_db.get_existing_timestamps.call_args_list[0]
+    # dep's get_existing_timestamps is the second call (index 1)
+    dep_call = mock_db.get_existing_timestamps.call_args_list[1]
     # dep start should be 2024-01-01 - 5d + 1d = 2023-12-28
     assert dep_call[0][2] == datetime(2023, 12, 28)
     assert dep_call[0][3] == datetime(2024, 1, 3)
@@ -696,10 +701,19 @@ def test_build_dataset_lookback_fetches_range(
         return _cfg(name="dep")
 
     mock_config.load_config.side_effect = fake_load_config
+    # dep range is expanded: dep_start = Jan 1 - 1d = Dec 31
+    # call order: ds first lock, dep first lock, ds second lock
     mock_db.get_existing_timestamps.side_effect = [
-        # dep: all timestamps exist (expanded range)
-        [datetime(2024, 1, 1), datetime(2024, 1, 2), datetime(2024, 1, 3)],
-        # ds: needs to build Jan 3
+        # ds first lock check (missing Jan 3)
+        [datetime(2024, 1, 1), datetime(2024, 1, 2)],
+        # dep first lock: all present in [Dec 31..Jan 3] (returns early)
+        [
+            datetime(2023, 12, 31),
+            datetime(2024, 1, 1),
+            datetime(2024, 1, 2),
+            datetime(2024, 1, 3),
+        ],
+        # ds second lock re-check (still missing Jan 3)
         [datetime(2024, 1, 1), datetime(2024, 1, 2)],
     ]
     # lookback range query returns multiple timestamps
@@ -746,9 +760,11 @@ def test_build_dataset_no_lookback_uses_get_rows_timestamps(
         return _cfg(name="dep")
 
     mock_config.load_config.side_effect = fake_load_config
+    # call order: ds first lock, dep first lock (recurse), ds second lock
     mock_db.get_existing_timestamps.side_effect = [
-        [datetime(2024, 1, 1)],  # dep
-        [],  # ds
+        [],  # ds first lock check (missing)
+        [datetime(2024, 1, 1)],  # dep first lock check (already built, returns early)
+        [],  # ds second lock re-check (still missing)
     ]
     ts = datetime(2024, 1, 1)
     mock_db.get_rows_timestamps.return_value = {ts: [{"val": 1}]}


### PR DESCRIPTION
## Summary

- Restructure `_build_recursive` to use a lock-release-recurse-reacquire pattern
- First lock region: check what timestamps are missing, early return if none
- Release lock before recursing into dependencies (prevents deadlocks)
- Second lock region: re-check missing timestamps, build, and insert
- Patch `build_lock` to no-op in unit and existing integration tests (they use a single shared connection, not a real pool)
- Update mock side_effects in unit tests to account for the double-check pattern

## Test plan

- [x] `just test` passes (unit tests updated for new call order)
- [x] Integration tests pass with no-op lock patch
- [ ] Concurrency race tests (PR 3) will verify real locking behavior