### PR TITLE
chore: update Dockerfile for workspace layout

### DIFF
--- a/infra/builder/Dockerfile
+++ b/infra/builder/Dockerfile
@@ -14,6 +14,7 @@ ENV UV_LINK_MODE=copy
 # Install dependencies (Medium frequency change)
 # This layer is only invalidated if pyproject.toml or uv.lock changes.
 COPY pyproject.toml uv.lock ./
+COPY builders/server/pyproject.toml ./builders/server/pyproject.toml
 # - --mount=type=cache: Persist uv's package cache across builds.
 # - --frozen: strict sync from uv.lock (no updates).
 # - --no-install-project: Do not attempt to install the project package itself (source not yet present).


### PR DESCRIPTION
## Summary

Updates the builder Dockerfile to copy the workspace member manifest before installing dependencies:

Added:
\`\`\`dockerfile
COPY builders/server/pyproject.toml ./builders/server/pyproject.toml
\`\`\`

## Why

With workspace layout, uv needs the member pyproject.toml present during the dependency resolution phase. Without it, the install layer would fail because uv can't resolve workspace members.

## Benefit

Docker build now works with the uv workspace. Dependencies are correctly resolved from both root and member manifests.