### PR TITLE
test: tighten cycle detection error message assertions

### DIFF
--- a/builders/server/tests/runtime/test_config.py
+++ b/builders/server/tests/runtime/test_config.py
@@ -813,7 +813,7 @@ price = "int"
 ds = "0.1.0"
 """,
     )
-    with pytest.raises(ValueError, match="cycle"):
+    with pytest.raises(ValueError, match="ds/0.1.0"):
         config.load_config("ds", V010)
 
 
@@ -857,7 +857,7 @@ price = "int"
 a = "0.1.0"
 """,
     )
-    with pytest.raises(ValueError, match="cycle"):
+    with pytest.raises(ValueError, match="a/0.1.0"):
         config.load_config("a", V010)
 
 
@@ -918,7 +918,7 @@ def test_cycles_self_cycle(mock_scripts_dir: Path, write_config: Callable) -> No
         "0.1.0",
         _MINIMAL_CFG_WITH_DEP.format(name="a", dep_name="a"),
     )
-    with pytest.raises(ValueError, match="cycle"):
+    with pytest.raises(ValueError, match="a/0.1.0"):
         config.check_dependency_graph_cycles("a", V010)
 
 
@@ -935,7 +935,7 @@ def test_cycles_two_node_cycle(mock_scripts_dir: Path, write_config: Callable) -
         "0.1.0",
         _MINIMAL_CFG_WITH_DEP.format(name="b", dep_name="a"),
     )
-    with pytest.raises(ValueError, match="cycle"):
+    with pytest.raises(ValueError, match="a/0.1.0"):
         config.check_dependency_graph_cycles("a", V010)
 
 
@@ -960,7 +960,7 @@ def test_cycles_three_node_cycle(
         "0.1.0",
         _MINIMAL_CFG_WITH_DEP.format(name="c", dep_name="a"),
     )
-    with pytest.raises(ValueError, match="cycle"):
+    with pytest.raises(ValueError, match="a/0.1.0"):
         config.check_dependency_graph_cycles("a", V010)
 
 


### PR DESCRIPTION
Update error message matching in cycle detection tests to be more specific.

Replaces generic "cycle" pattern matches with specific package/version identifiers (e.g., "ds/0.1.0", "a/0.1.0") in pytest assertions. This makes tests more precise and helps catch unintended changes to error messages.

- Updated 5 test cases for cycle detection scenarios
- Changes affect: `test_cycles_dep`, `test_cycles_indirect_dep`, `test_cycles_self_cycle`, `test_cycles_two_node_cycle`, `test_cycles_three_node_cycle`