### PR TITLE
fix: cap integration retries and shorten backoff

### DIFF
--- a/builders/server/tests/integration/conftest.py
+++ b/builders/server/tests/integration/conftest.py
@@ -87,6 +87,16 @@ def real_scripts_dir(monkeypatch):
     monkeypatch.setattr(loader, "SCRIPTS_DIR", REAL_SCRIPTS_DIR)
 
 
+@pytest.fixture(autouse=True)
+def integration_retry_settings(monkeypatch):
+    """Use short retries in integration tests to keep suite runtime bounded."""
+    from runtime import runner
+
+    monkeypatch.setattr(runner, "RETRY_MAX_RETRIES", 3)
+    monkeypatch.setattr(runner, "RETRY_INITIAL_DELAY", 0.01)
+    monkeypatch.setattr(runner, "RETRY_BACKOFF_FACTOR", 2.0)
+
+
 @pytest.fixture()
 def client():
     """FastAPI test client wrapping the real app (no lifespan)."""


### PR DESCRIPTION
## what changed
- add an autouse integration fixture that monkeypatches runner retry constants
- set integration retry policy to max 3 retries with short exponential backoff (0.01s, factor 2.0)

## why
- integration tests intentionally exercise failure paths, and production retry timings make those tests slow
- this keeps retry behavior active in integration while removing long sleep waits

## benefit
- much faster integration runtime
- retry semantics still covered in integration instead of being disabled