### PR TITLE
perf: cache load_config after cycle validation

### DIFF
--- a/builders/server/runtime/config.py
+++ b/builders/server/runtime/config.py
@@ -375,9 +375,21 @@ def _load_config_no_cycles_check(
     )
 
 
+@lru_cache(maxsize=256)
+def _load_config_with_cycles_check(
+    dataset_name: str, dataset_version: SemVer
+) -> DatasetConfig:
+    """Load config with dependency cycle validation."""
+    check_dependency_graph_cycles(dataset_name, dataset_version)
+    return _load_config_no_cycles_check(dataset_name, dataset_version)
+
+
 def clear_config_caches() -> None:
     """Clear in-process config caches."""
-    _load_config_no_cycles_check.cache_clear()
+    for fn in (_load_config_with_cycles_check, _load_config_no_cycles_check):
+        cache_clear = getattr(fn, "cache_clear", None)
+        if callable(cache_clear):
+            cache_clear()
 
 
 def load_config(dataset_name: str, dataset_version: SemVer) -> DatasetConfig:
@@ -385,5 +397,4 @@ def load_config(dataset_name: str, dataset_version: SemVer) -> DatasetConfig:
 
     Raises ValueError if the dependency graph contains a cycle.
     """
-    check_dependency_graph_cycles(dataset_name, dataset_version)
-    return _load_config_no_cycles_check(dataset_name, dataset_version)
+    return _load_config_with_cycles_check(dataset_name, dataset_version)

--- a/builders/server/tests/runtime/test_config.py
+++ b/builders/server/tests/runtime/test_config.py
@@ -103,6 +103,45 @@ price = "int"
     assert cfg.granularity == timedelta(days=1)
 
 
+def test_load_config_uses_cached_result(
+    mock_scripts_dir: Path, write_config: Callable, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Repeated load_config calls for the same dataset use cached result."""
+    write_config(
+        mock_scripts_dir,
+        "ds",
+        "0.1.0",
+        """
+name = "ds"
+version = "0.1.0"
+builder = "builder.py"
+granularity = "1d"
+start-date = "2020-01-01"
+calendar = "everyday"
+
+[schema]
+price = "int"
+""",
+    )
+
+    call_count = 0
+    original = config.check_dependency_graph_cycles
+
+    def wrapped(dataset_name: str, dataset_version: SemVer) -> None:
+        nonlocal call_count
+        call_count += 1
+        original(dataset_name, dataset_version)
+
+    monkeypatch.setattr(config, "check_dependency_graph_cycles", wrapped)
+    clear_config_caches()
+
+    first = config.load_config("ds", V010)
+    second = config.load_config("ds", V010)
+
+    assert first == second
+    assert call_count == 1
+
+
 def test_load_config_missing_file_raises(mock_scripts_dir: Path) -> None:
     """Nonexistent file raises FileNotFoundError."""
     _ = mock_scripts_dir  # fixture patches SCRIPTS_DIR; value not needed


### PR DESCRIPTION
What changed:
- Added an LRU-cached internal load path that includes cycle validation plus config load.
- Updated load_config to delegate to this cached path.
- Extended runtime config tests with a regression test that repeated load_config calls for the same dataset/version reuse cached results.

Why:
- The first pass through load_config currently repeats expensive graph checks and config work across calls.

Benefit:
- Lower repeated config-loading overhead within a process while keeping public behavior unchanged.