### PR TITLE
feat: add get_datasets_with_data db query

### DIFF
--- a/builders/server/db/datasets.py
+++ b/builders/server/db/datasets.py
@@ -106,6 +106,14 @@ def get_rows_range(
         return dict(result)
 
 
+def get_datasets_with_data() -> set[tuple[str, str]]:
+    """Return (name, version) pairs for all datasets that have at least one row."""
+    logger.debug("querying datasets with data")
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute("SELECT DISTINCT dataset_name, dataset_version FROM datasets")
+        return {(row[0], row[1]) for row in cur.fetchall()}
+
+
 def get_rows_timestamps(
     dataset_name: str,
     dataset_version: SemVer,

--- a/builders/server/tests/db/test_datasets.py
+++ b/builders/server/tests/db/test_datasets.py
@@ -144,3 +144,38 @@ def test_get_rows_range_returns_dict_by_timestamp(mock_get_conn: MagicMock) -> N
     assert len(result[ts2]) == 1
     assert result[ts1][0] == {"val": 10}
     assert result[ts2][0] == {"val": 20}
+
+
+@patch("db.datasets.get_conn")
+def test_get_datasets_with_data_returns_set(mock_get_conn: MagicMock) -> None:
+    """Returns set of (name, version) tuples from cursor rows."""
+    mock_cursor = MagicMock()
+    mock_cursor.fetchall.return_value = [
+        ("mock-ohlc", "0.1.0"),
+        ("mock-daily-close", "0.1.0"),
+    ]
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_get_conn.side_effect = _mock_get_conn(mock_conn)
+
+    result = datasets.get_datasets_with_data()
+    assert result == {("mock-ohlc", "0.1.0"), ("mock-daily-close", "0.1.0")}
+    executed_sql = mock_cursor.execute.call_args[0][0]
+    assert "DISTINCT" in executed_sql
+    assert "dataset_name" in executed_sql
+    assert "dataset_version" in executed_sql
+
+
+@patch("db.datasets.get_conn")
+def test_get_datasets_with_data_empty_table(mock_get_conn: MagicMock) -> None:
+    """Empty table returns empty set."""
+    mock_cursor = MagicMock()
+    mock_cursor.fetchall.return_value = []
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_get_conn.side_effect = _mock_get_conn(mock_conn)
+
+    result = datasets.get_datasets_with_data()
+    assert result == set()


### PR DESCRIPTION
adds `get_datasets_with_data() -> set[tuple[str, str]]` to the db layer. single `SELECT DISTINCT dataset_name, dataset_version` query that returns all (name, version) pairs with at least one row. returns a set for O(1) membership tests in the service layer (coming in next PR).