### PR TITLE
feat: add build lock registry

### DIFF
--- a/builders/server/service/locks.py
+++ b/builders/server/service/locks.py
@@ -1,0 +1,13 @@
+import threading
+
+_lock_map: dict[tuple[str, str], threading.Lock] = {}
+_lock_map_lock = threading.Lock()
+
+
+def get_build_lock(dataset_name: str, dataset_version: str) -> threading.Lock:
+    """Return the build lock for a (name, version) pair, creating it if needed."""
+    key = (dataset_name, dataset_version)
+    with _lock_map_lock:
+        if key not in _lock_map:
+            _lock_map[key] = threading.Lock()
+        return _lock_map[key]

--- a/builders/server/tests/service/test_locks.py
+++ b/builders/server/tests/service/test_locks.py
@@ -1,0 +1,42 @@
+import threading
+from unittest.mock import patch
+
+from service.locks import get_build_lock
+
+
+def test_get_build_lock_returns_same_lock_for_same_key() -> None:
+    """Same (name, version) returns the same Lock instance."""
+    with patch("service.locks._lock_map", {}):
+        lock1 = get_build_lock("ds", "0.1.0")
+        lock2 = get_build_lock("ds", "0.1.0")
+        assert lock1 is lock2
+
+
+def test_get_build_lock_returns_different_locks_for_different_keys() -> None:
+    """Different (name, version) pairs return distinct Lock instances."""
+    with patch("service.locks._lock_map", {}):
+        lock_a = get_build_lock("ds-a", "0.1.0")
+        lock_b = get_build_lock("ds-b", "0.1.0")
+        lock_a_v2 = get_build_lock("ds-a", "0.2.0")
+        assert lock_a is not lock_b
+        assert lock_a is not lock_a_v2
+
+
+def test_get_build_lock_is_thread_safe() -> None:
+    """Concurrent calls from multiple threads all get the same lock."""
+    with patch("service.locks._lock_map", {}):
+        results: list[threading.Lock] = []
+        barrier = threading.Barrier(10)
+
+        def grab_lock() -> None:
+            barrier.wait()
+            results.append(get_build_lock("ds", "0.1.0"))
+
+        threads = [threading.Thread(target=grab_lock) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(results) == 10
+        assert all(lock is results[0] for lock in results)


### PR DESCRIPTION
## Summary
- Add a per-dataset build lock registry (`service/locks.py`) that returns a `threading.Lock` for each `(dataset_name, dataset_version)` pair, creating it lazily on first access
- Add unit tests for identity, uniqueness, and thread safety

## Why
Concurrent build requests for the same dataset can race between the "check missing timestamps" read and the "insert rows" write, producing duplicate rows. This registry provides the locking primitive that `_build_recursive` will use in a follow-up PR.

## Test plan
- [x] `test_get_build_lock_returns_same_lock_for_same_key`
- [x] `test_get_build_lock_returns_different_locks_for_different_keys`
- [x] `test_get_build_lock_is_thread_safe`