### PR TITLE
chore: exclude integration tests from pre-commit pytest hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,7 @@ repos:
 
       - id: pytest
         name: pytest
-        entry: bash -c 'uv run pytest'
+        entry: bash -c 'uv run pytest --ignore=builders/server/tests/integration'
         language: system
         files: ^builders/server/
         pass_filenames: false


### PR DESCRIPTION
exclude integration tests from the pre-commit `pytest` hook so they don't run locally on every commit. integration tests require a live postgres via testcontainers and are only appropriate for CI. they continue to run in the `backend-integration-tests` CI job unchanged.