### PR TITLE
chore: add ci unit tests job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,11 @@ jobs:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
       - run: SKIP=pytest uv run pre-commit run --all-files
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync
+      - run: uv run pytest --ignore=builders/server/tests/integration


### PR DESCRIPTION
adds a `unit-tests` job to the CI workflow, mirroring `just test`. runs pytest over the full test suite excluding `builders/server/tests/integration/` — no Docker or DB needed. runs in parallel with `lint`.