### PR TITLE
chore: add frontend precommit github actions workflow

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,32 @@
+name: Frontend CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+      - '.pre-commit-config.yaml'
+      - '.github/workflows/frontend-ci.yml'
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - '.pre-commit-config.yaml'
+      - '.github/workflows/frontend-ci.yml'
+
+jobs:
+  frontend-precommit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - uses: oven-sh/setup-bun@v2
+      - run: uv sync
+      - run: cd frontend && bun install --frozen-lockfile
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+      - run: uv run pre-commit run frontend-format-check --all-files
+      - run: uv run pre-commit run frontend-eslint --all-files
+      - run: uv run pre-commit run frontend-typecheck --all-files --hook-stage pre-push
+      - run: uv run pre-commit run frontend-build --all-files --hook-stage pre-push

--- a/dev-docs/SPEC-frontend.md
+++ b/dev-docs/SPEC-frontend.md
@@ -65,11 +65,11 @@ Repository git hooks are managed via root `.pre-commit-config.yaml` and split by
 
 Both frontend hook types are installed by default (`default_install_hook_types: [pre-commit, pre-push]`).
 
-CI mirrors local frontend gates in `.github/workflows/ci.yml`:
+CI mirrors local frontend gates in `.github/workflows/frontend-ci.yml`:
 
 - installs Bun
 - runs `bun install --frozen-lockfile` in `frontend/`
-- runs `pre-commit` for both `pre-commit` and `pre-push` stages
+- runs frontend hook ids directly for both `pre-commit` and `pre-push` stages
 
 ### API integration
 


### PR DESCRIPTION
## What changed
- added a dedicated frontend GitHub Actions workflow at .github/workflows/frontend-ci.yml
- configured workflow triggers for frontend changes and pre-commit config changes
- installed Bun + frontend dependencies in the workflow before running frontend hooks
- executed frontend pre-commit hook ids directly:
  - frontend-format-check
  - frontend-eslint
  - frontend-typecheck (pre-push stage)
  - frontend-build (pre-push stage)
- updated frontend spec to document the dedicated frontend CI workflow

## Why
- backend-scoped CI no longer guarantees frontend hook coverage
- frontend pre-commit hooks require Bun and frontend deps, so they need their own CI path

## Benefit
- frontend formatting, lint, typecheck, and build gates now run reliably in CI for frontend-related changes
