### PR TITLE
refactor: centralize config cache clearing helpers

### DIFF
--- a/builders/server/runtime/config.py
+++ b/builders/server/runtime/config.py
@@ -375,6 +375,11 @@ def _load_config_no_cycles_check(
     )
 
 
+def clear_config_caches() -> None:
+    """Clear in-process config caches."""
+    _load_config_no_cycles_check.cache_clear()
+
+
 def load_config(dataset_name: str, dataset_version: SemVer) -> DatasetConfig:
     """Load and validate config.toml for a given dataset.
 

--- a/builders/server/tests/runtime/test_config.py
+++ b/builders/server/tests/runtime/test_config.py
@@ -7,7 +7,7 @@ from runtime import config
 from runtime.config import (
     DependencyInfo,
     SchemaType,
-    _load_config_no_cycles_check,
+    clear_config_caches,
     parse_lookback,
 )
 from utils.semver import SemVer
@@ -18,7 +18,7 @@ V010 = SemVer.parse("0.1.0")
 @pytest.fixture(autouse=True)
 def clear_config_cache() -> None:
     """clear lru_cache between tests to prevent cross-test contamination."""
-    _load_config_no_cycles_check.cache_clear()
+    clear_config_caches()
 
 
 # --- SchemaType tests ---


### PR DESCRIPTION
What changed:
- Added a centralized runtime.config cache clear helper for config caches.
- Updated runtime config tests to use the helper in the autouse fixture.

Why:
- Keeps cache lifecycle handling in one place so follow-up caching changes are safer.
- Reduces test fragility from clearing individual cache functions directly.

Benefit:
- Deterministic test setup with less duplicated cache-management logic.