### PR TITLE
feat: add retry logic to builder subprocess execution

### DIFF
--- a/builders/server/runtime/runner.py
+++ b/builders/server/runtime/runner.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pathlib import Path
 
 import structlog
+from utils.retry import retry_with_backoff
 
 from runtime.serialization import (
     WorkerError,
@@ -16,6 +17,9 @@ from runtime.serialization import (
 logger = structlog.get_logger()
 
 TIMEOUT_SECONDS = 120
+RETRY_MAX_RETRIES = 5
+RETRY_INITIAL_DELAY = 2.0  # seconds
+RETRY_BACKOFF_FACTOR = 2.0
 
 WORKER_PATH = Path(__file__).parent / "isolated_worker.py"
 
@@ -27,7 +31,7 @@ def run_builder(
     timestamp: datetime,
     env_file: Path | None,
 ) -> list[dict]:
-    """Run a builder script in an isolated subprocess and return its result."""
+    """Run a builder script in an isolated subprocess with retry on failure."""
     # use per-builder venv python if available, otherwise system python
     venv_python = script_dir / ".venv" / "bin" / "python"
     python = str(venv_python) if venv_python.exists() else sys.executable
@@ -41,70 +45,84 @@ def run_builder(
         builder_path, script_dir, dependencies, timestamp, env_file
     )
 
-    logger.info(
-        "subprocess started",
-        python=python,
-        builder=str(builder_path),
-        timestamp=str(timestamp),
-    )
-
-    start_time = time.monotonic()
-
-    proc = subprocess.Popen(
-        [python, str(WORKER_PATH)],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-
-    try:
-        stdout, stderr = proc.communicate(input=payload, timeout=TIMEOUT_SECONDS)
-    except subprocess.TimeoutExpired as exc:
-        proc.kill()
-        proc.wait()
-        logger.error(
-            "subprocess timed out",
+    def _execute_subprocess() -> list[dict]:
+        """Run the builder subprocess once, raising on any failure."""
+        logger.info(
+            "subprocess started",
+            python=python,
             builder=str(builder_path),
             timestamp=str(timestamp),
-            timeout_seconds=TIMEOUT_SECONDS,
         )
-        raise RuntimeError(
-            f"Builder timed out after {TIMEOUT_SECONDS}s for timestamp {timestamp}"
-        ) from exc
 
-    duration = time.monotonic() - start_time
+        start_time = time.monotonic()
 
-    # non-zero exit with no stdout means the process crashed hard
-    if proc.returncode != 0 and not stdout:
-        logger.error(
-            "subprocess crashed",
+        proc = subprocess.Popen(
+            [python, str(WORKER_PATH)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        try:
+            stdout, stderr = proc.communicate(input=payload, timeout=TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired as exc:
+            proc.kill()
+            proc.wait()
+            logger.error(
+                "subprocess timed out",
+                builder=str(builder_path),
+                timestamp=str(timestamp),
+                timeout_seconds=TIMEOUT_SECONDS,
+            )
+            raise RuntimeError(
+                f"Builder timed out after {TIMEOUT_SECONDS}s for timestamp {timestamp}"
+            ) from exc
+
+        duration = time.monotonic() - start_time
+
+        # non-zero exit with no stdout means the process crashed hard
+        if proc.returncode != 0 and not stdout:
+            logger.error(
+                "subprocess crashed",
+                builder=str(builder_path),
+                timestamp=str(timestamp),
+                exit_code=proc.returncode,
+                stderr=stderr.decode(errors="replace"),
+            )
+            raise RuntimeError(
+                "Builder subprocess crashed without returning a result "
+                f"for timestamp {timestamp}"
+            )
+
+        logger.info(
+            "subprocess completed",
             builder=str(builder_path),
-            timestamp=str(timestamp),
             exit_code=proc.returncode,
-            stderr=stderr.decode(errors="replace"),
-        )
-        raise RuntimeError(
-            "Builder subprocess crashed without returning a result "
-            f"for timestamp {timestamp}"
+            duration_s=round(duration, 3),
         )
 
-    logger.info(
-        "subprocess completed",
-        builder=str(builder_path),
-        exit_code=proc.returncode,
-        duration_s=round(duration, 3),
+        if stderr and proc.returncode == 0:
+            logger.warning(
+                "subprocess stderr output",
+                builder=str(builder_path),
+                stderr=stderr.decode(errors="replace"),
+            )
+
+        out = deserialize_output(stdout)
+        match out:
+            case WorkerSuccess(result=result):
+                return result
+            case WorkerError(message=msg):
+                raise RuntimeError(f"Builder failed for timestamp {timestamp}: {msg}")
+
+        raise RuntimeError(  # pragma: no cover
+            f"Unexpected worker output for timestamp {timestamp}"
+        )
+
+    return retry_with_backoff(
+        _execute_subprocess,
+        max_retries=RETRY_MAX_RETRIES,
+        initial_delay=RETRY_INITIAL_DELAY,
+        backoff_factor=RETRY_BACKOFF_FACTOR,
+        description=f"builder subprocess {builder_path} @ {timestamp}",
     )
-
-    if stderr and proc.returncode == 0:
-        logger.warning(
-            "subprocess stderr output",
-            builder=str(builder_path),
-            stderr=stderr.decode(errors="replace"),
-        )
-
-    out = deserialize_output(stdout)
-    match out:
-        case WorkerSuccess(result=result):
-            return result
-        case WorkerError(message=msg):
-            raise RuntimeError(f"Builder failed for timestamp {timestamp}: {msg}")

--- a/builders/server/tests/runtime/test_runner.py
+++ b/builders/server/tests/runtime/test_runner.py
@@ -28,8 +28,11 @@ def build(dependencies, timestamp):
     assert result == [{"value": 42}]
 
 
-def test_builder_exception_raises_runtime_error(tmp_path: Path) -> None:
+def test_builder_exception_raises_runtime_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Builder that raises propagates as RuntimeError."""
+    monkeypatch.setattr(runner, "RETRY_MAX_RETRIES", 0)
     script_dir = _write_builder(
         tmp_path,
         """
@@ -57,14 +60,18 @@ def build(dependencies, timestamp):
 """,
     )
     monkeypatch.setattr(runner, "TIMEOUT_SECONDS", 1)
+    monkeypatch.setattr(runner, "RETRY_MAX_RETRIES", 0)
     with pytest.raises(RuntimeError, match="timed out"):
         runner.run_builder(
             script_dir, "builder.py", {}, datetime(2024, 1, 1), env_file=None
         )
 
 
-def test_builder_crash_raises_runtime_error(tmp_path: Path) -> None:
+def test_builder_crash_raises_runtime_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Builder that calls os._exit(1) raises crash error."""
+    monkeypatch.setattr(runner, "RETRY_MAX_RETRIES", 0)
     script_dir = _write_builder(
         tmp_path,
         """
@@ -166,3 +173,82 @@ def build(dependencies, timestamp):
         script_dir, "builder.py", {}, datetime(2024, 1, 1), env_file=env_file
     )
     assert "TEST_LEAK_CHECK" not in os.environ
+
+
+# --- retry tests ---
+
+
+def test_retry_on_transient_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Builder that crashes once then succeeds is retried automatically."""
+    # use a counter file to track attempts across subprocess invocations
+    counter_file = tmp_path / "attempt_count"
+    counter_file.write_text("0")
+    script_dir = _write_builder(
+        tmp_path,
+        f"""
+import os
+def build(dependencies, timestamp):
+    counter_file = "{counter_file}"
+    count = int(open(counter_file).read())
+    count += 1
+    open(counter_file, "w").write(str(count))
+    if count == 1:
+        os._exit(1)  # crash on first attempt
+    return [{{"value": "recovered"}}]
+""",
+    )
+    monkeypatch.setattr(runner, "RETRY_MAX_RETRIES", 2)
+    monkeypatch.setattr(runner, "RETRY_INITIAL_DELAY", 0.01)
+    result = runner.run_builder(
+        script_dir, "builder.py", {}, datetime(2024, 1, 1), env_file=None
+    )
+    assert result == [{"value": "recovered"}]
+
+
+def test_retry_exhausted_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Builder that always crashes raises after retries exhausted."""
+    script_dir = _write_builder(
+        tmp_path,
+        """
+import os
+def build(dependencies, timestamp):
+    os._exit(1)
+""",
+    )
+    monkeypatch.setattr(runner, "RETRY_MAX_RETRIES", 1)
+    monkeypatch.setattr(runner, "RETRY_INITIAL_DELAY", 0.01)
+    with pytest.raises(RuntimeError, match="crashed"):
+        runner.run_builder(
+            script_dir, "builder.py", {}, datetime(2024, 1, 1), env_file=None
+        )
+
+
+def test_retry_on_timeout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Builder that times out once then succeeds is retried."""
+    counter_file = tmp_path / "attempt_count"
+    counter_file.write_text("0")
+    script_dir = _write_builder(
+        tmp_path,
+        f"""
+import time
+def build(dependencies, timestamp):
+    counter_file = "{counter_file}"
+    count = int(open(counter_file).read())
+    count += 1
+    open(counter_file, "w").write(str(count))
+    if count == 1:
+        time.sleep(10)  # timeout on first attempt
+    return [{{"value": "recovered"}}]
+""",
+    )
+    monkeypatch.setattr(runner, "TIMEOUT_SECONDS", 1)
+    monkeypatch.setattr(runner, "RETRY_MAX_RETRIES", 2)
+    monkeypatch.setattr(runner, "RETRY_INITIAL_DELAY", 0.01)
+    result = runner.run_builder(
+        script_dir, "builder.py", {}, datetime(2024, 1, 1), env_file=None
+    )
+    assert result == [{"value": "recovered"}]


### PR DESCRIPTION
## Summary
- Wrap builder subprocess execution in `retry_with_backoff()` for automatic retries on transient failures
- Extract subprocess logic into `_execute_subprocess()` inner function; payload serialization stays outside retry scope
- Add `RETRY_MAX_RETRIES=5`, `RETRY_INITIAL_DELAY=2.0`, `RETRY_BACKOFF_FACTOR=2.0` constants (delay progression: 2s, 4s, 8s, 16s, 32s)
- Existing failure tests now set `RETRY_MAX_RETRIES=0` to stay fast

## Test plan
- [x] `test_retry_on_transient_crash` -- builder crashes once then succeeds via file-based counter
- [x] `test_retry_exhausted_raises` -- always-crashing builder raises after retries exhausted
- [x] `test_retry_on_timeout` -- builder times out once then succeeds
- [x] All 12 runner tests pass in ~2.4s