### PR TITLE
feat: add global styles and app layout

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,17 +1,43 @@
 <script>
-  let status = $state('');
+  // view state: 'list' or 'detail'
+  let view = $state('list');
+  let selectedDataset = $state(null);
 
-  async function ping() {
-    status = '...';
-    try {
-      const res = await fetch('/api/v1/status');
-      status = res.ok ? 'OK' : `Error (${res.status})`;
-    } catch {
-      status = 'Error (network)';
-    }
+  function handleSelect(dataset) {
+    selectedDataset = dataset;
+    view = 'detail';
+  }
+
+  function handleBack() {
+    selectedDataset = null;
+    view = 'list';
   }
 </script>
 
-<h1>Datastream</h1>
-<button onclick={ping}>Ping API</button>
-<p>{status}</p>
+<header>
+  <h1>Datastream</h1>
+</header>
+
+<main>
+  {#if view === 'list'}
+    <p class="placeholder">dataset list goes here</p>
+  {:else if view === 'detail'}
+    <p class="placeholder">dataset detail goes here</p>
+  {/if}
+</main>
+
+<style>
+  header {
+    margin-bottom: var(--space-xl);
+  }
+
+  h1 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+  }
+
+  .placeholder {
+    color: var(--color-text-muted);
+  }
+</style>

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,0 +1,59 @@
+/* reset */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  /* colors */
+  --color-bg: #0f1117;
+  --color-surface: #1a1d27;
+  --color-surface-hover: #242836;
+  --color-border: #2e3345;
+  --color-text: #e1e4ed;
+  --color-text-muted: #8b90a0;
+  --color-accent: #6c8cff;
+  --color-accent-hover: #8da6ff;
+  --color-success: #4caf7c;
+  --color-error: #e05555;
+
+  /* json highlighting */
+  --json-key: #6c8cff;
+  --json-string: #4caf7c;
+  --json-number: #e0a356;
+  --json-boolean: #c084fc;
+  --json-null: #8b90a0;
+
+  /* typography */
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
+
+  /* spacing */
+  --space-xs: 0.25rem;
+  --space-sm: 0.5rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
+
+  /* radii */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+}
+
+body {
+  font-family: var(--font-sans);
+  background: var(--color-bg);
+  color: var(--color-text);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+#app {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: var(--space-lg) var(--space-xl);
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,4 +1,5 @@
 import { mount } from 'svelte'
+import './app.css'
 import App from './App.svelte'
 
 const app = mount(App, {


### PR DESCRIPTION
adds the foundational layout and styling for the frontend MVP.

- new `app.css` with CSS reset, dark theme custom properties, and typography defaults
- import global styles in `main.js`
- restructure `App.svelte` as a navigation shell with header + view switching state

subsequent PRs will add the actual dataset list and detail views.