### PR TITLE
feat: show newest data first by default

### DIFF
--- a/frontend/src/components/DatasetDetail.svelte
+++ b/frontend/src/components/DatasetDetail.svelte
@@ -14,6 +14,9 @@
   let error = $state(null);
   let modalRow = $state(null);
 
+  // newest data first
+  let reversedRows = $derived(result?.rows ? [...result.rows].reverse() : []);
+
   async function load() {
     loading = true;
     error = null;
@@ -67,7 +70,7 @@
     <p class="meta">
       showing {result.returned_timestamps} of {result.total_timestamps} timestamps
     </p>
-    <DataTable rows={result.rows} onrowclick={handleRowClick} />
+    <DataTable rows={reversedRows} onrowclick={handleRowClick} />
   {/if}
 
   {#if modalRow}

--- a/frontend/src/lib/format.js
+++ b/frontend/src/lib/format.js
@@ -25,13 +25,14 @@ export function toISODate(date) {
 }
 
 /**
- * return default date range: last 30 days as { start, end } strings.
+ * return default date range: last 5 years as { start, end } strings.
+ * wide range so the initial fetch is likely to find existing data.
  * @returns {{start: string, end: string}}
  */
 export function defaultDateRange() {
   const end = new Date();
   const start = new Date();
-  start.setDate(start.getDate() - 30);
+  start.setFullYear(start.getFullYear() - 5);
   return { start: toISODate(start), end: toISODate(end) };
 }
 


### PR DESCRIPTION
changes the default data display to show the newest data first.

- widen default date range from 30 days to 5 years so the initial fetch is likely to find existing data
- reverse row order so newest timestamps appear at the top of the table
- date selectors still available for custom filtering