### PR TITLE
fix: use make_url to set psycopg v3 dialect for alembic

### DIFF
--- a/builders/server/db/migrations/env.py
+++ b/builders/server/db/migrations/env.py
@@ -1,9 +1,11 @@
 import os
 
 from alembic import context
+from sqlalchemy.engine import make_url
 
-# read the same DATABASE_URL the app uses
-url = os.environ["DATABASE_URL"]
+# parse DATABASE_URL and set the psycopg v3 dialect explicitly;
+# plain postgresql:// defaults to psycopg2 in sqlalchemy
+url = make_url(os.environ["DATABASE_URL"]).set(drivername="postgresql+psycopg")
 
 config = context.config
 


### PR DESCRIPTION
## Summary
- Alembic's `env.py` was calling `create_engine` with a plain `postgresql://` URL, which SQLAlchemy defaults to the psycopg2 dialect — but psycopg2 is no longer installed after the migration to psycopg v3
- Fix uses `sqlalchemy.engine.make_url()` to parse `DATABASE_URL`, then `.set(drivername="postgresql+psycopg")` to explicitly select the psycopg v3 dialect — no string manipulation needed

## Test plan
- [ ] `just docker-up` starts all containers successfully
- [ ] Builder container passes healthcheck (alembic migrations run cleanly)