### PR TITLE
feat: add config registry with startup pre-loading

### DIFF
--- a/builders/server/main.py
+++ b/builders/server/main.py
@@ -9,6 +9,7 @@ from db.connection import close_pool, open_pool
 from fastapi import FastAPI, Request, Response
 from log_config import setup_logging as _setup_logging
 from runtime.config import SCRIPTS_DIR
+from runtime.registry import load_all_configs
 from runtime.venv_management import setup_builder_venvs
 
 _setup_logging()
@@ -17,6 +18,7 @@ _setup_logging()
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     """Startup: create per-builder venvs and open DB pool. Shutdown: close pool."""
+    load_all_configs(SCRIPTS_DIR)
     setup_builder_venvs(SCRIPTS_DIR)
     open_pool(os.environ["DATABASE_URL"])
     yield

--- a/builders/server/runtime/config.py
+++ b/builders/server/runtime/config.py
@@ -343,6 +343,21 @@ def check_dependency_graph_cycles(dataset_name: str, dataset_version: SemVer) ->
     _check_dependency_graph_cycles(dataset_name, dataset_version, set(), set())
 
 
+def build_dataset_config(raw: dict, name: str, version: SemVer) -> DatasetConfig:
+    """Construct a DatasetConfig from a validated and normalized raw config dict."""
+    return DatasetConfig(
+        name=raw["name"],
+        version=SemVer.parse(raw["version"]),
+        builder=raw.get("builder", DEFAULT_BUILDER),
+        calendar=CALENDARS_MAP[raw["calendar"]],
+        granularity=_GRANULARITY_MAP[raw["granularity"]],
+        start_date=datetime.strptime(raw["start-date"], "%Y-%m-%d"),
+        schema=raw["schema"],
+        dependencies=raw.get("dependencies", {}),
+        env_vars=raw.get("env-vars", False),
+    )
+
+
 @lru_cache(maxsize=256)
 def _load_config_no_cycles_check(
     dataset_name: str, dataset_version: SemVer
@@ -362,17 +377,7 @@ def _load_config_no_cycles_check(
         path=str(config_path),
     )
 
-    return DatasetConfig(
-        name=raw["name"],
-        version=SemVer.parse(raw["version"]),
-        builder=raw.get("builder", DEFAULT_BUILDER),
-        calendar=CALENDARS_MAP[raw["calendar"]],
-        granularity=_GRANULARITY_MAP[raw["granularity"]],
-        start_date=datetime.strptime(raw["start-date"], "%Y-%m-%d"),
-        schema=raw["schema"],
-        dependencies=raw.get("dependencies", {}),
-        env_vars=raw.get("env-vars", False),
-    )
+    return build_dataset_config(raw, dataset_name, dataset_version)
 
 
 def load_config(dataset_name: str, dataset_version: SemVer) -> DatasetConfig:

--- a/builders/server/runtime/registry.py
+++ b/builders/server/runtime/registry.py
@@ -1,0 +1,180 @@
+import tomllib
+from datetime import datetime
+from pathlib import Path
+
+import structlog
+from utils.semver import SemVer
+
+from runtime.config import (
+    DatasetConfig,
+    build_dataset_config,
+    normalize_config,
+    validate_config,
+)
+
+logger = structlog.get_logger()
+
+# populated once at startup by load_all_configs(); never mutated after that
+CONFIG_REGISTRY: dict[tuple[str, SemVer], DatasetConfig] = {}
+
+
+def get_config(name: str, version: SemVer) -> DatasetConfig:
+    """Return the pre-loaded config for a dataset. Raises ValueError if not found."""
+    key = (name, version)
+    if key not in CONFIG_REGISTRY:
+        raise ValueError(
+            f"dataset {name}/{version} not found in config registry; "
+            "ensure it exists in SCRIPTS_DIR and the server started successfully"
+        )
+    return CONFIG_REGISTRY[key]
+
+
+def _validate_deps_exist(
+    name: str,
+    version: SemVer,
+    visited: set[tuple[str, SemVer]] | None = None,
+) -> None:
+    """Recursively ensure all dependencies referenced by a config exist in the registry.
+
+    Uses a visited set to avoid infinite recursion on cyclic graphs (cycles are
+    caught separately by _check_cycles).
+    """
+    if visited is None:
+        visited = set()
+    node = (name, version)
+    if node in visited:
+        return
+    visited.add(node)
+    cfg = CONFIG_REGISTRY[node]
+    for dep_name, dep_info in cfg.dependencies.items():
+        key = (dep_name, dep_info.version)
+        if key not in CONFIG_REGISTRY:
+            raise ValueError(
+                f"{name}/{version} references dependency "
+                f"{dep_name}/{dep_info.version} which was not found in SCRIPTS_DIR"
+            )
+        _validate_deps_exist(dep_name, dep_info.version, visited)
+
+
+def _check_cycles(
+    name: str,
+    version: SemVer,
+    in_stack: set[tuple[str, SemVer]],
+    visited: set[tuple[str, SemVer]],
+) -> None:
+    """DFS cycle detection over CONFIG_REGISTRY.
+
+    `in_stack` tracks the current DFS path; a dep already in `in_stack` means
+    a cycle. `visited` tracks fully-explored nodes to avoid re-traversal.
+    """
+    node = (name, version)
+    if node in visited:
+        return
+    in_stack.add(node)
+    cfg = CONFIG_REGISTRY[node]
+    for dep_name, dep_info in cfg.dependencies.items():
+        dep_node = (dep_name, dep_info.version)
+        if dep_node in in_stack:
+            raise ValueError(
+                f"dependency cycle detected: {dep_name}/{dep_info.version} "
+                f"is an ancestor of {name}/{version}"
+            )
+        _check_cycles(dep_name, dep_info.version, in_stack, visited)
+    in_stack.discard(node)
+    visited.add(node)
+
+
+def _validate_granularity(name: str, version: SemVer) -> None:
+    """Recursively validate that each dataset's granularity is >= all dependencies'."""
+    cfg = CONFIG_REGISTRY[(name, version)]
+    for dep_name, dep_info in cfg.dependencies.items():
+        dep_cfg = CONFIG_REGISTRY[(dep_name, dep_info.version)]
+        if cfg.granularity < dep_cfg.granularity:
+            raise ValueError(
+                f"{name}/{version} has granularity '{cfg.granularity}' which is "
+                f"finer than dependency '{dep_name}/{dep_info.version}' with "
+                f"granularity '{dep_cfg.granularity}'"
+            )
+        _validate_granularity(dep_name, dep_info.version)
+
+
+def _validate_start_date(name: str, version: SemVer) -> datetime:
+    """Recursively validate start-date constraints. Returns the dataset's start_date.
+
+    A dataset's start_date must be >= all dependencies' start_dates.
+    """
+    cfg = CONFIG_REGISTRY[(name, version)]
+    parent_start = cfg.start_date
+    for dep_name, dep_info in cfg.dependencies.items():
+        dep_start = _validate_start_date(dep_name, dep_info.version)
+        if parent_start < dep_start:
+            raise ValueError(
+                f"{name}/{version} has start date '{parent_start}' which comes "
+                f"before dependency {dep_name}/{dep_info.version} "
+                f"with start date {dep_start}"
+            )
+    return parent_start
+
+
+def load_all_configs(scripts_dir: Path) -> None:
+    """Discover, load, and validate every config in scripts_dir.
+
+    Populates CONFIG_REGISTRY. Raises ValueError if any config is structurally
+    invalid, a dependency is missing from scripts_dir, or the dependency graph
+    has cycles, granularity violations, or start-date violations.
+
+    The server lifespan calls this at startup; any error here prevents startup.
+    """
+    global CONFIG_REGISTRY
+    CONFIG_REGISTRY = {}
+
+    if not scripts_dir.is_dir():
+        logger.warning(
+            "scripts_dir not found, no configs loaded", path=str(scripts_dir)
+        )
+        return
+
+    # step 1: discover and load all configs individually (structural validation)
+    for name_dir in sorted(scripts_dir.iterdir()):
+        if not name_dir.is_dir():
+            continue
+        for version_dir in sorted(name_dir.iterdir()):
+            if not version_dir.is_dir():
+                continue
+            config_path = version_dir / "config.toml"
+            if not config_path.exists():
+                continue
+
+            name = name_dir.name
+            version = SemVer.parse(version_dir.name)
+
+            with open(config_path, "rb") as f:
+                raw = tomllib.load(f)
+
+            validate_config(raw, name, version)
+            normalize_config(raw)
+
+            cfg = build_dataset_config(raw, name, version)
+            CONFIG_REGISTRY[(name, version)] = cfg
+            logger.debug("config loaded", dataset=name, version=str(version))
+
+    logger.info("all configs loaded", count=len(CONFIG_REGISTRY))
+
+    # step 2: ensure every referenced dependency exists in the registry
+    for name, version in CONFIG_REGISTRY:
+        _validate_deps_exist(name, version)
+
+    # step 3: check for cycles across all datasets (shared visited set for efficiency)
+    visited: set[tuple[str, SemVer]] = set()
+    for name, version in CONFIG_REGISTRY:
+        _check_cycles(name, version, set(), visited)
+
+    # step 4: validate granularity constraints
+    for name, version in CONFIG_REGISTRY:
+        _validate_granularity(name, version)
+
+    # step 5: validate start-date constraints
+    for name, version in CONFIG_REGISTRY:
+        _validate_start_date(name, version)
+
+    logger.info("config graph validation passed", count=len(CONFIG_REGISTRY))

--- a/builders/server/tests/runtime/test_registry.py
+++ b/builders/server/tests/runtime/test_registry.py
@@ -1,0 +1,440 @@
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from runtime import registry
+from runtime.config import DatasetConfig
+from utils.semver import SemVer
+
+V010 = SemVer.parse("0.1.0")
+V020 = SemVer.parse("0.2.0")
+
+_MINIMAL = """\
+name = "{name}"
+version = "{version}"
+granularity = "1d"
+start-date = "2020-01-01"
+calendar = "everyday"
+
+[schema]
+price = "int"
+"""
+
+_WITH_DEP = """\
+name = "{name}"
+version = "{version}"
+granularity = "1d"
+start-date = "2020-01-01"
+calendar = "everyday"
+
+[schema]
+price = "int"
+
+[dependencies]
+{dep_name} = "{dep_version}"
+"""
+
+
+@pytest.fixture(autouse=True)
+def clear_registry() -> None:
+    """reset CONFIG_REGISTRY between tests."""
+    registry.CONFIG_REGISTRY = {}
+
+
+# --- happy path ---
+
+
+def test_load_all_configs_empty_dir(tmp_path: Path) -> None:
+    """empty scripts_dir loads zero configs without error."""
+    registry.load_all_configs(tmp_path)
+    assert registry.CONFIG_REGISTRY == {}
+
+
+def test_load_all_configs_missing_dir(tmp_path: Path) -> None:
+    """non-existent scripts_dir warns and loads zero configs."""
+    registry.load_all_configs(tmp_path / "does-not-exist")
+    assert registry.CONFIG_REGISTRY == {}
+
+
+def test_load_all_configs_single(tmp_path: Path, write_config: Callable) -> None:
+    """single valid config is discovered and stored."""
+    write_config(tmp_path, "ds", "0.1.0", _MINIMAL.format(name="ds", version="0.1.0"))
+    registry.load_all_configs(tmp_path)
+    assert (("ds", V010)) in registry.CONFIG_REGISTRY
+    cfg = registry.CONFIG_REGISTRY[("ds", V010)]
+    assert isinstance(cfg, DatasetConfig)
+    assert cfg.name == "ds"
+
+
+def test_load_all_configs_multiple(tmp_path: Path, write_config: Callable) -> None:
+    """multiple configs across datasets all loaded."""
+    write_config(tmp_path, "a", "0.1.0", _MINIMAL.format(name="a", version="0.1.0"))
+    write_config(tmp_path, "b", "0.1.0", _MINIMAL.format(name="b", version="0.1.0"))
+    write_config(tmp_path, "b", "0.2.0", _MINIMAL.format(name="b", version="0.2.0"))
+    registry.load_all_configs(tmp_path)
+    assert len(registry.CONFIG_REGISTRY) == 3
+    assert ("a", V010) in registry.CONFIG_REGISTRY
+    assert ("b", V010) in registry.CONFIG_REGISTRY
+    assert ("b", V020) in registry.CONFIG_REGISTRY
+
+
+def test_load_all_configs_with_valid_dependency(
+    tmp_path: Path, write_config: Callable
+) -> None:
+    """dataset with a valid dependency loads without error."""
+    write_config(tmp_path, "dep", "0.1.0", _MINIMAL.format(name="dep", version="0.1.0"))
+    write_config(
+        tmp_path,
+        "parent",
+        "0.1.0",
+        _WITH_DEP.format(
+            name="parent", version="0.1.0", dep_name="dep", dep_version="0.1.0"
+        ),
+    )
+    registry.load_all_configs(tmp_path)
+    assert len(registry.CONFIG_REGISTRY) == 2
+
+
+def test_load_all_configs_skips_dirs_without_config_toml(
+    tmp_path: Path, write_config: Callable
+) -> None:
+    """directories without config.toml are silently skipped."""
+    write_config(tmp_path, "ds", "0.1.0", _MINIMAL.format(name="ds", version="0.1.0"))
+    # create a version dir with no config.toml
+    (tmp_path / "ds" / "0.2.0").mkdir(parents=True)
+    registry.load_all_configs(tmp_path)
+    assert len(registry.CONFIG_REGISTRY) == 1
+
+
+# --- get_config ---
+
+
+def test_get_config_found(tmp_path: Path, write_config: Callable) -> None:
+    """get_config returns the correct DatasetConfig."""
+    write_config(tmp_path, "ds", "0.1.0", _MINIMAL.format(name="ds", version="0.1.0"))
+    registry.load_all_configs(tmp_path)
+    cfg = registry.get_config("ds", V010)
+    assert cfg.name == "ds"
+    assert cfg.version == V010
+
+
+def test_get_config_not_found_raises(tmp_path: Path) -> None:
+    """get_config raises ValueError for unknown dataset."""
+    registry.load_all_configs(tmp_path)
+    with pytest.raises(ValueError, match="not found in config registry"):
+        registry.get_config("ghost", V010)
+
+
+# --- structural validation failures ---
+
+
+def test_load_all_configs_invalid_config_raises(
+    tmp_path: Path, write_config: Callable
+) -> None:
+    """structurally invalid config (missing schema) raises ValueError at startup."""
+    write_config(
+        tmp_path,
+        "ds",
+        "0.1.0",
+        """\
+name = "ds"
+version = "0.1.0"
+granularity = "1d"
+start-date = "2020-01-01"
+calendar = "everyday"
+""",
+    )
+    with pytest.raises(ValueError, match="missing 'schema' field"):
+        registry.load_all_configs(tmp_path)
+
+
+# --- dependency existence failures ---
+
+
+def test_load_all_configs_missing_dependency_raises(
+    tmp_path: Path, write_config: Callable
+) -> None:
+    """dataset referencing a dep not in scripts_dir raises ValueError."""
+    write_config(
+        tmp_path,
+        "parent",
+        "0.1.0",
+        _WITH_DEP.format(
+            name="parent", version="0.1.0", dep_name="missing-dep", dep_version="0.1.0"
+        ),
+    )
+    with pytest.raises(ValueError, match="missing-dep/0.1.0"):
+        registry.load_all_configs(tmp_path)
+
+
+# --- cycle detection ---
+
+
+def test_load_all_configs_self_cycle_raises(
+    tmp_path: Path, write_config: Callable
+) -> None:
+    """dataset depending on itself raises ValueError."""
+    write_config(
+        tmp_path,
+        "ds",
+        "0.1.0",
+        _WITH_DEP.format(
+            name="ds", version="0.1.0", dep_name="ds", dep_version="0.1.0"
+        ),
+    )
+    with pytest.raises(ValueError, match="cycle detected"):
+        registry.load_all_configs(tmp_path)
+
+
+def test_load_all_configs_two_node_cycle_raises(
+    tmp_path: Path, write_config: Callable
+) -> None:
+    """A->B->A cycle raises ValueError."""
+    write_config(
+        tmp_path,
+        "a",
+        "0.1.0",
+        _WITH_DEP.format(name="a", version="0.1.0", dep_name="b", dep_version="0.1.0"),
+    )
+    write_config(
+        tmp_path,
+        "b",
+        "0.1.0",
+        _WITH_DEP.format(name="b", version="0.1.0", dep_name="a", dep_version="0.1.0"),
+    )
+    with pytest.raises(ValueError, match="cycle detected"):
+        registry.load_all_configs(tmp_path)
+
+
+def test_load_all_configs_three_node_cycle_raises(
+    tmp_path: Path, write_config: Callable
+) -> None:
+    """A->B->C->A cycle raises ValueError."""
+    write_config(
+        tmp_path,
+        "a",
+        "0.1.0",
+        _WITH_DEP.format(name="a", version="0.1.0", dep_name="b", dep_version="0.1.0"),
+    )
+    write_config(
+        tmp_path,
+        "b",
+        "0.1.0",
+        _WITH_DEP.format(name="b", version="0.1.0", dep_name="c", dep_version="0.1.0"),
+    )
+    write_config(
+        tmp_path,
+        "c",
+        "0.1.0",
+        _WITH_DEP.format(name="c", version="0.1.0", dep_name="a", dep_version="0.1.0"),
+    )
+    with pytest.raises(ValueError, match="cycle detected"):
+        registry.load_all_configs(tmp_path)
+
+
+def test_load_all_configs_diamond_no_cycle(
+    tmp_path: Path, write_config: Callable
+) -> None:
+    """diamond shape (A->B, A->C, B->D, C->D) is valid."""
+    write_config(tmp_path, "d", "0.1.0", _MINIMAL.format(name="d", version="0.1.0"))
+    write_config(
+        tmp_path,
+        "b",
+        "0.1.0",
+        _WITH_DEP.format(name="b", version="0.1.0", dep_name="d", dep_version="0.1.0"),
+    )
+    write_config(
+        tmp_path,
+        "c",
+        "0.1.0",
+        _WITH_DEP.format(name="c", version="0.1.0", dep_name="d", dep_version="0.1.0"),
+    )
+    write_config(
+        tmp_path,
+        "a",
+        "0.1.0",
+        """\
+name = "a"
+version = "0.1.0"
+granularity = "1d"
+start-date = "2020-01-01"
+calendar = "everyday"
+
+[schema]
+price = "int"
+
+[dependencies]
+b = "0.1.0"
+c = "0.1.0"
+""",
+    )
+    registry.load_all_configs(tmp_path)  # no exception
+    assert len(registry.CONFIG_REGISTRY) == 4
+
+
+# --- granularity violation ---
+
+
+def test_load_all_configs_granularity_violation_raises(
+    tmp_path: Path, write_config: Callable
+) -> None:
+    """parent with finer granularity than dependency raises ValueError."""
+    write_config(
+        tmp_path,
+        "dep",
+        "0.1.0",
+        """\
+name = "dep"
+version = "0.1.0"
+granularity = "1d"
+start-date = "2020-01-01"
+calendar = "everyday"
+
+[schema]
+price = "int"
+""",
+    )
+    write_config(
+        tmp_path,
+        "parent",
+        "0.1.0",
+        """\
+name = "parent"
+version = "0.1.0"
+granularity = "1h"
+start-date = "2020-01-01"
+calendar = "everyday"
+
+[schema]
+price = "int"
+
+[dependencies]
+dep = "0.1.0"
+""",
+    )
+    with pytest.raises(ValueError, match="finer than dependency"):
+        registry.load_all_configs(tmp_path)
+
+
+def test_load_all_configs_equal_granularity_ok(
+    tmp_path: Path, write_config: Callable
+) -> None:
+    """equal granularity between parent and dep is valid."""
+    write_config(
+        tmp_path,
+        "dep",
+        "0.1.0",
+        """\
+name = "dep"
+version = "0.1.0"
+granularity = "1d"
+start-date = "2020-01-01"
+calendar = "everyday"
+
+[schema]
+price = "int"
+""",
+    )
+    write_config(
+        tmp_path,
+        "parent",
+        "0.1.0",
+        """\
+name = "parent"
+version = "0.1.0"
+granularity = "1d"
+start-date = "2020-01-01"
+calendar = "everyday"
+
+[schema]
+price = "int"
+
+[dependencies]
+dep = "0.1.0"
+""",
+    )
+    registry.load_all_configs(tmp_path)  # no exception
+
+
+# --- start-date violation ---
+
+
+def test_load_all_configs_start_date_violation_raises(
+    tmp_path: Path, write_config: Callable
+) -> None:
+    """parent with earlier start-date than dependency raises ValueError."""
+    write_config(
+        tmp_path,
+        "dep",
+        "0.1.0",
+        """\
+name = "dep"
+version = "0.1.0"
+granularity = "1d"
+start-date = "2021-01-01"
+calendar = "everyday"
+
+[schema]
+price = "int"
+""",
+    )
+    write_config(
+        tmp_path,
+        "parent",
+        "0.1.0",
+        """\
+name = "parent"
+version = "0.1.0"
+granularity = "1d"
+start-date = "2020-01-01"
+calendar = "everyday"
+
+[schema]
+price = "int"
+
+[dependencies]
+dep = "0.1.0"
+""",
+    )
+    with pytest.raises(ValueError, match="comes before dependency"):
+        registry.load_all_configs(tmp_path)
+
+
+def test_load_all_configs_start_date_equal_ok(
+    tmp_path: Path, write_config: Callable
+) -> None:
+    """equal start-date between parent and dep is valid."""
+    write_config(
+        tmp_path,
+        "dep",
+        "0.1.0",
+        """\
+name = "dep"
+version = "0.1.0"
+granularity = "1d"
+start-date = "2020-01-01"
+calendar = "everyday"
+
+[schema]
+price = "int"
+""",
+    )
+    write_config(
+        tmp_path,
+        "parent",
+        "0.1.0",
+        """\
+name = "parent"
+version = "0.1.0"
+granularity = "1d"
+start-date = "2020-01-01"
+calendar = "everyday"
+
+[schema]
+price = "int"
+
+[dependencies]
+dep = "0.1.0"
+""",
+    )
+    registry.load_all_configs(tmp_path)  # no exception


### PR DESCRIPTION
## Summary

- New `runtime/registry.py`: discovers all configs in `SCRIPTS_DIR` at startup, loads each into `DatasetConfig`, validates the full dependency graph (cycle detection, granularity constraints, start-date constraints), and stores results in a module-level `CONFIG_REGISTRY` dict
- `main.py` lifespan calls `load_all_configs(SCRIPTS_DIR)` before venv setup and DB pool open; any invalid config or graph error aborts startup
- `config.py` gains `build_dataset_config()` helper to centralize `DatasetConfig` construction (used by both `_load_config_no_cycles_check` and the new registry)
- 18 new unit tests covering happy paths and all failure modes (missing dep, cycles, granularity violation, start-date violation)

## Why

Config validation was scattered across request time: structural checks happened on first cache miss, graph validation (cycles, granularity, start-date) re-ran on every `build_dataset` call. Since configs are immutable for the server lifetime, validating once at startup is safer (fail-fast) and simpler. This PR adds the registry without changing any call sites yet — PR 2 will migrate callers and remove the old lazy-load path.