### PR TITLE
feat: add sdk types

### DIFF
--- a/builders/sdk/datastream/__init__.py
+++ b/builders/sdk/datastream/__init__.py
@@ -1,0 +1,13 @@
+from datastream.types import (
+    DatasetName,
+    DatasetResponse,
+    DatasetRow,
+    DatasetVersion,
+)
+
+__all__ = [
+    "DatasetName",
+    "DatasetResponse",
+    "DatasetRow",
+    "DatasetVersion",
+]

--- a/builders/sdk/datastream/types.py
+++ b/builders/sdk/datastream/types.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, NewType
+
+DatasetName = NewType("DatasetName", str)
+
+_SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+
+@dataclass(frozen=True)
+class DatasetVersion:
+    major: int
+    minor: int
+    patch: int
+
+    @classmethod
+    def parse(cls, version: str) -> DatasetVersion:
+        """Parse a semver string like '1.2.3' into a DatasetVersion."""
+        match = _SEMVER_RE.match(version)
+        if not match:
+            raise ValueError(f"invalid semver: {version!r}")
+        return cls(
+            major=int(match.group(1)),
+            minor=int(match.group(2)),
+            patch=int(match.group(3)),
+        )
+
+    def __str__(self) -> str:
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+
+@dataclass
+class DatasetRow:
+    timestamp: datetime
+    data: list[dict[str, Any]]
+
+
+@dataclass
+class DatasetResponse:
+    dataset_name: str
+    dataset_version: DatasetVersion
+    total_timestamps: int
+    returned_timestamps: int
+    rows: list[DatasetRow]

--- a/builders/sdk/tests/test_types.py
+++ b/builders/sdk/tests/test_types.py
@@ -1,0 +1,62 @@
+from datetime import datetime
+
+import pytest
+from datastream.types import DatasetResponse, DatasetRow, DatasetVersion
+
+
+def test_parse_valid_semver():
+    v = DatasetVersion.parse("1.2.3")
+    assert v.major == 1
+    assert v.minor == 2
+    assert v.patch == 3
+
+
+def test_parse_zero_version():
+    v = DatasetVersion.parse("0.0.0")
+    assert v == DatasetVersion(0, 0, 0)
+
+
+def test_str_roundtrip():
+    assert str(DatasetVersion.parse("0.1.0")) == "0.1.0"
+    assert str(DatasetVersion(10, 20, 30)) == "10.20.30"
+
+
+def test_parse_invalid_raises():
+    with pytest.raises(ValueError, match="invalid semver"):
+        DatasetVersion.parse("not-a-version")
+
+
+def test_parse_incomplete_raises():
+    with pytest.raises(ValueError, match="invalid semver"):
+        DatasetVersion.parse("1.2")
+
+
+def test_parse_extra_parts_raises():
+    with pytest.raises(ValueError, match="invalid semver"):
+        DatasetVersion.parse("1.2.3.4")
+
+
+def test_frozen():
+    v = DatasetVersion.parse("1.0.0")
+    with pytest.raises(AttributeError):
+        v.major = 2  # type: ignore[misc]
+
+
+def test_dataset_response_construction():
+    row = DatasetRow(
+        timestamp=datetime(2024, 1, 2),
+        data=[{"ticker": "AAPL", "close": 150}],
+    )
+    resp = DatasetResponse(
+        dataset_name="mock-ohlc",
+        dataset_version=DatasetVersion.parse("0.1.0"),
+        total_timestamps=3,
+        returned_timestamps=1,
+        rows=[row],
+    )
+    assert resp.dataset_name == "mock-ohlc"
+    assert str(resp.dataset_version) == "0.1.0"
+    assert resp.total_timestamps == 3
+    assert resp.returned_timestamps == 1
+    assert len(resp.rows) == 1
+    assert resp.rows[0].data == [{"ticker": "AAPL", "close": 150}]


### PR DESCRIPTION
Add SDK type definitions: `DatasetVersion` (frozen semver dataclass with `parse`/`__str__`), `DatasetName` (NewType), `DatasetRow`, and `DatasetResponse`.

Includes tests for parsing, roundtripping, invalid input, and response construction.