### PR TITLE
refactor: convert root pyproject.toml to uv workspace

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,34 +1,11 @@
-[project]
-name = "builder-server"
-version = "0.1.0"
-requires-python = ">=3.12"
-dependencies = [
-    "alembic>=1.18.4",
-    "fastapi>=0.135.1",
-    "psycopg[binary]>=3.2.0",
-    "psycopg_pool>=3.2.0",
-    "requests>=2.32.5",
-    "uvicorn>=0.41.0",
-    "exchange-calendars>=4.13",
-    "python-dotenv>=1.0.0",
-    "structlog>=24.0.0",
-]
+[tool.uv.workspace]
+members = ["builders/server"]
 
 [tool.pytest.ini_options]
 pythonpath = ["builders/server"]
 testpaths = ["builders/server/tests"]
 markers = [
     "integration: integration tests requiring a real postgres (via testcontainers)",
-]
-
-[dependency-groups]
-dev = [
-    "httpx>=0.28.1",
-    "mypy>=1.15.0",
-    "pre-commit>=4.0.0",
-    "pytest>=9.0.2",
-    "testcontainers[postgres]>=4.0.0",
-    "types-requests>=2.31.0",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,11 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[manifest]
+members = [
+    "builder-server",
+]
+
 [[package]]
 name = "alembic"
 version = "1.18.4"
@@ -58,7 +63,7 @@ wheels = [
 [[package]]
 name = "builder-server"
 version = "0.1.0"
-source = { virtual = "." }
+source = { virtual = "builders/server" }
 dependencies = [
     { name = "alembic" },
     { name = "exchange-calendars" },


### PR DESCRIPTION
## Summary

Converts root pyproject.toml to uv workspace format:
- Removed \`[project]\` and \`[dependency-groups]\` (moved to builders/server/pyproject.toml)
- Added \`[tool.uv.workspace]\` with members list
- Kept all \`[tool.*]\` sections (ruff, mypy, pytest) at root for shared configuration
- Regenerated uv.lock with workspace-aware metadata

## Why

Aligns the repo structure with Cargo-style workspaces: root coordinates members, each member owns its own deps. Tool configs stay at root and apply to all members.

## Benefit

Tool invocations (just fix, just test, etc.) work transparently from root. New workspace members can be added by declaring them in \`[tool.uv.workspace]\` and creating their own pyproject.toml.