### PR TITLE
refactor: migrate catalog.py call sites to config registry

### DIFF
--- a/builders/server/service/catalog.py
+++ b/builders/server/service/catalog.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 import db.datasets
-import runtime.config
+from runtime.registry import iter_config_keys
 
 
 @dataclass
@@ -13,31 +13,17 @@ class DatasetInfo:
     has_data: bool
 
 
-def discover_datasets() -> list[tuple[str, str]]:
-    """Scan SCRIPTS_DIR and return (name, version) pairs that have a config.toml.
-
-    Skips non-directories at both levels.
-    """
-    results: list[tuple[str, str]] = []
-    scripts_dir = runtime.config.SCRIPTS_DIR
-    if not scripts_dir.is_dir():
-        return results
-    for name_dir in sorted(scripts_dir.iterdir()):
-        if not name_dir.is_dir():
-            continue
-        for version_dir in sorted(name_dir.iterdir()):
-            if not version_dir.is_dir():
-                continue
-            if (version_dir / "config.toml").exists():
-                results.append((name_dir.name, version_dir.name))
-    return results
-
-
 def list_datasets() -> list[DatasetInfo]:
-    """Return all discovered datasets annotated with whether they have DB rows."""
-    discovered = discover_datasets()
+    """Return all pre-loaded datasets annotated with whether they have DB rows."""
     has_data = db.datasets.get_datasets_with_data()
-    return [
-        DatasetInfo(name=name, version=version, has_data=(name, version) in has_data)
-        for name, version in discovered
-    ]
+    return sorted(
+        [
+            DatasetInfo(
+                name=name,
+                version=str(version),
+                has_data=(name, str(version)) in has_data,
+            )
+            for name, version in iter_config_keys()
+        ],
+        key=lambda d: (d.name, d.version),
+    )

--- a/builders/server/tests/service/test_catalog.py
+++ b/builders/server/tests/service/test_catalog.py
@@ -1,101 +1,94 @@
-from collections.abc import Callable
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from service.catalog import DatasetInfo, discover_datasets, list_datasets
+from service.catalog import DatasetInfo, list_datasets
+from utils.semver import SemVer
 
-# --- discover_datasets tests ---
+V010 = SemVer.parse("0.1.0")
+V020 = SemVer.parse("0.2.0")
 
-
-def test_discover_datasets_finds_configs(
-    mock_scripts_dir: Path, write_config: Callable
-) -> None:
-    """Returns (name, version) for each dir with a config.toml."""
-    write_config(mock_scripts_dir, "ds-a", "0.1.0", "")
-    write_config(mock_scripts_dir, "ds-b", "1.0.0", "")
-    result = discover_datasets()
-    assert ("ds-a", "0.1.0") in result
-    assert ("ds-b", "1.0.0") in result
-
-
-def test_discover_datasets_skips_no_config(mock_scripts_dir: Path) -> None:
-    """Dirs without config.toml are skipped."""
-    (mock_scripts_dir / "orphan" / "0.1.0").mkdir(parents=True)
-    result = discover_datasets()
-    assert ("orphan", "0.1.0") not in result
-
-
-def test_discover_datasets_empty_dir(mock_scripts_dir: Path) -> None:
-    """Empty scripts dir returns empty list."""
-    result = discover_datasets()
-    assert result == []
-
-
-def test_discover_datasets_sorted(
-    mock_scripts_dir: Path, write_config: Callable
-) -> None:
-    """Results are sorted by name then version."""
-    write_config(mock_scripts_dir, "z-ds", "0.1.0", "")
-    write_config(mock_scripts_dir, "a-ds", "0.1.0", "")
-    result = discover_datasets()
-    names = [r[0] for r in result]
-    assert names == sorted(names)
+# minimal registry keys: catalog only iterates keys
+_MOCK_KEYS = [
+    ("mock-ohlc", V010),
+    ("mock-daily-close", V010),
+]
 
 
 # --- list_datasets tests ---
 
 
 @patch("service.catalog.db.datasets.get_datasets_with_data")
-@patch("service.catalog.discover_datasets")
+@patch("service.catalog.iter_config_keys", return_value=_MOCK_KEYS)
 def test_list_datasets_marks_has_data(
-    mock_discover: MagicMock, mock_has_data: MagicMock
+    mock_keys: MagicMock, mock_has_data: MagicMock
 ) -> None:
-    """has_data=True when (name, version) is in the DB set."""
-    mock_discover.return_value = [("mock-ohlc", "0.1.0"), ("mock-daily-close", "0.1.0")]
+    """has_data=True when (name, str(version)) is in the DB set."""
     mock_has_data.return_value = {("mock-ohlc", "0.1.0")}
 
     result = list_datasets()
+
     assert len(result) == 2
-    assert result[0] == DatasetInfo(name="mock-ohlc", version="0.1.0", has_data=True)
-    assert result[1] == DatasetInfo(
+    # results are sorted by name, so daily-close comes before ohlc
+    assert result[0] == DatasetInfo(
         name="mock-daily-close", version="0.1.0", has_data=False
     )
+    assert result[1] == DatasetInfo(name="mock-ohlc", version="0.1.0", has_data=True)
 
 
 @patch("service.catalog.db.datasets.get_datasets_with_data")
-@patch("service.catalog.discover_datasets")
+@patch("service.catalog.iter_config_keys", return_value=_MOCK_KEYS)
 def test_list_datasets_all_no_data(
-    mock_discover: MagicMock, mock_has_data: MagicMock
+    mock_keys: MagicMock, mock_has_data: MagicMock
 ) -> None:
     """All datasets have has_data=False when DB set is empty."""
-    mock_discover.return_value = [("ds", "0.1.0")]
     mock_has_data.return_value = set()
 
     result = list_datasets()
-    assert result == [DatasetInfo(name="ds", version="0.1.0", has_data=False)]
+
+    assert all(not d.has_data for d in result)
+    assert len(result) == 2
 
 
 @patch("service.catalog.db.datasets.get_datasets_with_data")
-@patch("service.catalog.discover_datasets")
-def test_list_datasets_empty_scripts_dir(
-    mock_discover: MagicMock, mock_has_data: MagicMock
+@patch("service.catalog.iter_config_keys", return_value=[])
+def test_list_datasets_empty_registry(
+    mock_keys: MagicMock, mock_has_data: MagicMock
 ) -> None:
-    """Empty discovery returns empty list regardless of DB."""
-    mock_discover.return_value = []
+    """Empty registry returns empty list regardless of DB."""
     mock_has_data.return_value = {("ds", "0.1.0")}
 
     result = list_datasets()
+
     assert result == []
 
 
 @patch("service.catalog.db.datasets.get_datasets_with_data")
-@patch("service.catalog.discover_datasets")
+@patch(
+    "service.catalog.iter_config_keys",
+    return_value=[("a", V010), ("b", V010), ("c", V010)],
+)
 def test_list_datasets_single_db_call(
-    mock_discover: MagicMock, mock_has_data: MagicMock
+    mock_keys: MagicMock, mock_has_data: MagicMock
 ) -> None:
     """DB is queried exactly once regardless of how many datasets exist."""
-    mock_discover.return_value = [("a", "0.1.0"), ("b", "0.1.0"), ("c", "0.1.0")]
     mock_has_data.return_value = set()
 
     list_datasets()
+
     mock_has_data.assert_called_once()
+
+
+@patch("service.catalog.db.datasets.get_datasets_with_data")
+@patch(
+    "service.catalog.iter_config_keys",
+    return_value=[("z-ds", V010), ("a-ds", V010), ("m-ds", V020)],
+)
+def test_list_datasets_sorted_by_name_then_version(
+    mock_keys: MagicMock, mock_has_data: MagicMock
+) -> None:
+    """Results are sorted by name then version."""
+    mock_has_data.return_value = set()
+
+    result = list_datasets()
+
+    names = [d.name for d in result]
+    assert names == sorted(names)


### PR DESCRIPTION
Migrate `catalog.py` from iterating `CONFIG_REGISTRY` directly to using `iter_config_keys()`. Updates `test_catalog.py` to patch `iter_config_keys` instead of the registry dict.