### PR TITLE
chore: add builders/server/pyproject.toml

### DIFF
--- a/builders/server/pyproject.toml
+++ b/builders/server/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "builder-server"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "alembic>=1.18.4",
+    "fastapi>=0.135.1",
+    "psycopg[binary]>=3.2.0",
+    "psycopg_pool>=3.2.0",
+    "requests>=2.32.5",
+    "uvicorn>=0.41.0",
+    "exchange-calendars>=4.13",
+    "python-dotenv>=1.0.0",
+    "structlog>=24.0.0",
+]
+
+[dependency-groups]
+dev = [
+    "httpx>=0.28.1",
+    "mypy>=1.15.0",
+    "pre-commit>=4.0.0",
+    "pytest>=9.0.2",
+    "testcontainers[postgres]>=4.0.0",
+    "types-requests>=2.31.0",
+]


### PR DESCRIPTION
## Summary

Creates the project manifest for the builder-server package that will soon become a member of a uv workspace.

- Declares all production and dev dependencies in one place
- No \`[build-system]\` (the server runs via --app-dir, not installed as a package)
- Self-contained: can be referenced by workspace member resolution

## Why

Preparing for workspace migration. The root pyproject.toml currently owns all deps. With this member manifest in place, we can then convert root to workspace coordinator.

## Benefit

Easier to add future Python projects to the monorepo without sharing a global dep set.