### PR TITLE
feat: add API client and utility helpers

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,0 +1,37 @@
+const BASE = '/api/v1';
+
+/**
+ * fetch all datasets from the catalog.
+ * @returns {Promise<{datasets: Array<{name: string, version: string, has_data: boolean}>}>}
+ */
+export async function fetchDatasets() {
+  const res = await fetch(`${BASE}/datasets`);
+  if (!res.ok) {
+    throw new Error(`failed to fetch datasets: ${res.status}`);
+  }
+  return res.json();
+}
+
+/**
+ * fetch data for a specific dataset in a time range.
+ * uses build-data=false so the frontend never triggers builds.
+ * accepts both 200 (complete) and 206 (partial) as valid responses.
+ * @param {string} name
+ * @param {string} version
+ * @param {string} start - ISO date string (YYYY-MM-DD)
+ * @param {string} end - ISO date string (YYYY-MM-DD)
+ * @returns {Promise<{dataset_name: string, dataset_version: string, total_timestamps: number, returned_timestamps: number, rows: Array}>}
+ */
+export async function fetchData(name, version, start, end) {
+  const params = new URLSearchParams({
+    start,
+    end,
+    'build-data': 'false',
+  });
+  const res = await fetch(`${BASE}/data/${name}/${version}?${params}`);
+  // 200 = complete, 206 = partial data
+  if (res.status !== 200 && res.status !== 206) {
+    throw new Error(`failed to fetch data: ${res.status}`);
+  }
+  return res.json();
+}

--- a/frontend/src/lib/format.js
+++ b/frontend/src/lib/format.js
@@ -1,0 +1,88 @@
+/**
+ * format an ISO timestamp string for display.
+ * @param {string} isoString
+ * @returns {string}
+ */
+export function formatTimestamp(isoString) {
+  const d = new Date(isoString);
+  return d.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+/**
+ * convert a Date to YYYY-MM-DD string for API queries and date inputs.
+ * @param {Date} date
+ * @returns {string}
+ */
+export function toISODate(date) {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * return default date range: last 30 days as { start, end } strings.
+ * @returns {{start: string, end: string}}
+ */
+export function defaultDateRange() {
+  const end = new Date();
+  const start = new Date();
+  start.setDate(start.getDate() - 30);
+  return { start: toISODate(start), end: toISODate(end) };
+}
+
+/**
+ * produce syntax-highlighted HTML for a JSON-serializable value.
+ * wraps tokens in spans with css classes for coloring.
+ * @param {any} value
+ * @param {number} indent - current indentation level
+ * @returns {string}
+ */
+export function highlightJson(value, indent = 0) {
+  const pad = '  '.repeat(indent);
+  const padInner = '  '.repeat(indent + 1);
+
+  if (value === null) {
+    return `<span class="json-null">null</span>`;
+  }
+
+  if (typeof value === 'boolean') {
+    return `<span class="json-boolean">${value}</span>`;
+  }
+
+  if (typeof value === 'number') {
+    return `<span class="json-number">${value}</span>`;
+  }
+
+  if (typeof value === 'string') {
+    const escaped = value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+    return `<span class="json-string">"${escaped}"</span>`;
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '[]';
+    const items = value
+      .map((v) => `${padInner}${highlightJson(v, indent + 1)}`)
+      .join(',\n');
+    return `[\n${items}\n${pad}]`;
+  }
+
+  // object
+  const keys = Object.keys(value);
+  if (keys.length === 0) return '{}';
+  const entries = keys
+    .map((k) => {
+      const keyHtml = `<span class="json-key">"${k}"</span>`;
+      const valHtml = highlightJson(value[k], indent + 1);
+      return `${padInner}${keyHtml}: ${valHtml}`;
+    })
+    .join(',\n');
+  return `{\n${entries}\n${pad}}`;
+}


### PR DESCRIPTION
adds the shared data-fetching and formatting utilities used by all frontend components.

- \`lib/api.js\`: fetch wrappers for \`/api/v1/datasets\` and \`/api/v1/data/{name}/{version}\`. always passes \`build-data=false\` since the frontend is read-only. accepts both 200 and 206 (partial data) as valid responses.
- \`lib/format.js\`: date formatting helpers (\`formatTimestamp\`, \`toISODate\`, \`defaultDateRange\`) and a recursive \`highlightJson\` function that produces syntax-highlighted HTML with css class spans for keys, strings, numbers, booleans, and null.