### PR TITLE
feat: add generic retry utility with exponential backoff

### DIFF
--- a/builders/server/tests/utils/test_retry.py
+++ b/builders/server/tests/utils/test_retry.py
@@ -1,0 +1,60 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from utils.retry import retry_with_backoff
+
+
+def test_succeeds_first_try() -> None:
+    """No retries needed when fn succeeds immediately."""
+    fn = MagicMock(return_value=42)
+    result = retry_with_backoff(
+        fn, max_retries=3, initial_delay=1.0, description="test"
+    )
+    assert result == 42
+    assert fn.call_count == 1
+
+
+@patch("utils.retry.time.sleep")
+def test_succeeds_after_retries(_mock_sleep: MagicMock) -> None:
+    """Retries until fn succeeds."""
+    fn = MagicMock(side_effect=[ValueError("fail"), ValueError("fail"), "ok"])
+    result = retry_with_backoff(
+        fn, max_retries=3, initial_delay=1.0, description="test"
+    )
+    assert result == "ok"
+    assert fn.call_count == 3
+
+
+@patch("utils.retry.time.sleep")
+def test_exhausts_retries(_mock_sleep: MagicMock) -> None:
+    """Raises last exception after all retries exhausted."""
+    fn = MagicMock(side_effect=ValueError("persistent failure"))
+    with pytest.raises(ValueError, match="persistent failure"):
+        retry_with_backoff(fn, max_retries=2, initial_delay=1.0, description="test")
+    # initial attempt + 2 retries = 3 calls
+    assert fn.call_count == 3
+
+
+@patch("utils.retry.time.sleep")
+def test_exponential_delay(mock_sleep: MagicMock) -> None:
+    """Sleep delays follow exponential backoff pattern."""
+    fn = MagicMock(side_effect=[RuntimeError] * 5 + ["ok"])
+    retry_with_backoff(
+        fn, max_retries=5, initial_delay=2.0, backoff_factor=2.0, description="test"
+    )
+    delays = [call.args[0] for call in mock_sleep.call_args_list]
+    assert delays == [2.0, 4.0, 8.0, 16.0, 32.0]
+
+
+@patch("utils.retry.logger")
+@patch("utils.retry.time.sleep")
+def test_logs_retry_attempts(_mock_sleep: MagicMock, mock_logger: MagicMock) -> None:
+    """Warning logged on each retry attempt."""
+    fn = MagicMock(side_effect=[RuntimeError("oops"), "ok"])
+    retry_with_backoff(
+        fn, max_retries=3, initial_delay=1.0, description="builder subprocess"
+    )
+    mock_logger.warning.assert_called_once()
+    call_kwargs = mock_logger.warning.call_args[1]
+    assert call_kwargs["description"] == "builder subprocess"
+    assert call_kwargs["attempt"] == 1

--- a/builders/server/utils/retry.py
+++ b/builders/server/utils/retry.py
@@ -1,0 +1,40 @@
+import time
+from collections.abc import Callable
+
+import structlog
+
+logger = structlog.get_logger()
+
+
+def retry_with_backoff[T](
+    fn: Callable[[], T],
+    *,
+    max_retries: int,
+    initial_delay: float,
+    backoff_factor: float = 2.0,
+    description: str,
+) -> T:
+    """Call fn(), retrying with exponential backoff on failure."""
+    last_exception: Exception | None = None
+
+    for attempt in range(max_retries + 1):
+        try:
+            return fn()
+        except Exception as exc:
+            last_exception = exc
+
+            if attempt == max_retries:
+                break
+
+            delay = initial_delay * (backoff_factor**attempt)
+            logger.warning(
+                "retrying after failure",
+                description=description,
+                attempt=attempt + 1,
+                max_retries=max_retries,
+                delay_seconds=delay,
+                error=str(exc),
+            )
+            time.sleep(delay)
+
+    raise last_exception  # type: ignore[misc] # always set when we reach here


### PR DESCRIPTION
## Summary
- Add a generic `retry_with_backoff()` utility in `builders/server/utils/retry.py`
- Calls a function with exponential backoff on failure (configurable max retries, initial delay, backoff factor)
- Logs warnings via structlog on each retry attempt
- Full test coverage: success, retries, exhaustion, delay verification, logging

## Test plan
- [x] `uv run pytest builders/server/tests/utils/test_retry.py` -- all 5 tests pass
- [x] `just fix` -- linting and formatting clean