### PR TITLE
docs: update curl examples to use caddy port

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,22 +40,22 @@ This additionally exposes `localhost:3000` (builder), `localhost:5432` (Postgres
 Build mock OHLC data (root dataset):
 
 ```bash
-curl -X POST "http://localhost:3000/api/v1/build/mock-ohlc/0.1.0?start=2024-01-01&end=2024-01-31"
+curl -X POST "http://localhost/api/v1/build/mock-ohlc/0.1.0?start=2024-01-01&end=2024-01-31"
 ```
 
 Build a derived dataset (automatically builds `mock-ohlc` first if data is missing):
 
 ```bash
-curl -X POST "http://localhost:3000/api/v1/build/mock-daily-close/0.1.0?start=2024-01-01&end=2024-01-31"
+curl -X POST "http://localhost/api/v1/build/mock-daily-close/0.1.0?start=2024-01-01&end=2024-01-31"
 ```
 
 Fetch data for a dataset:
 
 ```bash
-curl "http://localhost:3000/api/v1/data/mock-ohlc/0.1.0?start=2024-01-01&end=2024-01-31"
+curl "http://localhost/api/v1/data/mock-ohlc/0.1.0?start=2024-01-01&end=2024-01-31"
 ```
 
-These examples assume dev mode (`just docker-up-dev`) or `just backend-dev` so port 3000 is accessible. In production, use the Caddy endpoint on port 80/443 instead.
+These examples go through Caddy on port 80. In dev mode (`just docker-up-dev` or `just backend-dev`), replace `localhost` with `localhost:3000` to hit the builder server directly.
 
 ### 3. Verify data
 


### PR DESCRIPTION
update curl examples in the readme to use localhost (port 80 via Caddy) instead of localhost:3000, which only works in dev mode. added a note clarifying that dev mode is the exception.