### PR TITLE
feat: add sdk exceptions

### DIFF
--- a/builders/sdk/datastream/__init__.py
+++ b/builders/sdk/datastream/__init__.py
@@ -1,3 +1,4 @@
+from datastream.exceptions import DatastreamAPIError, DatastreamError
 from datastream.types import (
     DatasetName,
     DatasetResponse,
@@ -10,4 +11,6 @@ __all__ = [
     "DatasetResponse",
     "DatasetRow",
     "DatasetVersion",
+    "DatastreamAPIError",
+    "DatastreamError",
 ]

--- a/builders/sdk/datastream/exceptions.py
+++ b/builders/sdk/datastream/exceptions.py
@@ -1,0 +1,11 @@
+class DatastreamError(Exception):
+    """Base exception for all datastream SDK errors."""
+
+
+class DatastreamAPIError(DatastreamError):
+    """Raised when the API returns a non-success status code."""
+
+    def __init__(self, status_code: int, detail: str) -> None:
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(f"API error {status_code}: {detail}")

--- a/builders/sdk/tests/test_exceptions.py
+++ b/builders/sdk/tests/test_exceptions.py
@@ -1,0 +1,27 @@
+import pytest
+from datastream.exceptions import DatastreamAPIError, DatastreamError
+
+
+def test_base_error_is_exception():
+    assert issubclass(DatastreamError, Exception)
+
+
+def test_api_error_inherits_base():
+    assert issubclass(DatastreamAPIError, DatastreamError)
+
+
+def test_api_error_attrs():
+    err = DatastreamAPIError(status_code=400, detail="bad request")
+    assert err.status_code == 400
+    assert err.detail == "bad request"
+
+
+def test_api_error_message():
+    err = DatastreamAPIError(status_code=500, detail="internal error")
+    assert "500" in str(err)
+    assert "internal error" in str(err)
+
+
+def test_api_error_catchable_as_base():
+    with pytest.raises(DatastreamError):
+        raise DatastreamAPIError(status_code=422, detail="unprocessable")


### PR DESCRIPTION
Add SDK exception classes: `DatastreamError` (base) and `DatastreamAPIError` (with `status_code` and `detail` attrs).

Includes tests for inheritance, attributes, and catchability.