### PR TITLE
feat: add sdk client with get_data

### DIFF
--- a/builders/sdk/datastream/__init__.py
+++ b/builders/sdk/datastream/__init__.py
@@ -1,3 +1,4 @@
+from datastream.client import DatastreamClient, get_data
 from datastream.config import configure
 from datastream.exceptions import DatastreamAPIError, DatastreamError
 from datastream.types import (
@@ -12,7 +13,9 @@ __all__ = [
     "DatasetResponse",
     "DatasetRow",
     "DatasetVersion",
-    "configure",
     "DatastreamAPIError",
+    "DatastreamClient",
     "DatastreamError",
+    "configure",
+    "get_data",
 ]

--- a/builders/sdk/datastream/client.py
+++ b/builders/sdk/datastream/client.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import httpx
+
+from datastream.config import get_base_url
+from datastream.exceptions import DatastreamAPIError
+from datastream.types import (
+    DatasetName,
+    DatasetResponse,
+    DatasetRow,
+    DatasetVersion,
+)
+
+
+class DatastreamClient:
+    """HTTP client for the datastream API."""
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        self._base_url = base_url or get_base_url()
+        self._transport = transport
+
+    def get_data(
+        self,
+        name: str | DatasetName,
+        version: str | DatasetVersion,
+        start: datetime,
+        end: datetime,
+        *,
+        build_data: bool = True,
+    ) -> DatasetResponse:
+        """Fetch dataset data for a time range."""
+        if isinstance(version, str):
+            version = DatasetVersion.parse(version)
+
+        url = f"{self._base_url}/data/{name}/{version}"
+        params = {
+            "start": start.isoformat(),
+            "end": end.isoformat(),
+            "build-data": str(build_data).lower(),
+        }
+
+        with httpx.Client(transport=self._transport) as http:
+            resp = http.get(url, params=params)
+
+        if resp.status_code not in (200, 206):
+            raise DatastreamAPIError(
+                status_code=resp.status_code,
+                detail=resp.text,
+            )
+
+        body = resp.json()
+        rows = [
+            DatasetRow(
+                timestamp=datetime.fromisoformat(r["timestamp"]),
+                data=r["data"],
+            )
+            for r in body["rows"]
+        ]
+
+        return DatasetResponse(
+            dataset_name=body["dataset_name"],
+            dataset_version=DatasetVersion.parse(body["dataset_version"]),
+            total_timestamps=body["total_timestamps"],
+            returned_timestamps=body["returned_timestamps"],
+            rows=rows,
+        )
+
+
+def get_data(
+    name: str | DatasetName,
+    version: str | DatasetVersion,
+    start: datetime,
+    end: datetime,
+    *,
+    build_data: bool = True,
+) -> DatasetResponse:
+    """Convenience function using default config."""
+    return DatastreamClient().get_data(name, version, start, end, build_data=build_data)

--- a/builders/sdk/tests/test_client.py
+++ b/builders/sdk/tests/test_client.py
@@ -1,0 +1,118 @@
+import json
+from datetime import datetime
+
+import httpx
+import pytest
+from datastream.client import DatastreamClient, get_data
+from datastream.exceptions import DatastreamAPIError
+from datastream.types import DatasetVersion
+
+
+def _mock_transport(status_code: int, body: dict) -> httpx.MockTransport:
+    """Create a mock transport that returns a fixed response."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            status_code=status_code,
+            content=json.dumps(body).encode(),
+            headers={"content-type": "application/json"},
+        )
+
+    return httpx.MockTransport(handler)
+
+
+SAMPLE_RESPONSE = {
+    "dataset_name": "mock-ohlc",
+    "dataset_version": "0.1.0",
+    "total_timestamps": 2,
+    "returned_timestamps": 2,
+    "rows": [
+        {
+            "timestamp": "2024-01-02T00:00:00",
+            "data": [{"ticker": "AAPL", "open": 100, "close": 130}],
+        },
+        {
+            "timestamp": "2024-01-03T00:00:00",
+            "data": [{"ticker": "AAPL", "open": 131, "close": 135}],
+        },
+    ],
+}
+
+
+def test_get_data_success():
+    transport = _mock_transport(200, SAMPLE_RESPONSE)
+    client = DatastreamClient(base_url="http://test:3000/api/v1", transport=transport)
+    resp = client.get_data(
+        "mock-ohlc", "0.1.0", datetime(2024, 1, 2), datetime(2024, 1, 3)
+    )
+
+    assert resp.dataset_name == "mock-ohlc"
+    assert str(resp.dataset_version) == "0.1.0"
+    assert resp.total_timestamps == 2
+    assert resp.returned_timestamps == 2
+    assert len(resp.rows) == 2
+    assert resp.rows[0].timestamp == datetime(2024, 1, 2)
+    assert resp.rows[0].data == [{"ticker": "AAPL", "open": 100, "close": 130}]
+
+
+def test_get_data_partial_206():
+    partial = {**SAMPLE_RESPONSE, "returned_timestamps": 1}
+    partial["rows"] = [SAMPLE_RESPONSE["rows"][0]]
+    transport = _mock_transport(206, partial)
+    client = DatastreamClient(base_url="http://test:3000/api/v1", transport=transport)
+    resp = client.get_data(
+        "mock-ohlc",
+        "0.1.0",
+        datetime(2024, 1, 2),
+        datetime(2024, 1, 3),
+        build_data=False,
+    )
+
+    assert resp.returned_timestamps == 1
+    assert resp.total_timestamps == 2
+    assert len(resp.rows) == 1
+
+
+def test_get_data_error_400():
+    transport = _mock_transport(400, {"detail": "bad request"})
+    client = DatastreamClient(base_url="http://test:3000/api/v1", transport=transport)
+    with pytest.raises(DatastreamAPIError) as exc_info:
+        client.get_data("bad", "0.0.1", datetime(2024, 1, 1), datetime(2024, 1, 2))
+
+    assert exc_info.value.status_code == 400
+
+
+def test_get_data_error_500():
+    transport = _mock_transport(500, {"detail": "internal error"})
+    client = DatastreamClient(base_url="http://test:3000/api/v1", transport=transport)
+    with pytest.raises(DatastreamAPIError) as exc_info:
+        client.get_data("bad", "0.0.1", datetime(2024, 1, 1), datetime(2024, 1, 2))
+
+    assert exc_info.value.status_code == 500
+
+
+def test_get_data_accepts_version_object():
+    transport = _mock_transport(200, SAMPLE_RESPONSE)
+    client = DatastreamClient(base_url="http://test:3000/api/v1", transport=transport)
+    resp = client.get_data(
+        "mock-ohlc",
+        DatasetVersion(0, 1, 0),
+        datetime(2024, 1, 2),
+        datetime(2024, 1, 3),
+    )
+    assert resp.dataset_name == "mock-ohlc"
+
+
+def test_module_level_get_data(monkeypatch):
+    transport = _mock_transport(200, SAMPLE_RESPONSE)
+    # patch DatastreamClient to inject transport
+    original_init = DatastreamClient.__init__
+
+    def patched_init(self, base_url=None, transport=None):
+        original_init(self, base_url=base_url, transport=transport or _transport)
+
+    _transport = transport
+    monkeypatch.setattr(DatastreamClient, "__init__", patched_init)
+
+    resp = get_data("mock-ohlc", "0.1.0", datetime(2024, 1, 2), datetime(2024, 1, 3))
+    assert resp.dataset_name == "mock-ohlc"


### PR DESCRIPTION
Add `DatastreamClient` class and module-level `get_data()` convenience function.

- `get_data()` calls `GET /data/{name}/{version}` with start/end/build-data params
- Returns `DatasetResponse` for both 200 and 206 (partial data indicated by metadata fields)
- Raises `DatastreamAPIError` on non-2xx responses
- Accepts version as string or `DatasetVersion` object
- Supports injecting `httpx.BaseTransport` for testing

Tests use `httpx.MockTransport` to cover success, partial 206, 400/500 errors, and version object input.