### PR TITLE
feat: add to_pandas() to DatasetResponse

### DIFF
--- a/builders/sdk/datastream/types.py
+++ b/builders/sdk/datastream/types.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, NewType
+from typing import TYPE_CHECKING, Any, NewType
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 DatasetName = NewType("DatasetName", str)
 
@@ -45,3 +48,16 @@ class DatasetResponse:
     total_timestamps: int
     returned_timestamps: int
     rows: list[DatasetRow]
+
+    def to_pandas(self) -> pd.DataFrame:
+        """Flatten rows into a pandas DataFrame with timestamp + data columns."""
+        try:
+            import pandas as pd
+        except ImportError as err:
+            raise ImportError(
+                "pandas is required: pip install datastream-sdk[pandas]"
+            ) from err
+        records = [
+            {"timestamp": row.timestamp, **d} for row in self.rows for d in row.data
+        ]
+        return pd.DataFrame(records)

--- a/builders/sdk/tests/test_types.py
+++ b/builders/sdk/tests/test_types.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from unittest.mock import patch
 
 import pytest
 from datastream.types import DatasetResponse, DatasetRow, DatasetVersion
@@ -60,3 +61,46 @@ def test_dataset_response_construction():
     assert resp.returned_timestamps == 1
     assert len(resp.rows) == 1
     assert resp.rows[0].data == [{"ticker": "AAPL", "close": 150}]
+
+
+def _make_response(rows: list[DatasetRow]) -> DatasetResponse:
+    return DatasetResponse(
+        dataset_name="mock-ohlc",
+        dataset_version=DatasetVersion.parse("0.1.0"),
+        total_timestamps=len(rows),
+        returned_timestamps=len(rows),
+        rows=rows,
+    )
+
+
+def test_to_pandas_flat_rows():
+    pytest.importorskip("pandas")
+    rows = [
+        DatasetRow(
+            timestamp=datetime(2024, 1, 2),
+            data=[
+                {"ticker": "AAPL", "close": 130},
+                {"ticker": "MSFT", "close": 220},
+            ],
+        ),
+    ]
+    df = _make_response(rows).to_pandas()
+    assert list(df.columns) == ["timestamp", "ticker", "close"]
+    assert len(df) == 2
+    assert df["ticker"].tolist() == ["AAPL", "MSFT"]
+    assert df["timestamp"].tolist() == [datetime(2024, 1, 2), datetime(2024, 1, 2)]
+
+
+def test_to_pandas_empty_rows():
+    pandas = pytest.importorskip("pandas")
+    df = _make_response([]).to_pandas()
+    assert isinstance(df, pandas.DataFrame)
+    assert len(df) == 0
+
+
+def test_to_pandas_import_error():
+    with (
+        patch.dict("sys.modules", {"pandas": None}),
+        pytest.raises(ImportError, match="pip install datastream-sdk\\[pandas\\]"),
+    ):
+        _make_response([]).to_pandas()


### PR DESCRIPTION
Adds `to_pandas()` to `DatasetResponse` for converting time-series rows into a flat pandas DataFrame. Each data dict is expanded with its timestamp, so multi-row timestamps (e.g. multiple tickers) become separate rows. Raises `ImportError` with install hint if pandas is not installed.