### PR TITLE
docs: add benchmarks note to readme tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ All endpoints are prefixed with `/api/v1`.
 
 ```
 datastream-rs/
+  .benchmarks/                  # benchmark artifacts/output (e.g. profiling flames)
   infra/                        # Docker infrastructure
     docker-compose.yml            # production (only Caddy ports exposed)
     docker-compose.dev.yml        # dev overlay (exposes internal ports)


### PR DESCRIPTION
## What changed
- added `.benchmarks/` to the README project structure tree
- documented it as benchmark artifacts/output (for example profiling flame outputs)

## Why
- make benchmark-related files discoverable from the top-level docs

## Benefit
- helps contributors quickly find where benchmark outputs live when running or reviewing performance work