### PR TITLE
chore: rename ci workflow to backend-ci with backend-only triggers

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -4,18 +4,16 @@ on:
   push:
     branches: [main]
     paths:
-      - 'builders/server/**'
-      - 'builders/sdk/**'
+      - 'builders/**'
       - 'pyproject.toml'
-      - '.pre-commit-config.yaml'
-      - '.github/workflows/ci.yml'
+      - 'uv.lock'
+      - '.github/workflows/backend-ci.yml'
   pull_request:
     paths:
-      - 'builders/server/**'
-      - 'builders/sdk/**'
+      - 'builders/**'
       - 'pyproject.toml'
-      - '.pre-commit-config.yaml'
-      - '.github/workflows/ci.yml'
+      - 'uv.lock'
+      - '.github/workflows/backend-ci.yml'
 
 jobs:
   backend-lint:

--- a/dev-docs/SPEC-backend.md
+++ b/dev-docs/SPEC-backend.md
@@ -168,6 +168,18 @@ The server uses `structlog` for structured logging. Configuration lives in `log_
 - `runtime/loader.py`: builder script imported (debug)
 - `runtime/venv_management.py`: venv creation progress (info), failures (exception)
 
+### CI workflow
+
+Backend checks run in `.github/workflows/backend-ci.yml`.
+
+The workflow triggers on:
+- `builders/**`
+- `pyproject.toml`
+- `uv.lock`
+- `.github/workflows/backend-ci.yml`
+
+This keeps backend CI scoped to builder and shared Python dependency changes.
+
 ## Containers
 
 - The service, Postgres database, and Caddy reverse proxy each run in their own Docker containers.


### PR DESCRIPTION
## What changed
- renamed GitHub Actions workflow from .github/workflows/ci.yml to .github/workflows/backend-ci.yml
- narrowed push and pull_request path filters to:
  - builders/**
  - pyproject.toml
  - uv.lock
  - .github/workflows/backend-ci.yml
- updated backend spec docs with a CI workflow section describing the new trigger scope

## Why
- keep backend CI focused on builder and shared Python dependency changes
- avoid running backend checks for unrelated frontend-only edits

## Benefit
- lower CI noise and faster feedback relevance for backend work
- workflow naming now matches intent (backend CI)