### PR TITLE
feat: add sdk config

### DIFF
--- a/builders/sdk/datastream/__init__.py
+++ b/builders/sdk/datastream/__init__.py
@@ -1,3 +1,4 @@
+from datastream.config import configure
 from datastream.exceptions import DatastreamAPIError, DatastreamError
 from datastream.types import (
     DatasetName,
@@ -11,6 +12,7 @@ __all__ = [
     "DatasetResponse",
     "DatasetRow",
     "DatasetVersion",
+    "configure",
     "DatastreamAPIError",
     "DatastreamError",
 ]

--- a/builders/sdk/datastream/config.py
+++ b/builders/sdk/datastream/config.py
@@ -1,0 +1,12 @@
+_base_url: str = "http://localhost:3000/api/v1"
+
+
+def configure(base_url: str) -> None:
+    """Set the default base URL for the datastream API."""
+    global _base_url
+    _base_url = base_url
+
+
+def get_base_url() -> str:
+    """Return the current default base URL."""
+    return _base_url

--- a/builders/sdk/tests/test_config.py
+++ b/builders/sdk/tests/test_config.py
@@ -1,0 +1,23 @@
+from datastream import config
+
+
+def test_default_base_url():
+    assert config.get_base_url() == "http://localhost:3000/api/v1"
+
+
+def test_configure_changes_url():
+    original = config.get_base_url()
+    try:
+        config.configure("https://example.com/api/v1")
+        assert config.get_base_url() == "https://example.com/api/v1"
+    finally:
+        config.configure(original)
+
+
+def test_get_base_url_returns_configured():
+    original = config.get_base_url()
+    try:
+        config.configure("http://custom:8080")
+        assert config.get_base_url() == "http://custom:8080"
+    finally:
+        config.configure(original)


### PR DESCRIPTION
Add SDK config module with module-level default base URL (`http://localhost:3000/api/v1`), `configure()` to override it, and `get_base_url()` to read it.

Includes tests for default value and reconfiguration.