### PR TITLE
chore: add ci integration tests job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,11 @@ jobs:
       - uses: astral-sh/setup-uv@v5
       - run: uv sync
       - run: uv run pytest --ignore=builders/server/tests/integration
+
+  integration-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync
+      - run: uv run pytest -m integration builders/server/tests/integration/


### PR DESCRIPTION
adds an `integration-tests` job that runs only tests marked `integration` under `builders/server/tests/integration/`. testcontainers spins up a real Postgres 16 container so these tests hit an actual DB. Docker daemon is available on `ubuntu-latest` runners so no extra setup is needed. runs in parallel with `lint` and `unit-tests`.