### PR TITLE
feat: add to_polars() to DatasetResponse

### DIFF
--- a/builders/sdk/datastream/types.py
+++ b/builders/sdk/datastream/types.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, NewType
 
 if TYPE_CHECKING:
     import pandas as pd
+    import polars as pl
 
 DatasetName = NewType("DatasetName", str)
 
@@ -61,3 +62,16 @@ class DatasetResponse:
             {"timestamp": row.timestamp, **d} for row in self.rows for d in row.data
         ]
         return pd.DataFrame(records)
+
+    def to_polars(self) -> pl.DataFrame:
+        """Flatten rows into a polars DataFrame with timestamp + data columns."""
+        try:
+            import polars as pl
+        except ImportError as err:
+            raise ImportError(
+                "polars is required: pip install datastream-sdk[polars]"
+            ) from err
+        records = [
+            {"timestamp": row.timestamp, **d} for row in self.rows for d in row.data
+        ]
+        return pl.DataFrame(records)

--- a/builders/sdk/tests/test_types.py
+++ b/builders/sdk/tests/test_types.py
@@ -104,3 +104,35 @@ def test_to_pandas_import_error():
         pytest.raises(ImportError, match="pip install datastream-sdk\\[pandas\\]"),
     ):
         _make_response([]).to_pandas()
+
+
+def test_to_polars_flat_rows():
+    pytest.importorskip("polars")
+    rows = [
+        DatasetRow(
+            timestamp=datetime(2024, 1, 2),
+            data=[
+                {"ticker": "AAPL", "close": 130},
+                {"ticker": "MSFT", "close": 220},
+            ],
+        ),
+    ]
+    df = _make_response(rows).to_polars()
+    assert set(df.columns) == {"timestamp", "ticker", "close"}
+    assert len(df) == 2
+    assert df["ticker"].to_list() == ["AAPL", "MSFT"]
+
+
+def test_to_polars_empty_rows():
+    polars = pytest.importorskip("polars")
+    df = _make_response([]).to_polars()
+    assert isinstance(df, polars.DataFrame)
+    assert len(df) == 0
+
+
+def test_to_polars_import_error():
+    with (
+        patch.dict("sys.modules", {"polars": None}),
+        pytest.raises(ImportError, match="pip install datastream-sdk\\[polars\\]"),
+    ):
+        _make_response([]).to_polars()


### PR DESCRIPTION
Adds `to_polars()` to `DatasetResponse`, mirroring `to_pandas()`. Flattens time-series rows into a polars DataFrame with timestamp + data columns. Raises `ImportError` with install hint if polars is not installed.