### PR TITLE
docs: add design section to frontend spec

### DIFF
--- a/dev-docs/SPEC-frontend.md
+++ b/dev-docs/SPEC-frontend.md
@@ -6,3 +6,14 @@ A lightweight internal UI built with Svelte + Vite, using Bun as the package man
 - **Docker**: the frontend is built as static files (`bun run build`) and served by nginx on port 80. nginx proxies `/api` to `http://builder:3000` via Docker internal DNS.
 - Current functionality: a status button that calls `GET /status` on the Python backend and displays the status.
 - The frontend is not containerized — it runs locally via `just frontend-dev` and proxies to the backend container on port 3000.
+
+## Design
+
+This is a purely internal tool. The goal is functional clarity, not aesthetics.
+
+- **No CSS framework or component library** — plain CSS only, kept minimal
+- **No custom fonts** — system font stack (`sans-serif`)
+- **No color palette** — black text on white background; use standard browser defaults where possible
+- **Layout** — single-column, top-to-bottom; no sidebars or complex layouts
+- **Spacing** — basic padding/margin for readability, nothing decorative
+- **Interactive states** — rely on native browser styles (e.g. default button hover/focus); no custom animations or transitions


### PR DESCRIPTION
adds a design section to the frontend spec. since this is an internal tool, the philosophy is functional clarity only -- no css framework, system fonts, white/black defaults, single-column layout, no custom animations.