### PR TITLE
feat: add GET /api/v1/datasets endpoint

### DIFF
--- a/builders/server/api/routes.py
+++ b/builders/server/api/routes.py
@@ -4,6 +4,7 @@ import structlog
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import JSONResponse
 from service.builder import NoValidTimestampsError, build_dataset, get_data
+from service.catalog import list_datasets
 from utils.semver import SemVer
 
 logger = structlog.get_logger()
@@ -15,6 +16,22 @@ router = APIRouter()
 def status():
     """Health check endpoint."""
     return {"status": "ok"}
+
+
+@router.get("/datasets")
+def datasets_list() -> dict:
+    """List all discovered datasets with their data presence status."""
+    try:
+        items = list_datasets()
+    except Exception as e:
+        logger.exception("datasets list failed")
+        raise HTTPException(status_code=500, detail=str(e)) from e
+    return {
+        "datasets": [
+            {"name": item.name, "version": item.version, "has_data": item.has_data}
+            for item in items
+        ]
+    }
 
 
 @router.post("/build/{dataset_name}/{dataset_version}")

--- a/builders/server/tests/api/test_routes.py
+++ b/builders/server/tests/api/test_routes.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 from fastapi.testclient import TestClient
 from main import app
 from service.builder import DataResult, NoValidTimestampsError
+from service.catalog import DatasetInfo
 
 client: TestClient = TestClient(app)
 
@@ -161,3 +162,46 @@ def test_data_endpoint_no_valid_timestamps_422(mock_get_data: MagicMock) -> None
     resp = client.get("/api/v1/data/ds/0.1.0?start=2024-01-06&end=2024-01-07")
     assert resp.status_code == 422
     assert "no valid timestamps in range" in resp.json()["detail"]
+
+
+# --- GET /datasets tests ---
+
+
+@patch("api.routes.list_datasets")
+def test_datasets_endpoint_returns_list(mock_list: MagicMock) -> None:
+    """Returns 200 with datasets array."""
+    mock_list.return_value = [
+        DatasetInfo(name="mock-ohlc", version="0.1.0", has_data=True),
+        DatasetInfo(name="faang-daily-close", version="0.1.0", has_data=False),
+    ]
+    resp = client.get("/api/v1/datasets")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "datasets" in body
+    assert len(body["datasets"]) == 2
+    assert body["datasets"][0] == {
+        "name": "mock-ohlc",
+        "version": "0.1.0",
+        "has_data": True,
+    }
+    assert body["datasets"][1] == {
+        "name": "faang-daily-close",
+        "version": "0.1.0",
+        "has_data": False,
+    }
+
+
+@patch("api.routes.list_datasets")
+def test_datasets_endpoint_empty(mock_list: MagicMock) -> None:
+    """Returns 200 with empty list when no datasets discovered."""
+    mock_list.return_value = []
+    resp = client.get("/api/v1/datasets")
+    assert resp.status_code == 200
+    assert resp.json() == {"datasets": []}
+
+
+@patch("api.routes.list_datasets", side_effect=OSError("disk error"))
+def test_datasets_endpoint_internal_error(mock_list: MagicMock) -> None:
+    """Unexpected failure returns 500."""
+    resp = client.get("/api/v1/datasets")
+    assert resp.status_code == 500

--- a/dev-docs/SPEC-backend.md
+++ b/dev-docs/SPEC-backend.md
@@ -13,12 +13,42 @@ GET /status
 ```
 
 ```
+GET /datasets
+```
+
+```
 POST /build/{dataset_name}/{dataset_version}?start=<timestamp>&end=<timestamp>
 ```
 
 ```
 GET /data/{dataset_name}/{dataset_version}?start=<timestamp>&end=<timestamp>&build-data=<bool>
 ```
+
+### Datasets endpoint
+
+`GET /datasets` returns all datasets discovered on the filesystem, annotated with whether each has any data in the database.
+
+**Response format:**
+
+```json
+{
+  "datasets": [
+    {"name": "mock-ohlc", "version": "0.1.0", "has_data": true},
+    {"name": "faang-daily-close", "version": "0.1.0", "has_data": false}
+  ]
+}
+```
+
+- `has_data`: `true` when at least one row exists in the DB for that `(name, version)` pair, `false` otherwise
+- datasets are sorted alphabetically by name, then by version
+- datasets are discovered by scanning `SCRIPTS_DIR` for directories containing a `config.toml`
+
+**Status codes:**
+
+| Status | Meaning |
+|--------|---------|
+| `200` | success |
+| `500` | unexpected failure (filesystem error, DB error) |
 
 ### Data endpoint
 


### PR DESCRIPTION
adds `GET /api/v1/datasets` endpoint. lists all datasets discovered from SCRIPTS_DIR and annotates each with `has_data: bool` (true when at least one DB row exists for that (name, version)). also updates SPEC-backend.md with the new endpoint docs.