### PR TITLE
chore: add ci lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+      - run: SKIP=pytest uv run pre-commit run --all-files


### PR DESCRIPTION
adds `.github/workflows/ci.yml` with a single `lint` job. runs all pre-commit hooks except the local pytest hook (`SKIP=pytest`) so linting, formatting, mypy, sqlfluff, and path checks all run in CI. pre-commit cache keyed on `.pre-commit-config.yaml` to avoid re-downloading tool envs on every run.