### PR TITLE
chore: add submit recipe with worktree branch cleanup

### DIFF
--- a/dev-tools/wt-submit.sh
+++ b/dev-tools/wt-submit.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# wrapper around gt submit that auto-cleans _wt-* worktree branches from the stack.
+# gt delete --force restacks children onto parent (main), so the first real
+# PR branch ends up directly on main with no phantom empty branch.
+
+current=$(git branch --show-current)
+
+if [[ "$current" == _wt-* ]]; then
+    echo "error: still on worktree branch '$current'. run 'gt create' first." >&2
+    exit 1
+fi
+
+# find _wt-* branch in current stack
+wt_branch=""
+while IFS= read -r line; do
+    # strip unicode bullets, spaces, and marker characters
+    branch=$(echo "$line" | sed 's/^[^a-zA-Z0-9_]*//')
+    if [[ "$branch" == _wt-* ]]; then
+        wt_branch="$branch"
+        break
+    fi
+done < <(gt log short --no-interactive --stack 2>/dev/null)
+
+# if worktree branch found, delete it (auto-restacks children onto main)
+if [[ -n "$wt_branch" ]]; then
+    echo "cleaning up worktree branch: $wt_branch"
+    gt delete "$wt_branch" --force --no-interactive
+fi
+
+gt submit --no-interactive

--- a/justfile
+++ b/justfile
@@ -71,6 +71,10 @@ worktree-create NAME:
     @echo "worktree created at ../{{NAME}}"
     @echo "cd {{justfile_directory()}}/../{{NAME}} to start working"
 
+# submit graphite stack, auto-cleaning any worktree branch
+submit:
+    {{justfile_directory()}}/dev-tools/wt-submit.sh
+
 # remove a worktree and clean up its graphite branch
 worktree-remove NAME:
     git worktree remove "{{justfile_directory()}}/../{{NAME}}"


### PR DESCRIPTION
Add `just submit` as a wrapper around `gt submit --no-interactive` that auto-cleans worktree branches.

When a `_wt-*` branch exists in the current Graphite stack (created by `just worktree-create`), it deletes it before submitting. `gt branch delete --force` auto-restacks children onto the parent (main), so the first real PR ends up directly on main with no phantom empty branch.

Idempotent: if no `_wt-*` branch in stack, passes through to `gt submit` directly.