### PR TITLE
ci: run frontend pre-commit hooks in github actions

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -21,12 +21,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
+      - uses: oven-sh/setup-bun@v2
       - run: uv sync
+      - run: cd frontend && bun install --frozen-lockfile
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
       - run: SKIP=pytest uv run pre-commit run --all-files
+      - run: SKIP=pytest uv run pre-commit run --all-files --hook-stage pre-push
 
   backend-unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What changed
- updated CI lint job to install Bun in GitHub Actions
- installed frontend dependencies in CI with bun install --frozen-lockfile
- added a second pre-commit invocation for pre-push stage hooks in CI

## Why
- frontend hooks now include both pre-commit and pre-push checks, so CI needs to execute both stages for parity with local developer workflow

## Benefit
- CI catches frontend format/lint/typecheck/build gate failures consistently, even if local hooks are skipped
