### PR TITLE
feat: add per-dataset locking to _build_recursive

### DIFF
--- a/builders/server/service/builder.py
+++ b/builders/server/service/builder.py
@@ -8,6 +8,8 @@ from calendars.interface import Calendar
 from runtime import config, runner, validator
 from utils.semver import SemVer
 
+from service.locks import get_build_lock
+
 logger = structlog.get_logger()
 
 
@@ -152,7 +154,7 @@ def _build_recursive(
             dep_start = start
         _build_recursive(dep_name, dep_info.version, dep_start, end)
 
-    # determine which timestamps are missing
+    # determine which timestamps are valid for the range (outside lock, deterministic)
     all_timestamps = generate_timestamps(start, end, cfg.granularity, cfg.calendar)
 
     if not all_timestamps:
@@ -161,87 +163,92 @@ def _build_recursive(
             f"in range [{start}, {end}] for calendar '{cfg.calendar.name}'"
         )
 
-    existing = set(
-        db.datasets.get_existing_timestamps(dataset_name, dataset_version, start, end)
-    )
-    missing = [ts for ts in all_timestamps if ts not in existing]
+    # acquire per-dataset lock to prevent concurrent builds from racing
+    # between the "check missing" read and "insert rows" write
+    with get_build_lock(dataset_name, str(dataset_version)):
+        existing = set(
+            db.datasets.get_existing_timestamps(
+                dataset_name, dataset_version, start, end
+            )
+        )
+        missing = [ts for ts in all_timestamps if ts not in existing]
 
-    if not missing:
+        if not missing:
+            logger.info(
+                "all timestamps present, skipping",
+                dataset=dataset_name,
+                version=str(dataset_version),
+            )
+            return
+
         logger.info(
-            "all timestamps present, skipping",
+            "building missing timestamps",
             dataset=dataset_name,
             version=str(dataset_version),
+            count=len(missing),
         )
-        return
 
-    logger.info(
-        "building missing timestamps",
-        dataset=dataset_name,
-        version=str(dataset_version),
-        count=len(missing),
-    )
+        # resolve env file if env-vars is enabled
+        env_file: Path | None = None
+        if cfg.env_vars:
+            env_file = config.SCRIPTS_DIR / dataset_name / str(cfg.version) / ".env"
+            if not env_file.exists():
+                raise FileNotFoundError(
+                    f"{dataset_name}/{dataset_version}: env-vars is enabled "
+                    f"but {env_file} does not exist"
+                )
 
-    # resolve env file if env-vars is enabled
-    env_file: Path | None = None
-    if cfg.env_vars:
-        env_file = config.SCRIPTS_DIR / dataset_name / str(cfg.version) / ".env"
-        if not env_file.exists():
-            raise FileNotFoundError(
-                f"{dataset_name}/{dataset_version}: env-vars is enabled "
-                f"but {env_file} does not exist"
+        script_dir = config.SCRIPTS_DIR / dataset_name / str(cfg.version)
+
+        # TODO (bryan): this spawns builder processes sequentially, one for each
+        # timestamp. we then sync wait for that process to be done before moving on.
+        # can we spawn them all at the start, then launch them all at the same time?
+        # because certain builders may block (i.e. fetch from an external API)
+
+        # build each missing timestamp
+        rows = []
+        for ts in missing:
+            # fetch dependency data for this timestamp
+            dep_data: dict[str, dict[datetime, list[dict]]] = {}
+            for dep_name, dep_info in cfg.dependencies.items():
+                if dep_info.lookback_subtract is not None:
+                    dep_rows = db.datasets.get_rows_range(
+                        dep_name,
+                        dep_info.version,
+                        ts - dep_info.lookback_subtract,
+                        ts,
+                    )
+                else:
+                    # no lookback, fetch just this timestamp
+                    dep_rows = db.datasets.get_rows_timestamps(
+                        dep_name, dep_info.version, [ts]
+                    )
+
+                if not dep_rows:
+                    raise RuntimeError(
+                        f"Dependency '{dep_name}/{dep_info.version}' "
+                        f"missing data for timestamp {ts}"
+                    )
+                dep_data[dep_name] = dep_rows
+
+            # run builder in subprocess
+            result = runner.run_builder(
+                script_dir, cfg.builder, dep_data, ts, env_file=env_file
             )
 
-    script_dir = config.SCRIPTS_DIR / dataset_name / str(cfg.version)
+            # validate output against schema
+            validator.validate_rows(result, cfg.schema)
 
-    # TODO (bryan): this spawns builder processes sequentially, one for each timestamp.
-    # we then sync wait for that process to be done before moving on.
-    # can we spawn them all at the start, then launch them all at the same time?
-    # because certain builders may block (i.e. fetch from an external API)
+            rows.append((ts, result))
 
-    # build each missing timestamp
-    rows = []
-    for ts in missing:
-        # fetch dependency data for this timestamp
-        dep_data: dict[str, dict[datetime, list[dict]]] = {}
-        for dep_name, dep_info in cfg.dependencies.items():
-            if dep_info.lookback_subtract is not None:
-                dep_rows = db.datasets.get_rows_range(
-                    dep_name,
-                    dep_info.version,
-                    ts - dep_info.lookback_subtract,
-                    ts,
-                )
-            else:
-                # no lookback, fetch just this timestamp
-                dep_rows = db.datasets.get_rows_timestamps(
-                    dep_name, dep_info.version, [ts]
-                )
-
-            if not dep_rows:
-                raise RuntimeError(
-                    f"Dependency '{dep_name}/{dep_info.version}' "
-                    f"missing data for timestamp {ts}"
-                )
-            dep_data[dep_name] = dep_rows
-
-        # run builder in subprocess
-        result = runner.run_builder(
-            script_dir, cfg.builder, dep_data, ts, env_file=env_file
+        # bulk insert all rows
+        db.datasets.insert_rows(dataset_name, dataset_version, rows)
+        logger.info(
+            "inserted rows",
+            dataset=dataset_name,
+            version=str(dataset_version),
+            count=len(rows),
         )
-
-        # validate output against schema
-        validator.validate_rows(result, cfg.schema)
-
-        rows.append((ts, result))
-
-    # bulk insert all rows
-    db.datasets.insert_rows(dataset_name, dataset_version, rows)
-    logger.info(
-        "inserted rows",
-        dataset=dataset_name,
-        version=str(dataset_version),
-        count=len(rows),
-    )
 
 
 def get_data(


### PR DESCRIPTION
## Summary
- Wrap the critical section in \`_build_recursive\` (check existing timestamps, compute missing, build, validate, insert) with a per-dataset \`threading.Lock\` from the lock registry
- Dependencies are built outside the lock so each dataset only holds its own lock during its own build
- The lock is a context manager so it is always released, even on builder failures

## Why
Without locking, concurrent requests for the same \`(name, version)\` race between the DB read (what's missing) and write (insert rows), producing duplicate rows. This also prevents the shared-dependency race where two datasets that depend on the same child both try to build it simultaneously.

## Test plan
- [x] All 42 existing builder tests pass unchanged
- [x] Lock registry tests from PR #227