### PR TITLE
chore: add sdk workspace member

### DIFF
--- a/builders/sdk/pyproject.toml
+++ b/builders/sdk/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "datastream-sdk"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "httpx>=0.28.1",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [tool.uv.workspace]
-members = ["builders/server"]
+members = ["builders/server", "builders/sdk"]
 
 [tool.pytest.ini_options]
-pythonpath = ["builders/server"]
-testpaths = ["builders/server/tests"]
+pythonpath = ["builders/server", "builders/sdk"]
+testpaths = ["builders/server/tests", "builders/sdk/tests"]
 markers = [
     "integration: integration tests requiring a real postgres (via testcontainers)",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -13,6 +13,7 @@ resolution-markers = [
 [manifest]
 members = [
     "builder-server",
+    "datastream-sdk",
 ]
 
 [[package]]
@@ -204,6 +205,25 @@ sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
 ]
+
+[[package]]
+name = "datastream-sdk"
+version = "0.1.0"
+source = { virtual = "builders/sdk" }
+dependencies = [
+    { name = "httpx" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "httpx", specifier = ">=0.28.1" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.2" }]
 
 [[package]]
 name = "distlib"


### PR DESCRIPTION
Add `builders/sdk` as a new uv workspace member for the Python SDK package (`datastream-sdk`).

- `builders/sdk/pyproject.toml` with `httpx` dependency
- Empty `datastream/__init__.py`
- Root `pyproject.toml` updated with new workspace member and test path