### PR TITLE
feat: add dataset detail view with data table

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,5 +1,6 @@
 <script>
   import DatasetList from './components/DatasetList.svelte';
+  import DatasetDetail from './components/DatasetDetail.svelte';
 
   // view state: 'list' or 'detail'
   let view = $state('list');
@@ -23,8 +24,12 @@
 <main>
   {#if view === 'list'}
     <DatasetList onselect={handleSelect} />
-  {:else if view === 'detail'}
-    <p class="placeholder">dataset detail goes here</p>
+  {:else if view === 'detail' && selectedDataset}
+    <DatasetDetail
+      name={selectedDataset.name}
+      version={selectedDataset.version}
+      onback={handleBack}
+    />
   {/if}
 </main>
 
@@ -37,9 +42,5 @@
     font-size: 1.5rem;
     font-weight: 600;
     letter-spacing: -0.02em;
-  }
-
-  .placeholder {
-    color: var(--color-text-muted);
   }
 </style>

--- a/frontend/src/components/DataTable.svelte
+++ b/frontend/src/components/DataTable.svelte
@@ -1,0 +1,96 @@
+<script>
+  let { rows, onrowclick } = $props();
+
+  // derive column headers from keys of the first data entry
+  let columns = $derived(() => {
+    if (!rows || rows.length === 0) return [];
+    for (const row of rows) {
+      if (row.data && row.data.length > 0) {
+        return Object.keys(row.data[0]);
+      }
+    }
+    return [];
+  });
+</script>
+
+{#if !rows || rows.length === 0}
+  <p class="empty">no data for this range</p>
+{:else}
+  <div class="table-wrap">
+    <table>
+      <thead>
+        <tr>
+          <th>timestamp</th>
+          {#each columns() as col}
+            <th>{col}</th>
+          {/each}
+        </tr>
+      </thead>
+      <tbody>
+        {#each rows as row}
+          {#each row.data as entry, i}
+            <tr onclick={() => onrowclick({ timestamp: row.timestamp, ...entry })}>
+              {#if i === 0}
+                <td class="ts" rowspan={row.data.length}>{row.timestamp}</td>
+              {/if}
+              {#each columns() as col}
+                <td>{entry[col] ?? ''}</td>
+              {/each}
+            </tr>
+          {/each}
+        {/each}
+      </tbody>
+    </table>
+  </div>
+{/if}
+
+<style>
+  .empty {
+    color: var(--color-text-muted);
+    padding: var(--space-lg) 0;
+  }
+
+  .table-wrap {
+    overflow-x: auto;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.875rem;
+  }
+
+  thead th {
+    text-align: left;
+    color: var(--color-text-muted);
+    font-size: 0.75rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: var(--space-sm) var(--space-md);
+    border-bottom: 1px solid var(--color-border);
+    white-space: nowrap;
+  }
+
+  tbody tr {
+    cursor: pointer;
+    transition: background 0.1s;
+  }
+
+  tbody tr:hover {
+    background: var(--color-surface-hover);
+  }
+
+  tbody td {
+    padding: var(--space-sm) var(--space-md);
+    border-bottom: 1px solid var(--color-border);
+    white-space: nowrap;
+  }
+
+  .ts {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    color: var(--color-text-muted);
+    vertical-align: top;
+  }
+</style>

--- a/frontend/src/components/DatasetDetail.svelte
+++ b/frontend/src/components/DatasetDetail.svelte
@@ -1,0 +1,184 @@
+<script>
+  import { fetchData } from '../lib/api.js';
+  import { defaultDateRange } from '../lib/format.js';
+  import DataTable from './DataTable.svelte';
+
+  let { name, version, onback } = $props();
+
+  const defaults = defaultDateRange();
+  let startDate = $state(defaults.start);
+  let endDate = $state(defaults.end);
+  let result = $state(null);
+  let loading = $state(false);
+  let error = $state(null);
+
+  async function load() {
+    loading = true;
+    error = null;
+    try {
+      result = await fetchData(name, version, startDate, endDate);
+    } catch (e) {
+      error = e.message;
+      result = null;
+    } finally {
+      loading = false;
+    }
+  }
+
+  // auto-fetch on mount
+  $effect(() => {
+    load();
+  });
+
+  function handleRowClick(rowData) {
+    // modal wiring added in next PR
+  }
+</script>
+
+<div class="detail">
+  <button class="back" onclick={onback}>&larr; back</button>
+
+  <h2>{name} <span class="ver">{version}</span></h2>
+
+  <div class="controls">
+    <label>
+      start
+      <input type="date" bind:value={startDate} />
+    </label>
+    <label>
+      end
+      <input type="date" bind:value={endDate} />
+    </label>
+    <button class="load-btn" onclick={load} disabled={loading}>
+      {loading ? 'loading...' : 'load'}
+    </button>
+  </div>
+
+  {#if error}
+    <div class="error">
+      <p>{error}</p>
+      <button onclick={load}>retry</button>
+    </div>
+  {/if}
+
+  {#if result}
+    <p class="meta">
+      showing {result.returned_timestamps} of {result.total_timestamps} timestamps
+    </p>
+    <DataTable rows={result.rows} onrowclick={handleRowClick} />
+  {/if}
+</div>
+
+<style>
+  .detail {
+    width: 100%;
+  }
+
+  .back {
+    background: none;
+    border: none;
+    color: var(--color-accent);
+    cursor: pointer;
+    font-size: 0.875rem;
+    padding: 0;
+    margin-bottom: var(--space-md);
+  }
+
+  .back:hover {
+    color: var(--color-accent-hover);
+  }
+
+  h2 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-bottom: var(--space-lg);
+  }
+
+  .ver {
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+    font-weight: 400;
+  }
+
+  .controls {
+    display: flex;
+    align-items: flex-end;
+    gap: var(--space-md);
+    margin-bottom: var(--space-lg);
+    flex-wrap: wrap;
+  }
+
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  input[type='date'] {
+    background: var(--color-surface);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: var(--space-xs) var(--space-sm);
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+  }
+
+  input[type='date']:focus {
+    outline: 1px solid var(--color-accent);
+    border-color: var(--color-accent);
+  }
+
+  .load-btn {
+    background: var(--color-accent);
+    color: #fff;
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: var(--space-xs) var(--space-lg);
+    font-size: 0.85rem;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .load-btn:hover:not(:disabled) {
+    background: var(--color-accent-hover);
+  }
+
+  .load-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .error {
+    color: var(--color-error);
+    display: flex;
+    align-items: center;
+    gap: var(--space-md);
+    margin-bottom: var(--space-md);
+  }
+
+  .error button {
+    background: var(--color-surface);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+    padding: var(--space-xs) var(--space-md);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    font-size: 0.85rem;
+  }
+
+  .error button:hover {
+    background: var(--color-surface-hover);
+  }
+
+  .meta {
+    font-size: 0.8rem;
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-md);
+  }
+</style>


### PR DESCRIPTION
adds the dataset detail view with date range controls and a dynamic data table.

- \`DatasetDetail.svelte\`: back button, dataset name/version header, start/end date inputs, load button. auto-fetches the last 30 days on mount. shows "X of Y timestamps" completeness indicator. handles loading/error states.
- \`DataTable.svelte\`: dynamically derives column headers from data keys. handles multi-row timestamps with rowspan. rows are clickable (modal wiring in next PR). horizontally scrollable for wide datasets.
- wires the detail view into \`App.svelte\` so clicking a dataset from the list navigates to its detail page.