### PR TITLE
docs: update frontend spec with hook workflow

### DIFF
--- a/dev-docs/SPEC-frontend.md
+++ b/dev-docs/SPEC-frontend.md
@@ -48,6 +48,29 @@ frontend/src/
 
 Zero additional runtime dependencies beyond Svelte 5 and Vite.
 
+### Tooling and quality gates
+
+Frontend developer tooling is managed in `frontend/package.json` with Bun scripts:
+
+- `bun run format:check` -- Prettier check for all frontend files
+- `bun run format:write` -- Prettier write mode
+- `bun run lint` -- ESLint (flat config + `eslint-plugin-svelte`)
+- `bun run typecheck` -- `svelte-check --workspace ./src --no-tsconfig` (Svelte-focused checks)
+- `bun run build` -- Vite production build
+
+Repository git hooks are managed via root `.pre-commit-config.yaml` and split by stage:
+
+- **pre-commit** (fast checks): `frontend-format-check`, `frontend-eslint`
+- **pre-push** (heavier checks): `frontend-typecheck`, `frontend-build`
+
+Both frontend hook types are installed by default (`default_install_hook_types: [pre-commit, pre-push]`).
+
+CI mirrors local frontend gates in `.github/workflows/ci.yml`:
+
+- installs Bun
+- runs `bun install --frozen-lockfile` in `frontend/`
+- runs `pre-commit` for both `pre-commit` and `pre-push` stages
+
 ### API integration
 
 All API calls go through `lib/api.js` and use the `/api/v1` prefix (proxied to the backend by Vite in dev).


### PR DESCRIPTION
## What changed
- updated dev-docs/SPEC-frontend.md with frontend quality tooling details
- documented frontend scripts for format/lint/typecheck/build
- documented pre-commit vs pre-push hook split for frontend checks
- documented CI parity behavior (Bun install + both hook stages)

## Why
- keep technical specs in sync with implemented hook workflow and developer expectations

## Benefit
- makes local and CI frontend quality gates explicit and easier to follow for contributors
