### PR TITLE
docs: fix sdk standalone installation instructions

### DIFF
--- a/dev-docs/SPEC-sdk.md
+++ b/dev-docs/SPEC-sdk.md
@@ -4,7 +4,11 @@ A lightweight Python client for the datastream API, packaged as `datastream-sdk`
 
 ## Installation
 
-The SDK is a uv workspace member. `uv sync` from the repo root installs it.
+```bash
+pip install "git+https://github.com/Wat-Street/datastream#subdirectory=builders/sdk"
+```
+
+Within this repo, the SDK is a uv workspace member — `uv sync` from the repo root installs it.
 
 ## Usage
 


### PR DESCRIPTION
clarify installation for users outside the repo -- github install is the primary path, uv workspace sync is noted as a one-liner for contributors