### PR TITLE
feat: add topological scheduler with Kahn's algorithm

### DIFF
--- a/builders/server/service/scheduler.py
+++ b/builders/server/service/scheduler.py
@@ -1,0 +1,174 @@
+"""Dependency graph collection for build scheduling.
+
+This module walks a dataset's dependency tree and computes the time ranges
+each dataset needs to be built over, accounting for lookback expansion,
+start-date clamping, and diamond dependency deduplication.
+
+The graph is collected in a single DFS pass. A separate module (added later)
+will consume this graph to produce a topologically ordered BuildPlan via
+Kahn's algorithm.
+
+Terminology:
+    Node: a (dataset_name, SemVer) pair identifying one dataset.
+    Edge: parent -> dependency. "A depends on B" means edge A -> B.
+    Range: the [start, end] time interval a dataset must be built for.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+import structlog
+from runtime import registry
+from utils.semver import SemVer
+
+logger = structlog.get_logger()
+
+type Node = tuple[str, SemVer]
+
+
+@dataclass
+class DependencyGraph:
+    """The raw dependency graph with computed time ranges.
+
+    Produced by collect_graph(). Contains all the information needed for
+    Kahn's algorithm to produce a topologically ordered BuildPlan.
+
+    Attributes:
+        ranges: maps each node to its required (start, end) build range.
+            Ranges account for lookback expansion and start-date clamping.
+            For diamond dependencies, the range is the union (widest) of
+            all ranges requested by different parents.
+        edges: maps each parent node to the set of its direct dependencies.
+            Only populated for nodes that have dependencies. Root nodes
+            (no deps) appear in ranges but not in edges.
+    """
+
+    ranges: dict[Node, tuple[datetime, datetime]] = field(default_factory=dict)
+    edges: dict[Node, set[Node]] = field(default_factory=dict)
+
+
+def collect_graph(
+    dataset_name: str,
+    dataset_version: SemVer,
+    start: datetime,
+    end: datetime,
+) -> DependencyGraph:
+    """Walk the dependency tree and collect all nodes with their required ranges.
+
+    Starting from the root dataset, performs a DFS through the dependency
+    graph. For each node it:
+    1. Clamps start to the dataset's start_date (same as _build_recursive)
+    2. Records the required [start, end] range
+    3. Expands dependency ranges by lookback_subtract when applicable
+    4. Recurses into dependencies
+
+    Diamond dependencies (same dataset reachable via multiple paths) are
+    handled by taking the union of required ranges. If a second visit
+    widens a node's range, its subtree is re-walked so the expansion
+    propagates to grandchildren. Since ranges only ever widen (never
+    shrink), convergence is guaranteed for any acyclic graph.
+
+    Args:
+        dataset_name: root dataset to build
+        dataset_version: version of the root dataset
+        start: requested build start time
+        end: requested build end time
+
+    Returns:
+        DependencyGraph with ranges and edges for all reachable datasets
+
+    Raises:
+        ValueError: if end < start_date for any dataset in the graph
+    """
+    graph = DependencyGraph()
+    _collect(dataset_name, dataset_version, start, end, graph)
+    return graph
+
+
+def _collect(
+    name: str,
+    version: SemVer,
+    start: datetime,
+    end: datetime,
+    graph: DependencyGraph,
+) -> None:
+    """Recursive DFS helper that populates the graph.
+
+    For each node, this function:
+    1. Loads the config from the startup registry
+    2. Validates end >= start_date, clamps start to start_date
+    3. Checks if we've visited this node before (diamond case):
+       - If yes and the range didn't expand: return early (no re-walk needed)
+       - If yes and the range expanded: update to union, re-walk children
+       - If no: record the range and walk children
+    4. For each dependency, computes the expanded range (lookback) and recurses
+
+    Args:
+        name: dataset name
+        version: dataset version
+        start: required start for this node (may be expanded by parent's lookback)
+        end: required end for this node
+        graph: mutable graph being built up across the DFS
+    """
+    cfg = registry.get_config(name, version)
+    node: Node = (name, version)
+
+    # enforce start-date: reject if end is before the dataset's start_date,
+    # clamp start forward if it precedes start_date
+    if end < cfg.start_date:
+        raise ValueError(
+            f"build request end date {end} is before "
+            f"dataset {name}/{version} start-date {cfg.start_date}"
+        )
+    if start < cfg.start_date:
+        logger.warning(
+            "clamping start to dataset start-date",
+            dataset=name,
+            version=str(version),
+            original_start=str(start),
+            start_date=str(cfg.start_date),
+        )
+        start = cfg.start_date
+
+    # diamond dependency handling: if we've seen this node before,
+    # check whether the new range is wider than what we recorded
+    if node in graph.ranges:
+        existing_start, existing_end = graph.ranges[node]
+        new_start = min(existing_start, start)
+        new_end = max(existing_end, end)
+
+        # if the range didn't actually expand, no need to re-walk
+        # children since they already cover the required range
+        if new_start >= existing_start and new_end <= existing_end:
+            return
+
+        # range expanded -- update and fall through to re-walk children
+        graph.ranges[node] = (new_start, new_end)
+        start = new_start
+        end = new_end
+    else:
+        graph.ranges[node] = (start, end)
+
+    # walk dependencies, expanding ranges for lookback
+    if not cfg.dependencies:
+        return
+
+    deps: set[Node] = set()
+    for dep_name, dep_info in cfg.dependencies.items():
+        dep_node: Node = (dep_name, dep_info.version)
+        deps.add(dep_node)
+
+        # lookback expansion: if this dependency has a lookback window,
+        # we need data starting earlier. e.g. "5d" lookback with
+        # lookback_subtract=timedelta(days=4) means we need data from
+        # [start - 4d, end] so the builder gets 5 days inclusive.
+        dep_start = start
+        if dep_info.lookback_subtract is not None:
+            dep_start = start - dep_info.lookback_subtract
+
+        _collect(dep_name, dep_info.version, dep_start, end, graph)
+
+    # record edges (overwrite on re-walk is fine, deps don't change)
+    graph.edges[node] = deps

--- a/builders/server/service/scheduler.py
+++ b/builders/server/service/scheduler.py
@@ -1,12 +1,17 @@
-"""Dependency graph collection for build scheduling.
+"""Dependency graph collection and topological scheduling for builds.
 
-This module walks a dataset's dependency tree and computes the time ranges
-each dataset needs to be built over, accounting for lookback expansion,
-start-date clamping, and diamond dependency deduplication.
+This module has two layers:
 
-The graph is collected in a single DFS pass. A separate module (added later)
-will consume this graph to produce a topologically ordered BuildPlan via
-Kahn's algorithm.
+1. Graph collection (collect_graph): DFS walk that computes time ranges
+   each dataset needs, accounting for lookback expansion, start-date
+   clamping, and diamond dependency deduplication.
+
+2. Topological scheduling (schedule_build): Kahn's algorithm that consumes
+   the collected graph and produces a BuildPlan with jobs grouped by
+   topological level. Level 0 = roots (no deps), level N+1 = datasets
+   whose deps all live in levels 0..N. The orchestrator executes levels
+   sequentially as barriers -- all jobs in level N must complete before
+   any job in level N+1 starts.
 
 Terminology:
     Node: a (dataset_name, SemVer) pair identifying one dataset.
@@ -16,12 +21,15 @@ Terminology:
 
 from __future__ import annotations
 
+from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
 
 import structlog
 from runtime import registry
 from utils.semver import SemVer
+
+from service.models import BuildPlan, JobDescriptor
 
 logger = structlog.get_logger()
 
@@ -172,3 +180,97 @@ def _collect(
 
     # record edges (overwrite on re-walk is fine, deps don't change)
     graph.edges[node] = deps
+
+
+def schedule_build(
+    dataset_name: str,
+    dataset_version: SemVer,
+    start: datetime,
+    end: datetime,
+) -> BuildPlan:
+    """Produce a topologically ordered build plan for a dataset and its dependencies.
+
+    Uses Kahn's algorithm (BFS-based topological sort) on the graph from
+    collect_graph(). Kahn's is chosen over Tarjan's DFS-based sort because
+    it naturally produces level-order grouping -- nodes are processed in
+    waves by their distance from roots, which directly maps to the barrier
+    model the orchestrator needs.
+
+    Algorithm:
+        1. Collect the dependency graph (nodes, ranges, edges)
+        2. Compute in-degree for each node (number of dependencies it has)
+        3. Seed level 0 with all zero-in-degree nodes (roots)
+        4. For each level: remove those nodes, decrement in-degrees of their
+           dependents (parents), and collect newly zero-in-degree nodes as
+           the next level
+        5. Convert each node + range into a JobDescriptor, grouped by level
+
+    The result is a BuildPlan where:
+        - levels[0] = root datasets (no deps, build first)
+        - levels[-1] = the originally requested dataset (build last)
+        - within each level, jobs are independent and safe to parallelize
+
+    Args:
+        dataset_name: root dataset to build
+        dataset_version: version of the root dataset
+        start: requested build start time
+        end: requested build end time
+
+    Returns:
+        BuildPlan with jobs grouped by topological level
+
+    Raises:
+        ValueError: if end < start_date for any dataset in the graph
+    """
+    graph = collect_graph(dataset_name, dataset_version, start, end)
+
+    # build reverse_edges: dep -> set of parents that depend on it.
+    # this lets us efficiently find which parents to update when a
+    # dependency completes (in-degree decrement).
+    reverse_edges: dict[Node, set[Node]] = defaultdict(set)
+    for parent, deps in graph.edges.items():
+        for dep in deps:
+            reverse_edges[dep].add(parent)
+
+    # compute in-degree: how many dependencies each node has.
+    # nodes with in_degree 0 are roots -- they have no deps and can
+    # be built immediately.
+    in_degree: dict[Node, int] = {}
+    for node in graph.ranges:
+        in_degree[node] = len(graph.edges.get(node, set()))
+
+    # Kahn's algorithm: process nodes level by level.
+    # each "level" is a wave of nodes whose dependencies have all been
+    # processed in prior levels.
+    levels: list[list[JobDescriptor]] = []
+    current_level_nodes = [node for node, deg in in_degree.items() if deg == 0]
+
+    while current_level_nodes:
+        # convert this level's nodes to JobDescriptors
+        jobs = []
+        for node in current_level_nodes:
+            name, version = node
+            range_start, range_end = graph.ranges[node]
+            jobs.append(
+                JobDescriptor(
+                    dataset_name=name,
+                    dataset_version=version,
+                    start=range_start,
+                    end=range_end,
+                )
+            )
+        levels.append(jobs)
+
+        # find the next level: for each node we just processed, decrement
+        # the in-degree of its parents (nodes that depend on it). any
+        # parent whose in-degree hits 0 is ready for the next level.
+        next_level_nodes: list[Node] = []
+        for node in current_level_nodes:
+            for parent in reverse_edges[node]:
+                in_degree[parent] -= 1
+                if in_degree[parent] == 0:
+                    next_level_nodes.append(parent)
+
+        current_level_nodes = next_level_nodes
+
+    return BuildPlan(levels=levels)

--- a/builders/server/tests/service/test_scheduler.py
+++ b/builders/server/tests/service/test_scheduler.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 from runtime.config import DependencyInfo
-from service.scheduler import collect_graph
+from service.scheduler import collect_graph, schedule_build
 
 from .conftest import V010, _cfg
 
@@ -321,3 +321,146 @@ def test_diamond_reexpansion_propagates_to_grandchildren(mock_registry) -> None:
         datetime(2024, 1, 4),
         datetime(2024, 1, 20),
     )
+
+
+# ============================================================
+# schedule_build tests
+# ============================================================
+
+
+def _job_names_by_level(plan) -> list[set[str]]:
+    """Extract dataset names per level for easier assertions."""
+    return [{j.dataset_name for j in level} for level in plan.levels]
+
+
+@patch("service.scheduler.registry")
+def test_schedule_single_root(mock_registry) -> None:
+    """Root with no deps -> 1 level, 1 job."""
+    mock_registry.get_config.return_value = _cfg(name="root")
+
+    plan = schedule_build("root", V010, datetime(2024, 1, 1), datetime(2024, 1, 5))
+
+    assert len(plan.levels) == 1
+    assert len(plan.levels[0]) == 1
+    job = plan.levels[0][0]
+    assert job.dataset_name == "root"
+    assert job.start == datetime(2024, 1, 1)
+    assert job.end == datetime(2024, 1, 5)
+
+
+@patch("service.scheduler.registry")
+def test_schedule_linear_chain_order(mock_registry) -> None:
+    """A -> B -> C produces 3 levels: C first, A last."""
+    configs = {
+        "A": _cfg(
+            name="A",
+            dependencies={"B": DependencyInfo(version=V010)},
+        ),
+        "B": _cfg(
+            name="B",
+            dependencies={"C": DependencyInfo(version=V010)},
+        ),
+        "C": _cfg(name="C"),
+    }
+    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+
+    plan = schedule_build("A", V010, datetime(2024, 1, 1), datetime(2024, 1, 5))
+
+    names = _job_names_by_level(plan)
+    assert len(names) == 3
+    assert names[0] == {"C"}  # root, level 0
+    assert names[1] == {"B"}  # level 1
+    assert names[2] == {"A"}  # level 2, requested dataset
+
+
+@patch("service.scheduler.registry")
+def test_schedule_diamond_levels(mock_registry) -> None:
+    """Diamond produces 3 levels: D at 0, {B, C} at 1, A at 2."""
+    configs = {
+        "A": _cfg(
+            name="A",
+            dependencies={
+                "B": DependencyInfo(version=V010),
+                "C": DependencyInfo(version=V010),
+            },
+        ),
+        "B": _cfg(
+            name="B",
+            dependencies={"D": DependencyInfo(version=V010)},
+        ),
+        "C": _cfg(
+            name="C",
+            dependencies={"D": DependencyInfo(version=V010)},
+        ),
+        "D": _cfg(name="D"),
+    }
+    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+
+    plan = schedule_build("A", V010, datetime(2024, 1, 1), datetime(2024, 1, 5))
+
+    names = _job_names_by_level(plan)
+    assert len(names) == 3
+    assert names[0] == {"D"}
+    assert names[1] == {"B", "C"}
+    assert names[2] == {"A"}
+
+
+@patch("service.scheduler.registry")
+def test_schedule_lookback_ranges_in_jobs(mock_registry) -> None:
+    """Lookback-expanded ranges are reflected in the JobDescriptor start/end."""
+    configs = {
+        "parent": _cfg(
+            name="parent",
+            dependencies={
+                "dep": DependencyInfo(
+                    version=V010, lookback_subtract=timedelta(days=4)
+                ),
+            },
+        ),
+        "dep": _cfg(name="dep"),
+    }
+    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+
+    plan = schedule_build("parent", V010, datetime(2024, 1, 10), datetime(2024, 1, 20))
+
+    # level 0 = dep (expanded range), level 1 = parent
+    dep_job = plan.levels[0][0]
+    parent_job = plan.levels[1][0]
+
+    assert dep_job.dataset_name == "dep"
+    assert dep_job.start == datetime(2024, 1, 6)  # Jan 10 - 4d
+    assert dep_job.end == datetime(2024, 1, 20)
+
+    assert parent_job.dataset_name == "parent"
+    assert parent_job.start == datetime(2024, 1, 10)
+    assert parent_job.end == datetime(2024, 1, 20)
+
+
+@patch("service.scheduler.registry")
+def test_schedule_jobs_within_level_are_independent(mock_registry) -> None:
+    """Jobs within the same level have no dependency edges between them."""
+    configs = {
+        "A": _cfg(
+            name="A",
+            dependencies={
+                "B": DependencyInfo(version=V010),
+                "C": DependencyInfo(version=V010),
+            },
+        ),
+        "B": _cfg(name="B"),
+        "C": _cfg(name="C"),
+    }
+    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+
+    plan = schedule_build("A", V010, datetime(2024, 1, 1), datetime(2024, 1, 5))
+
+    # level 0 should have B and C (both roots)
+    level0_names = {j.dataset_name for j in plan.levels[0]}
+    assert level0_names == {"B", "C"}
+
+    # verify no edges between B and C in the underlying graph
+    graph = collect_graph("A", V010, datetime(2024, 1, 1), datetime(2024, 1, 5))
+    b_deps = graph.edges.get(("B", V010), set())
+    c_deps = graph.edges.get(("C", V010), set())
+    assert ("C", V010) not in b_deps
+    assert ("B", V010) not in c_deps

--- a/builders/server/tests/service/test_scheduler.py
+++ b/builders/server/tests/service/test_scheduler.py
@@ -1,0 +1,323 @@
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+from runtime.config import DependencyInfo
+from service.scheduler import collect_graph
+
+from .conftest import V010, _cfg
+
+V020 = V010  # alias for readability in multi-version tests
+
+
+# --- single root, no deps ---
+
+
+@patch("service.scheduler.registry")
+def test_single_root_no_deps(mock_registry) -> None:
+    """Root dataset with no dependencies produces 1 node, no edges."""
+    mock_registry.get_config.return_value = _cfg(name="root")
+
+    graph = collect_graph("root", V010, datetime(2024, 1, 1), datetime(2024, 1, 5))
+
+    assert len(graph.ranges) == 1
+    assert ("root", V010) in graph.ranges
+    assert graph.ranges[("root", V010)] == (datetime(2024, 1, 1), datetime(2024, 1, 5))
+    assert graph.edges == {}
+
+
+# --- linear chain ---
+
+
+@patch("service.scheduler.registry")
+def test_linear_chain(mock_registry) -> None:
+    """A -> B -> C produces 3 nodes with correct edges and identical ranges."""
+    configs = {
+        "A": _cfg(
+            name="A",
+            dependencies={"B": DependencyInfo(version=V010)},
+        ),
+        "B": _cfg(
+            name="B",
+            dependencies={"C": DependencyInfo(version=V010)},
+        ),
+        "C": _cfg(name="C"),
+    }
+    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+
+    graph = collect_graph("A", V010, datetime(2024, 1, 1), datetime(2024, 1, 5))
+
+    assert len(graph.ranges) == 3
+    for name in ["A", "B", "C"]:
+        assert (name, V010) in graph.ranges
+        assert graph.ranges[(name, V010)] == (
+            datetime(2024, 1, 1),
+            datetime(2024, 1, 5),
+        )
+
+    assert graph.edges[("A", V010)] == {("B", V010)}
+    assert graph.edges[("B", V010)] == {("C", V010)}
+    assert ("C", V010) not in graph.edges
+
+
+# --- diamond dependency ---
+
+
+@patch("service.scheduler.registry")
+def test_diamond_deduplication(mock_registry) -> None:
+    """Diamond: A -> {B, C}, B -> D, C -> D. D appears once in ranges."""
+    configs = {
+        "A": _cfg(
+            name="A",
+            dependencies={
+                "B": DependencyInfo(version=V010),
+                "C": DependencyInfo(version=V010),
+            },
+        ),
+        "B": _cfg(
+            name="B",
+            dependencies={"D": DependencyInfo(version=V010)},
+        ),
+        "C": _cfg(
+            name="C",
+            dependencies={"D": DependencyInfo(version=V010)},
+        ),
+        "D": _cfg(name="D"),
+    }
+    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+
+    graph = collect_graph("A", V010, datetime(2024, 1, 1), datetime(2024, 1, 5))
+
+    assert len(graph.ranges) == 4
+    # D appears exactly once
+    assert ("D", V010) in graph.ranges
+    assert graph.ranges[("D", V010)] == (datetime(2024, 1, 1), datetime(2024, 1, 5))
+
+    # edges
+    assert graph.edges[("A", V010)] == {("B", V010), ("C", V010)}
+    assert graph.edges[("B", V010)] == {("D", V010)}
+    assert graph.edges[("C", V010)] == {("D", V010)}
+
+
+# --- lookback expansion ---
+
+
+@patch("service.scheduler.registry")
+def test_lookback_expands_dep_range(mock_registry) -> None:
+    """Lookback on a dependency widens its build range backwards."""
+    configs = {
+        "parent": _cfg(
+            name="parent",
+            dependencies={
+                "dep": DependencyInfo(
+                    version=V010,
+                    lookback_subtract=timedelta(days=4),
+                ),
+            },
+        ),
+        "dep": _cfg(name="dep"),
+    }
+    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+
+    graph = collect_graph("parent", V010, datetime(2024, 1, 10), datetime(2024, 1, 20))
+
+    # parent range unchanged
+    assert graph.ranges[("parent", V010)] == (
+        datetime(2024, 1, 10),
+        datetime(2024, 1, 20),
+    )
+    # dep range expanded: Jan 10 - 4d = Jan 6
+    assert graph.ranges[("dep", V010)] == (
+        datetime(2024, 1, 6),
+        datetime(2024, 1, 20),
+    )
+
+
+@patch("service.scheduler.registry")
+def test_lookback_propagates_through_chain(mock_registry) -> None:
+    """Lookback expansion propagates: A (lookback=5d on B) -> B -> C.
+    C's range should be expanded by A's lookback on B."""
+    configs = {
+        "A": _cfg(
+            name="A",
+            dependencies={
+                "B": DependencyInfo(
+                    version=V010,
+                    lookback_subtract=timedelta(days=4),
+                ),
+            },
+        ),
+        "B": _cfg(
+            name="B",
+            dependencies={"C": DependencyInfo(version=V010)},
+        ),
+        "C": _cfg(name="C"),
+    }
+    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+
+    graph = collect_graph("A", V010, datetime(2024, 1, 10), datetime(2024, 1, 20))
+
+    # A: unchanged
+    assert graph.ranges[("A", V010)] == (
+        datetime(2024, 1, 10),
+        datetime(2024, 1, 20),
+    )
+    # B: expanded by A's lookback
+    assert graph.ranges[("B", V010)] == (
+        datetime(2024, 1, 6),
+        datetime(2024, 1, 20),
+    )
+    # C: inherits B's expanded range (no additional lookback)
+    assert graph.ranges[("C", V010)] == (
+        datetime(2024, 1, 6),
+        datetime(2024, 1, 20),
+    )
+
+
+# --- diamond with different lookbacks ---
+
+
+@patch("service.scheduler.registry")
+def test_diamond_different_lookbacks_union(mock_registry) -> None:
+    """Diamond where B and C both depend on D with different lookbacks.
+    D's range should be the union of both expanded ranges."""
+    configs = {
+        "A": _cfg(
+            name="A",
+            dependencies={
+                "B": DependencyInfo(version=V010),
+                "C": DependencyInfo(version=V010),
+            },
+        ),
+        "B": _cfg(
+            name="B",
+            dependencies={
+                # B needs D with 3d lookback -> dep_start = Jan 10 - 2d = Jan 8
+                "D": DependencyInfo(version=V010, lookback_subtract=timedelta(days=2)),
+            },
+        ),
+        "C": _cfg(
+            name="C",
+            dependencies={
+                # C needs D with 7d lookback -> dep_start = Jan 10 - 6d = Jan 4
+                "D": DependencyInfo(version=V010, lookback_subtract=timedelta(days=6)),
+            },
+        ),
+        "D": _cfg(name="D"),
+    }
+    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+
+    graph = collect_graph("A", V010, datetime(2024, 1, 10), datetime(2024, 1, 20))
+
+    # D's range should be union: min(Jan 8, Jan 4)=Jan 4, max(Jan 20, Jan 20)=Jan 20
+    assert graph.ranges[("D", V010)] == (
+        datetime(2024, 1, 4),
+        datetime(2024, 1, 20),
+    )
+
+
+# --- start-date clamping ---
+
+
+@patch("service.scheduler.registry")
+def test_start_date_clamping(mock_registry) -> None:
+    """Start before dataset start-date gets clamped forward."""
+    mock_registry.get_config.return_value = _cfg(
+        name="ds", start_date=datetime(2024, 1, 5)
+    )
+
+    graph = collect_graph("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 10))
+
+    # start clamped to Jan 5
+    assert graph.ranges[("ds", V010)] == (
+        datetime(2024, 1, 5),
+        datetime(2024, 1, 10),
+    )
+
+
+@patch("service.scheduler.registry")
+def test_end_before_start_date_raises(mock_registry) -> None:
+    """End before dataset start-date raises ValueError."""
+    mock_registry.get_config.return_value = _cfg(
+        name="ds", start_date=datetime(2024, 6, 1)
+    )
+
+    with pytest.raises(ValueError, match="before.*start-date"):
+        collect_graph("ds", V010, datetime(2024, 5, 1), datetime(2024, 5, 15))
+
+
+@patch("service.scheduler.registry")
+def test_lookback_clamped_by_dep_start_date(mock_registry) -> None:
+    """Lookback expansion that pushes start before dep's start-date gets clamped."""
+    configs = {
+        "parent": _cfg(
+            name="parent",
+            dependencies={
+                "dep": DependencyInfo(
+                    version=V010,
+                    lookback_subtract=timedelta(days=30),
+                ),
+            },
+        ),
+        # dep has start-date Jan 1, lookback would push to Dec 2023
+        "dep": _cfg(name="dep", start_date=datetime(2024, 1, 1)),
+    }
+    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+
+    graph = collect_graph("parent", V010, datetime(2024, 1, 10), datetime(2024, 1, 20))
+
+    # dep start clamped to its start-date, not pushed before it
+    assert graph.ranges[("dep", V010)][0] == datetime(2024, 1, 1)
+
+
+# --- diamond re-expansion propagation ---
+
+
+@patch("service.scheduler.registry")
+def test_diamond_reexpansion_propagates_to_grandchildren(mock_registry) -> None:
+    """When a diamond dep's range expands on second visit, the expansion
+    propagates to its children.
+
+    Graph: A -> {B, C}. B -> D -> E. C -> D (with lookback).
+    B is visited first, giving D range [Jan 10, Jan 20].
+    C is visited second with lookback, giving D range [Jan 4, Jan 20].
+    D's range expands, so E must also get the expanded range.
+    """
+    configs = {
+        "A": _cfg(
+            name="A",
+            dependencies={
+                "B": DependencyInfo(version=V010),
+                "C": DependencyInfo(version=V010),
+            },
+        ),
+        "B": _cfg(
+            name="B",
+            dependencies={"D": DependencyInfo(version=V010)},
+        ),
+        "C": _cfg(
+            name="C",
+            dependencies={
+                "D": DependencyInfo(version=V010, lookback_subtract=timedelta(days=6)),
+            },
+        ),
+        "D": _cfg(
+            name="D",
+            dependencies={"E": DependencyInfo(version=V010)},
+        ),
+        "E": _cfg(name="E"),
+    }
+    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+
+    graph = collect_graph("A", V010, datetime(2024, 1, 10), datetime(2024, 1, 20))
+
+    # D expanded to Jan 4 via C's lookback
+    assert graph.ranges[("D", V010)] == (
+        datetime(2024, 1, 4),
+        datetime(2024, 1, 20),
+    )
+    # E must also have the expanded range from D's re-walk
+    assert graph.ranges[("E", V010)] == (
+        datetime(2024, 1, 4),
+        datetime(2024, 1, 20),
+    )


### PR DESCRIPTION
## Summary
- Add `schedule_build()` to `service/scheduler.py` -- Kahn's algorithm that consumes `collect_graph()` output and produces a `BuildPlan`
- Jobs grouped by topological level: level 0 = roots, level N+1 = datasets whose deps all live in levels 0..N
- Thorough docstrings explaining Kahn's algorithm, why it's chosen over Tarjan's (natural level-order output), and barrier semantics

## Test plan
- [x] 5 new tests: single root, linear chain ordering, diamond levels, lookback ranges in JobDescriptors, independence within levels
- [x] All 15 scheduler tests pass
- [x] \`just fix\` passes
- [x] \`just test\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)