### PR TITLE
docs: document integration retry override

### DIFF
--- a/dev-docs/SPEC-backend.md
+++ b/dev-docs/SPEC-backend.md
@@ -444,6 +444,13 @@ Builder subprocess execution is wrapped in automatic retry with exponential back
 
 **Logging**: each retry attempt logs a structlog warning with the attempt number, delay, and error message.
 
+**Integration test override**: integration tests monkeypatch retry constants in `tests/integration/conftest.py` to keep runtime fast while preserving retry semantics:
+- `RETRY_MAX_RETRIES = 3`
+- `RETRY_INITIAL_DELAY = 0.01`
+- `RETRY_BACKOFF_FACTOR = 2.0`
+
+This keeps integration coverage for transient-recovery and retry-exhaustion behavior without incurring production-scale backoff delays.
+
 ### Mock builders
 
 The following mock builders exist for testing and development:


### PR DESCRIPTION
## what changed
- update backend spec retry section with integration-specific override values
- document that integration uses max 3 retries and short delays

## why
- keep technical spec aligned with actual test harness behavior

## benefit
- clearer expectations for contributors and reviewers about production vs integration retry behavior