### PR TITLE
docs: update backend spec for scheduler/worker/orchestrator architecture

### DIFF
--- a/builders/server/service/builder.py
+++ b/builders/server/service/builder.py
@@ -1,20 +1,24 @@
 from dataclasses import dataclass
-from datetime import datetime, timedelta
-from pathlib import Path
+from datetime import datetime
 
 import db.datasets
 import structlog
-from calendars.interface import Calendar
-from runtime import config, registry, runner, validator
+from runtime import registry
 from utils.semver import SemVer
 
-from service.locks import get_build_lock
+from service.orchestrator import run_build
+from service.timestamps import NoValidTimestampsError, generate_timestamps
 
 logger = structlog.get_logger()
 
-
-class NoValidTimestampsError(Exception):
-    """raised when generate_timestamps returns no valid calendar dates for the range."""
+# re-export so existing imports (api/routes.py, tests) keep working
+__all__ = [
+    "NoValidTimestampsError",
+    "generate_timestamps",
+    "build_dataset",
+    "get_data",
+    "DataResult",
+]
 
 
 @dataclass
@@ -26,27 +30,6 @@ class DataResult:
     returned_timestamps: int
 
 
-# TODO (bryan): benchmark this, and optimize if needed
-def generate_timestamps(
-    start: datetime,
-    end: datetime,
-    granularity: timedelta,
-    calendar: Calendar,
-) -> list[datetime]:
-    """Generate timestamps in [start, end], filtered by calendar."""
-    current = calendar.next_open(start)
-    if current is None:
-        # no open timestamps
-        return []
-
-    timestamps = []
-    while current <= end:
-        if calendar.is_open(current):
-            timestamps.append(current)
-        current += granularity
-    return timestamps
-
-
 def build_dataset(
     dataset_name: str,
     dataset_version: SemVer,
@@ -54,137 +37,7 @@ def build_dataset(
     end: datetime,
 ) -> None:
     """Public entrypoint for building a dataset and its dependencies."""
-    _build_recursive(dataset_name, dataset_version, start, end)
-
-
-def _build_recursive(
-    dataset_name: str,
-    dataset_version: SemVer,
-    start: datetime,
-    end: datetime,
-) -> None:
-    """Resolve dependencies, build missing timestamps, insert rows."""
-    cfg = registry.get_config(dataset_name, dataset_version)
-
-    # enforce start-date
-    start_date = cfg.start_date
-    if end < start_date:
-        raise ValueError(
-            f"build request end date {end} is before dataset start-date {start_date}"
-        )
-    if start < start_date:
-        logger.warning(
-            "clamping start to dataset start-date",
-            dataset=dataset_name,
-            version=str(dataset_version),
-            original_start=str(start),
-            start_date=str(start_date),
-        )
-        start = start_date
-
-    # recursively build dependencies first, expanding range for lookback
-    for dep_name, dep_info in cfg.dependencies.items():
-        if dep_info.lookback_subtract is not None:
-            dep_start = start - dep_info.lookback_subtract
-        else:
-            dep_start = start
-        _build_recursive(dep_name, dep_info.version, dep_start, end)
-
-    # determine which timestamps are valid for the range (outside lock, deterministic)
-    all_timestamps = generate_timestamps(start, end, cfg.granularity, cfg.calendar)
-
-    if not all_timestamps:
-        raise NoValidTimestampsError(
-            f"{dataset_name}/{dataset_version}: no valid calendar timestamps "
-            f"in range [{start}, {end}] for calendar '{cfg.calendar.name}'"
-        )
-
-    # acquire per-dataset lock to prevent concurrent builds from racing
-    # between the "check missing" read and "insert rows" write
-    with get_build_lock(dataset_name, str(dataset_version)):
-        existing = set(
-            db.datasets.get_existing_timestamps(
-                dataset_name, dataset_version, start, end
-            )
-        )
-        missing = [ts for ts in all_timestamps if ts not in existing]
-
-        if not missing:
-            logger.info(
-                "all timestamps present, skipping",
-                dataset=dataset_name,
-                version=str(dataset_version),
-            )
-            return
-
-        logger.info(
-            "building missing timestamps",
-            dataset=dataset_name,
-            version=str(dataset_version),
-            count=len(missing),
-        )
-
-        # resolve env file if env-vars is enabled
-        env_file: Path | None = None
-        if cfg.env_vars:
-            env_file = config.SCRIPTS_DIR / dataset_name / str(cfg.version) / ".env"
-            if not env_file.exists():
-                raise FileNotFoundError(
-                    f"{dataset_name}/{dataset_version}: env-vars is enabled "
-                    f"but {env_file} does not exist"
-                )
-
-        script_dir = config.SCRIPTS_DIR / dataset_name / str(cfg.version)
-
-        # TODO (bryan): this spawns builder processes sequentially, one for each
-        # timestamp. we then sync wait for that process to be done before moving on.
-        # can we spawn them all at the start, then launch them all at the same time?
-        # because certain builders may block (i.e. fetch from an external API)
-
-        # build each missing timestamp
-        rows = []
-        for ts in missing:
-            # fetch dependency data for this timestamp
-            dep_data: dict[str, dict[datetime, list[dict]]] = {}
-            for dep_name, dep_info in cfg.dependencies.items():
-                if dep_info.lookback_subtract is not None:
-                    dep_rows = db.datasets.get_rows_range(
-                        dep_name,
-                        dep_info.version,
-                        ts - dep_info.lookback_subtract,
-                        ts,
-                    )
-                else:
-                    # no lookback, fetch just this timestamp
-                    dep_rows = db.datasets.get_rows_timestamps(
-                        dep_name, dep_info.version, [ts]
-                    )
-
-                if not dep_rows:
-                    raise RuntimeError(
-                        f"Dependency '{dep_name}/{dep_info.version}' "
-                        f"missing data for timestamp {ts}"
-                    )
-                dep_data[dep_name] = dep_rows
-
-            # run builder in subprocess
-            result = runner.run_builder(
-                script_dir, cfg.builder, dep_data, ts, env_file=env_file
-            )
-
-            # validate output against schema
-            validator.validate_rows(result, cfg.schema)
-
-            rows.append((ts, result))
-
-        # bulk insert all rows
-        db.datasets.insert_rows(dataset_name, dataset_version, rows)
-        logger.info(
-            "inserted rows",
-            dataset=dataset_name,
-            version=str(dataset_version),
-            count=len(rows),
-        )
+    run_build(dataset_name, dataset_version, start, end)
 
 
 def get_data(

--- a/builders/server/service/orchestrator.py
+++ b/builders/server/service/orchestrator.py
@@ -1,0 +1,87 @@
+"""Build orchestrator: level-by-level execution of a topological build plan.
+
+Given a dataset and time range, the orchestrator:
+
+1. Calls ``schedule_build()`` to produce a ``BuildPlan`` (topological
+   levels via Kahn's algorithm)
+2. Iterates levels sequentially (barrier model: all level N jobs must
+   complete before any level N+1 job starts)
+3. Within each level, executes jobs sequentially via ``execute_job()``
+   (MVP single worker -- future: parallelize within levels)
+4. On any job failure: sets a ``cancelled`` event so in-flight siblings
+   can terminate early, then raises ``RuntimeError``
+
+The orchestrator does not touch the DB directly -- that is the worker's
+responsibility. It only coordinates execution order.
+"""
+
+import threading
+from datetime import datetime
+
+import structlog
+from utils.semver import SemVer
+
+from service.scheduler import schedule_build
+from service.worker import execute_job
+
+logger = structlog.get_logger()
+
+
+def run_build(
+    dataset_name: str,
+    dataset_version: SemVer,
+    start: datetime,
+    end: datetime,
+) -> None:
+    """Orchestrate a full build: schedule, then execute level by level.
+
+    Produces a topological build plan via ``schedule_build()`` and
+    executes it. Levels are barriers -- all jobs in level N complete
+    before level N+1 starts. Within a level, jobs are independent
+    (currently executed sequentially; safe to parallelize later).
+
+    If any job fails, remaining jobs in the current level and all
+    subsequent levels are skipped. A ``cancelled`` event is set so
+    any in-flight workers (future parallel execution) can terminate
+    early.
+
+    Args:
+        dataset_name: root dataset to build
+        dataset_version: version of the root dataset
+        start: requested build start time
+        end: requested build end time
+
+    Raises:
+        ValueError: if end < start_date for any dataset (from scheduler)
+        RuntimeError: if any job fails during execution
+        NoValidTimestampsError: if a job has no valid calendar timestamps
+    """
+    plan = schedule_build(dataset_name, dataset_version, start, end)
+    cancelled = threading.Event()
+
+    logger.info(
+        "build plan ready",
+        dataset=dataset_name,
+        version=str(dataset_version),
+        levels=len(plan.levels),
+        total_jobs=sum(len(level) for level in plan.levels),
+    )
+
+    for level_idx, jobs in enumerate(plan.levels):
+        logger.info(
+            "starting level",
+            level=level_idx,
+            jobs=[j.dataset_name for j in jobs],
+        )
+
+        for job in jobs:
+            result = execute_job(job, cancelled)
+
+            if not result.success:
+                cancelled.set()
+                raise RuntimeError(
+                    f"build failed for {job.dataset_name}/"
+                    f"{job.dataset_version}: {result.error}"
+                )
+
+        logger.info("level complete", level=level_idx)

--- a/builders/server/service/scheduler.py
+++ b/builders/server/service/scheduler.py
@@ -1,0 +1,174 @@
+"""Dependency graph collection for build scheduling.
+
+This module walks a dataset's dependency tree and computes the time ranges
+each dataset needs to be built over, accounting for lookback expansion,
+start-date clamping, and diamond dependency deduplication.
+
+The graph is collected in a single DFS pass. A separate module (added later)
+will consume this graph to produce a topologically ordered BuildPlan via
+Kahn's algorithm.
+
+Terminology:
+    Node: a (dataset_name, SemVer) pair identifying one dataset.
+    Edge: parent -> dependency. "A depends on B" means edge A -> B.
+    Range: the [start, end] time interval a dataset must be built for.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+import structlog
+from runtime import registry
+from utils.semver import SemVer
+
+logger = structlog.get_logger()
+
+type Node = tuple[str, SemVer]
+
+
+@dataclass
+class DependencyGraph:
+    """The raw dependency graph with computed time ranges.
+
+    Produced by collect_graph(). Contains all the information needed for
+    Kahn's algorithm to produce a topologically ordered BuildPlan.
+
+    Attributes:
+        ranges: maps each node to its required (start, end) build range.
+            Ranges account for lookback expansion and start-date clamping.
+            For diamond dependencies, the range is the union (widest) of
+            all ranges requested by different parents.
+        edges: maps each parent node to the set of its direct dependencies.
+            Only populated for nodes that have dependencies. Root nodes
+            (no deps) appear in ranges but not in edges.
+    """
+
+    ranges: dict[Node, tuple[datetime, datetime]] = field(default_factory=dict)
+    edges: dict[Node, set[Node]] = field(default_factory=dict)
+
+
+def collect_graph(
+    dataset_name: str,
+    dataset_version: SemVer,
+    start: datetime,
+    end: datetime,
+) -> DependencyGraph:
+    """Walk the dependency tree and collect all nodes with their required ranges.
+
+    Starting from the root dataset, performs a DFS through the dependency
+    graph. For each node it:
+    1. Clamps start to the dataset's start_date (same as _build_recursive)
+    2. Records the required [start, end] range
+    3. Expands dependency ranges by lookback_subtract when applicable
+    4. Recurses into dependencies
+
+    Diamond dependencies (same dataset reachable via multiple paths) are
+    handled by taking the union of required ranges. If a second visit
+    widens a node's range, its subtree is re-walked so the expansion
+    propagates to grandchildren. Since ranges only ever widen (never
+    shrink), convergence is guaranteed for any acyclic graph.
+
+    Args:
+        dataset_name: root dataset to build
+        dataset_version: version of the root dataset
+        start: requested build start time
+        end: requested build end time
+
+    Returns:
+        DependencyGraph with ranges and edges for all reachable datasets
+
+    Raises:
+        ValueError: if end < start_date for any dataset in the graph
+    """
+    graph = DependencyGraph()
+    _collect(dataset_name, dataset_version, start, end, graph)
+    return graph
+
+
+def _collect(
+    name: str,
+    version: SemVer,
+    start: datetime,
+    end: datetime,
+    graph: DependencyGraph,
+) -> None:
+    """Recursive DFS helper that populates the graph.
+
+    For each node, this function:
+    1. Loads the config from the startup registry
+    2. Validates end >= start_date, clamps start to start_date
+    3. Checks if we've visited this node before (diamond case):
+       - If yes and the range didn't expand: return early (no re-walk needed)
+       - If yes and the range expanded: update to union, re-walk children
+       - If no: record the range and walk children
+    4. For each dependency, computes the expanded range (lookback) and recurses
+
+    Args:
+        name: dataset name
+        version: dataset version
+        start: required start for this node (may be expanded by parent's lookback)
+        end: required end for this node
+        graph: mutable graph being built up across the DFS
+    """
+    cfg = registry.get_config(name, version)
+    node: Node = (name, version)
+
+    # enforce start-date: reject if end is before the dataset's start_date,
+    # clamp start forward if it precedes start_date
+    if end < cfg.start_date:
+        raise ValueError(
+            f"build request end date {end} is before "
+            f"dataset {name}/{version} start-date {cfg.start_date}"
+        )
+    if start < cfg.start_date:
+        logger.warning(
+            "clamping start to dataset start-date",
+            dataset=name,
+            version=str(version),
+            original_start=str(start),
+            start_date=str(cfg.start_date),
+        )
+        start = cfg.start_date
+
+    # diamond dependency handling: if we've seen this node before,
+    # check whether the new range is wider than what we recorded
+    if node in graph.ranges:
+        existing_start, existing_end = graph.ranges[node]
+        new_start = min(existing_start, start)
+        new_end = max(existing_end, end)
+
+        # if the range didn't actually expand, no need to re-walk
+        # children since they already cover the required range
+        if new_start >= existing_start and new_end <= existing_end:
+            return
+
+        # range expanded -- update and fall through to re-walk children
+        graph.ranges[node] = (new_start, new_end)
+        start = new_start
+        end = new_end
+    else:
+        graph.ranges[node] = (start, end)
+
+    # walk dependencies, expanding ranges for lookback
+    if not cfg.dependencies:
+        return
+
+    deps: set[Node] = set()
+    for dep_name, dep_info in cfg.dependencies.items():
+        dep_node: Node = (dep_name, dep_info.version)
+        deps.add(dep_node)
+
+        # lookback expansion: if this dependency has a lookback window,
+        # we need data starting earlier. e.g. "5d" lookback with
+        # lookback_subtract=timedelta(days=4) means we need data from
+        # [start - 4d, end] so the builder gets 5 days inclusive.
+        dep_start = start
+        if dep_info.lookback_subtract is not None:
+            dep_start = start - dep_info.lookback_subtract
+
+        _collect(dep_name, dep_info.version, dep_start, end, graph)
+
+    # record edges (overwrite on re-walk is fine, deps don't change)
+    graph.edges[node] = deps

--- a/builders/server/service/scheduler.py
+++ b/builders/server/service/scheduler.py
@@ -1,12 +1,17 @@
-"""Dependency graph collection for build scheduling.
+"""Dependency graph collection and topological scheduling for builds.
 
-This module walks a dataset's dependency tree and computes the time ranges
-each dataset needs to be built over, accounting for lookback expansion,
-start-date clamping, and diamond dependency deduplication.
+This module has two layers:
 
-The graph is collected in a single DFS pass. A separate module (added later)
-will consume this graph to produce a topologically ordered BuildPlan via
-Kahn's algorithm.
+1. Graph collection (collect_graph): DFS walk that computes time ranges
+   each dataset needs, accounting for lookback expansion, start-date
+   clamping, and diamond dependency deduplication.
+
+2. Topological scheduling (schedule_build): Kahn's algorithm that consumes
+   the collected graph and produces a BuildPlan with jobs grouped by
+   topological level. Level 0 = roots (no deps), level N+1 = datasets
+   whose deps all live in levels 0..N. The orchestrator executes levels
+   sequentially as barriers -- all jobs in level N must complete before
+   any job in level N+1 starts.
 
 Terminology:
     Node: a (dataset_name, SemVer) pair identifying one dataset.
@@ -16,12 +21,15 @@ Terminology:
 
 from __future__ import annotations
 
+from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
 
 import structlog
 from runtime import registry
 from utils.semver import SemVer
+
+from service.models import BuildPlan, JobDescriptor
 
 logger = structlog.get_logger()
 
@@ -172,3 +180,97 @@ def _collect(
 
     # record edges (overwrite on re-walk is fine, deps don't change)
     graph.edges[node] = deps
+
+
+def schedule_build(
+    dataset_name: str,
+    dataset_version: SemVer,
+    start: datetime,
+    end: datetime,
+) -> BuildPlan:
+    """Produce a topologically ordered build plan for a dataset and its dependencies.
+
+    Uses Kahn's algorithm (BFS-based topological sort) on the graph from
+    collect_graph(). Kahn's is chosen over Tarjan's DFS-based sort because
+    it naturally produces level-order grouping -- nodes are processed in
+    waves by their distance from roots, which directly maps to the barrier
+    model the orchestrator needs.
+
+    Algorithm:
+        1. Collect the dependency graph (nodes, ranges, edges)
+        2. Compute in-degree for each node (number of dependencies it has)
+        3. Seed level 0 with all zero-in-degree nodes (roots)
+        4. For each level: remove those nodes, decrement in-degrees of their
+           dependents (parents), and collect newly zero-in-degree nodes as
+           the next level
+        5. Convert each node + range into a JobDescriptor, grouped by level
+
+    The result is a BuildPlan where:
+        - levels[0] = root datasets (no deps, build first)
+        - levels[-1] = the originally requested dataset (build last)
+        - within each level, jobs are independent and safe to parallelize
+
+    Args:
+        dataset_name: root dataset to build
+        dataset_version: version of the root dataset
+        start: requested build start time
+        end: requested build end time
+
+    Returns:
+        BuildPlan with jobs grouped by topological level
+
+    Raises:
+        ValueError: if end < start_date for any dataset in the graph
+    """
+    graph = collect_graph(dataset_name, dataset_version, start, end)
+
+    # build reverse_edges: dep -> set of parents that depend on it.
+    # this lets us efficiently find which parents to update when a
+    # dependency completes (in-degree decrement).
+    reverse_edges: dict[Node, set[Node]] = defaultdict(set)
+    for parent, deps in graph.edges.items():
+        for dep in deps:
+            reverse_edges[dep].add(parent)
+
+    # compute in-degree: how many dependencies each node has.
+    # nodes with in_degree 0 are roots -- they have no deps and can
+    # be built immediately.
+    in_degree: dict[Node, int] = {}
+    for node in graph.ranges:
+        in_degree[node] = len(graph.edges.get(node, set()))
+
+    # Kahn's algorithm: process nodes level by level.
+    # each "level" is a wave of nodes whose dependencies have all been
+    # processed in prior levels.
+    levels: list[list[JobDescriptor]] = []
+    current_level_nodes = [node for node, deg in in_degree.items() if deg == 0]
+
+    while current_level_nodes:
+        # convert this level's nodes to JobDescriptors
+        jobs = []
+        for node in current_level_nodes:
+            name, version = node
+            range_start, range_end = graph.ranges[node]
+            jobs.append(
+                JobDescriptor(
+                    dataset_name=name,
+                    dataset_version=version,
+                    start=range_start,
+                    end=range_end,
+                )
+            )
+        levels.append(jobs)
+
+        # find the next level: for each node we just processed, decrement
+        # the in-degree of its parents (nodes that depend on it). any
+        # parent whose in-degree hits 0 is ready for the next level.
+        next_level_nodes: list[Node] = []
+        for node in current_level_nodes:
+            for parent in reverse_edges[node]:
+                in_degree[parent] -= 1
+                if in_degree[parent] == 0:
+                    next_level_nodes.append(parent)
+
+        current_level_nodes = next_level_nodes
+
+    return BuildPlan(levels=levels)

--- a/builders/server/service/timestamps.py
+++ b/builders/server/service/timestamps.py
@@ -1,0 +1,34 @@
+"""Timestamp generation and related exceptions.
+
+Separated from builder.py to avoid circular imports between
+builder -> orchestrator -> worker -> builder.
+"""
+
+from datetime import datetime, timedelta
+
+from calendars.interface import Calendar
+
+
+class NoValidTimestampsError(Exception):
+    """raised when generate_timestamps returns no valid calendar dates for the range."""
+
+
+# TODO (bryan): benchmark this, and optimize if needed
+def generate_timestamps(
+    start: datetime,
+    end: datetime,
+    granularity: timedelta,
+    calendar: Calendar,
+) -> list[datetime]:
+    """Generate timestamps in [start, end], filtered by calendar."""
+    current = calendar.next_open(start)
+    if current is None:
+        # no open timestamps
+        return []
+
+    timestamps = []
+    while current <= end:
+        if calendar.is_open(current):
+            timestamps.append(current)
+        current += granularity
+    return timestamps

--- a/builders/server/service/worker.py
+++ b/builders/server/service/worker.py
@@ -1,0 +1,185 @@
+"""Single-job build worker.
+
+Extracts the per-dataset build logic from the former ``_build_recursive()``
+into a standalone ``execute_job()`` function. Given a ``JobDescriptor``,
+the worker:
+
+1. Generates valid timestamps for the job's range
+2. Acquires the per-dataset lock
+3. Checks which timestamps already exist in the DB
+4. For each missing timestamp: fetches dep data, runs the builder
+   subprocess, validates output against the schema
+5. Bulk-inserts all rows on success (atomicity: no partial inserts)
+
+The worker does NOT handle dependency graph walking or start-date
+clamping -- those are the scheduler's responsibility.
+"""
+
+import threading
+from datetime import datetime
+from pathlib import Path
+
+import db.datasets
+import structlog
+from runtime import config, registry, runner, validator
+
+from service.builder import NoValidTimestampsError, generate_timestamps
+from service.locks import get_build_lock
+from service.models import JobDescriptor, JobResult
+
+logger = structlog.get_logger()
+
+
+def execute_job(
+    job: JobDescriptor,
+    cancelled: threading.Event,
+) -> JobResult:
+    """Execute a single build job: build missing timestamps for one dataset.
+
+    This is the per-dataset build logic extracted from the former
+    ``_build_recursive()``. The scheduler has already resolved the
+    dependency graph and computed time ranges (with lookback expansion
+    and start-date clamping), so the worker just builds.
+
+    Atomicity: rows are accumulated in memory and bulk-inserted only
+    after all timestamps succeed. If any timestamp fails, no rows are
+    inserted for this job.
+
+    Args:
+        job: describes which dataset to build and over what time range.
+        cancelled: shared event that signals early termination. checked
+            between timestamps so a failed sibling job can stop peers.
+
+    Returns:
+        JobResult indicating success or failure with error detail.
+    """
+    try:
+        _execute(job, cancelled)
+        return JobResult(job=job, success=True)
+    except NoValidTimestampsError:
+        # let NoValidTimestampsError propagate so routes.py can return 422
+        raise
+    except Exception as exc:
+        return JobResult(job=job, success=False, error=str(exc))
+
+
+def _execute(
+    job: JobDescriptor,
+    cancelled: threading.Event,
+) -> None:
+    """Inner execution logic. Raises on any failure.
+
+    Separated from execute_job() so the outer function can catch all
+    exceptions uniformly and wrap them into a JobResult.
+    """
+    cfg = registry.get_config(job.dataset_name, job.dataset_version)
+
+    # generate valid calendar timestamps for the range
+    all_timestamps = generate_timestamps(
+        job.start, job.end, cfg.granularity, cfg.calendar
+    )
+
+    if not all_timestamps:
+        raise NoValidTimestampsError(
+            f"{job.dataset_name}/{job.dataset_version}: no valid calendar "
+            f"timestamps in range [{job.start}, {job.end}] "
+            f"for calendar '{cfg.calendar.name}'"
+        )
+
+    # acquire per-dataset lock to prevent concurrent builds from racing
+    # between the "check missing" read and "insert rows" write
+    with get_build_lock(job.dataset_name, str(job.dataset_version)):
+        existing = set(
+            db.datasets.get_existing_timestamps(
+                job.dataset_name, job.dataset_version, job.start, job.end
+            )
+        )
+        missing = [ts for ts in all_timestamps if ts not in existing]
+
+        if not missing:
+            logger.info(
+                "all timestamps present, skipping",
+                dataset=job.dataset_name,
+                version=str(job.dataset_version),
+            )
+            return
+
+        logger.info(
+            "building missing timestamps",
+            dataset=job.dataset_name,
+            version=str(job.dataset_version),
+            count=len(missing),
+        )
+
+        # resolve env file if env-vars is enabled
+        env_file: Path | None = None
+        if cfg.env_vars:
+            env_file = config.SCRIPTS_DIR / job.dataset_name / str(cfg.version) / ".env"
+            if not env_file.exists():
+                raise FileNotFoundError(
+                    f"{job.dataset_name}/{job.dataset_version}: env-vars is "
+                    f"enabled but {env_file} does not exist"
+                )
+
+        script_dir = config.SCRIPTS_DIR / job.dataset_name / str(cfg.version)
+
+        # build each missing timestamp, accumulating rows in memory
+        rows: list[tuple[datetime, list[dict]]] = []
+        for ts in missing:
+            # check cancellation between timestamps so a failed sibling
+            # job can stop this worker early
+            if cancelled.is_set():
+                raise RuntimeError(
+                    f"{job.dataset_name}/{job.dataset_version}: "
+                    "build cancelled by failed sibling job"
+                )
+
+            dep_data = _fetch_dep_data(cfg, ts)
+
+            result = runner.run_builder(
+                script_dir, cfg.builder, dep_data, ts, env_file=env_file
+            )
+            validator.validate_rows(result, cfg.schema)
+            rows.append((ts, result))
+
+        # bulk insert -- only reached if all timestamps succeeded
+        db.datasets.insert_rows(job.dataset_name, job.dataset_version, rows)
+        logger.info(
+            "inserted rows",
+            dataset=job.dataset_name,
+            version=str(job.dataset_version),
+            count=len(rows),
+        )
+
+
+def _fetch_dep_data(
+    cfg: config.DatasetConfig,
+    ts: datetime,
+) -> dict[str, dict[datetime, list[dict]]]:
+    """Fetch dependency data for a single timestamp.
+
+    For deps with lookback, fetches a range [ts - lookback_subtract, ts].
+    For deps without lookback, fetches just the single timestamp.
+    Raises RuntimeError if any dependency is missing data.
+    """
+    dep_data: dict[str, dict[datetime, list[dict]]] = {}
+
+    for dep_name, dep_info in cfg.dependencies.items():
+        if dep_info.lookback_subtract is not None:
+            dep_rows = db.datasets.get_rows_range(
+                dep_name,
+                dep_info.version,
+                ts - dep_info.lookback_subtract,
+                ts,
+            )
+        else:
+            dep_rows = db.datasets.get_rows_timestamps(dep_name, dep_info.version, [ts])
+
+        if not dep_rows:
+            raise RuntimeError(
+                f"Dependency '{dep_name}/{dep_info.version}' "
+                f"missing data for timestamp {ts}"
+            )
+        dep_data[dep_name] = dep_rows
+
+    return dep_data

--- a/builders/server/service/worker.py
+++ b/builders/server/service/worker.py
@@ -23,9 +23,9 @@ import db.datasets
 import structlog
 from runtime import config, registry, runner, validator
 
-from service.builder import NoValidTimestampsError, generate_timestamps
 from service.locks import get_build_lock
 from service.models import JobDescriptor, JobResult
+from service.timestamps import NoValidTimestampsError, generate_timestamps
 
 logger = structlog.get_logger()
 

--- a/builders/server/tests/service/test_builder.py
+++ b/builders/server/tests/service/test_builder.py
@@ -5,7 +5,6 @@ import pytest
 from calendars.definitions.always_open import AlwaysOpenCalendar
 from calendars.definitions.everyday import EverydayCalendar
 from calendars.definitions.weekday import WeekdayCalendar
-from runtime.config import DependencyInfo
 from service.builder import (
     NoValidTimestampsError,
     build_dataset,
@@ -124,384 +123,36 @@ def test_generate_timestamps_start_on_closed_day_no_valid_range_returns_empty() 
     assert result == []
 
 
-# --- build_dataset tests ---
+# --- build_dataset delegation tests ---
+# detailed build behavior is tested in test_scheduler, test_worker, test_orchestrator
 
 
-@patch("service.builder.db.datasets")
-@patch("service.builder.registry")
-def test_build_dataset_skips_existing(
-    mock_registry: MagicMock, mock_db: MagicMock
-) -> None:
-    """All timestamps exist, runner never called."""
-    mock_registry.get_config.return_value = _cfg()
-    # all timestamps already exist
-    mock_db.get_existing_timestamps.return_value = [
-        datetime(2024, 1, 1),
-        datetime(2024, 1, 2),
-    ]
+@patch("service.builder.run_build")
+def test_build_dataset_delegates_to_orchestrator(mock_run_build: MagicMock) -> None:
+    """build_dataset delegates to run_build with the same args."""
+    build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 5))
 
-    with patch("service.builder.runner") as mock_runner:
-        build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 2))
-        mock_runner.run_builder.assert_not_called()
-    mock_db.insert_rows.assert_not_called()
+    mock_run_build.assert_called_once_with(
+        "ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 5)
+    )
 
 
-@patch("service.builder.validator")
-@patch("service.builder.runner")
-@patch("service.builder.db.datasets")
-@patch("service.builder.registry")
-def test_build_dataset_builds_missing(
-    mock_registry: MagicMock,
-    mock_db: MagicMock,
-    mock_runner: MagicMock,
-    mock_validator: MagicMock,
-) -> None:
-    """Missing timestamps trigger runner + insert."""
-    mock_registry.get_config.return_value = _cfg()
-    mock_db.get_existing_timestamps.return_value = [datetime(2024, 1, 1)]
-    mock_runner.run_builder.return_value = [{"val": 1}]
+@patch("service.builder.run_build")
+def test_build_dataset_propagates_value_error(mock_run_build: MagicMock) -> None:
+    """ValueError from scheduler (end before start-date) propagates."""
+    mock_run_build.side_effect = ValueError("before start-date")
 
-    build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 2))
-
-    # only 2024-01-02 is missing, so runner called once
-    assert mock_runner.run_builder.call_count == 1
-    mock_db.insert_rows.assert_called_once()
-    inserted_rows = mock_db.insert_rows.call_args[0][2]
-    assert len(inserted_rows) == 1
-    assert inserted_rows[0][0] == datetime(2024, 1, 2)
-    assert inserted_rows[0][1] == [{"val": 1}]
-
-
-@patch("service.builder.validator")
-@patch("service.builder.runner")
-@patch("service.builder.db.datasets")
-@patch("service.builder.registry")
-def test_build_dataset_recursive_dependencies(
-    mock_registry: MagicMock,
-    mock_db: MagicMock,
-    mock_runner: MagicMock,
-    mock_validator: MagicMock,
-) -> None:
-    """Dependencies built before parent."""
-
-    def fake_get_config(name, version):
-        if name == "parent":
-            return _cfg(
-                name="parent",
-                dependencies={"child": DependencyInfo(version=V010)},
-            )
-        return _cfg(name="child")
-
-    mock_registry.get_config.side_effect = fake_get_config
-    # all timestamps exist so no building needed, but we track get_config call order
-    mock_db.get_existing_timestamps.return_value = [datetime(2024, 1, 1)]
-
-    build_dataset("parent", V010, datetime(2024, 1, 1), datetime(2024, 1, 1))
-
-    # get_config called for parent first, then child (recursive)
-    calls = mock_registry.get_config.call_args_list
-    assert calls[0][0][0] == "parent"
-    assert calls[1][0][0] == "child"
-
-
-@patch("service.builder.runner")
-@patch("service.builder.db.datasets")
-@patch("service.builder.registry")
-def test_build_dataset_missing_dependency_data_raises(
-    mock_registry: MagicMock,
-    mock_db: MagicMock,
-    mock_runner: MagicMock,
-) -> None:
-    """Missing dep data raises RuntimeError."""
-
-    def fake_get_config(name, version):
-        if name == "ds":
-            return _cfg(
-                dependencies={"dep": DependencyInfo(version=V010)},
-            )
-        # dep has no dependencies, so recursion stops
-        return _cfg(name="dep")
-
-    mock_registry.get_config.side_effect = fake_get_config
-    # no existing timestamps for either dataset
-    mock_db.get_existing_timestamps.return_value = []
-    # dep has no data for the timestamp (after dep build completes with no inserts)
-    mock_db.get_rows_timestamps.return_value = {}
-    mock_runner.run_builder.return_value = []
-
-    with pytest.raises(RuntimeError, match="missing data for timestamp"):
-        build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 1))
-
-
-@patch("service.builder.validator")
-@patch("service.builder.runner")
-@patch("service.builder.db.datasets")
-@patch("service.builder.registry")
-def test_build_dataset_passes_dep_data_as_dict_of_timestamps(
-    mock_registry: MagicMock,
-    mock_db: MagicMock,
-    mock_runner: MagicMock,
-    mock_validator: MagicMock,
-) -> None:
-    """Dependency data is passed as dict[datetime, list[dict]] to the builder."""
-
-    def fake_get_config(name, version):
-        if name == "ds":
-            return _cfg(
-                dependencies={"dep": DependencyInfo(version=V010)},
-            )
-        return _cfg(name="dep")
-
-    mock_registry.get_config.side_effect = fake_get_config
-    # dep recurses first, then ds
-    mock_db.get_existing_timestamps.side_effect = [
-        [datetime(2024, 1, 1)],  # dep already built (recursive call happens first)
-        [],  # ds has no data
-    ]
-    # dep returns multi-row data keyed by timestamp
-    ts = datetime(2024, 1, 1)
-    dep_rows = [{"ticker": "AAPL", "close": 150}, {"ticker": "MSFT", "close": 200}]
-    mock_db.get_rows_timestamps.return_value = {ts: dep_rows}
-    mock_runner.run_builder.return_value = [{"val": 1}]
-
-    build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 1))
-
-    # verify dep_data passed to runner is dict[datetime, list[dict]]
-    runner_call = mock_runner.run_builder.call_args
-    passed_deps = runner_call[0][2]
-    assert passed_deps["dep"] == {ts: dep_rows}
-
-
-# --- start-date enforcement tests ---
-
-
-@patch("service.builder.db.datasets")
-@patch("service.builder.registry")
-def test_build_dataset_end_before_start_date_raises(
-    mock_registry: MagicMock, mock_db: MagicMock
-) -> None:
-    """End date before dataset start-date raises ValueError."""
-    mock_registry.get_config.return_value = _cfg(start_date=datetime(2024, 6, 1))
-
-    with pytest.raises(ValueError, match="before dataset start-date"):
+    with pytest.raises(ValueError, match="before start-date"):
         build_dataset("ds", V010, datetime(2024, 5, 1), datetime(2024, 5, 15))
 
 
-@patch("service.builder.validator")
-@patch("service.builder.runner")
-@patch("service.builder.db.datasets")
-@patch("service.builder.registry")
-def test_build_dataset_start_before_start_date_clamps(
-    mock_registry: MagicMock,
-    mock_db: MagicMock,
-    mock_runner: MagicMock,
-    mock_validator: MagicMock,
-) -> None:
-    """Start date before dataset start-date gets clamped."""
-    mock_registry.get_config.return_value = _cfg(start_date=datetime(2024, 1, 3))
-    mock_db.get_existing_timestamps.return_value = []
-    mock_runner.run_builder.return_value = [{"val": 1}]
+@patch("service.builder.run_build")
+def test_build_dataset_propagates_runtime_error(mock_run_build: MagicMock) -> None:
+    """RuntimeError from worker failure propagates."""
+    mock_run_build.side_effect = RuntimeError("build failed")
 
-    # request starts on Jan 1 but start-date is Jan 3
-    build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 4))
-
-    # timestamps should start from Jan 3 (clamped), not Jan 1
-    inserted_rows = mock_db.insert_rows.call_args[0][2]
-    timestamps = [row[0] for row in inserted_rows]
-    assert timestamps[0] == datetime(2024, 1, 3)
-    assert datetime(2024, 1, 1) not in timestamps
-    assert datetime(2024, 1, 2) not in timestamps
-
-
-@patch("service.builder.validator")
-@patch("service.builder.runner")
-@patch("service.builder.db.datasets")
-@patch("service.builder.registry")
-def test_build_dataset_after_start_date_proceeds_normally(
-    mock_registry: MagicMock,
-    mock_db: MagicMock,
-    mock_runner: MagicMock,
-    mock_validator: MagicMock,
-) -> None:
-    """Both dates after start-date proceeds without clamping."""
-    mock_registry.get_config.return_value = _cfg()
-    mock_db.get_existing_timestamps.return_value = []
-    mock_runner.run_builder.return_value = [{"val": 1}]
-
-    build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 3))
-
-    inserted_rows = mock_db.insert_rows.call_args[0][2]
-    timestamps = [row[0] for row in inserted_rows]
-    assert timestamps[0] == datetime(2024, 1, 1)
-    assert len(timestamps) == 3
-
-
-# --- NoValidTimestampsError tests ---
-
-
-@patch("service.builder.db.datasets")
-@patch("service.builder.registry")
-def test_build_dataset_no_valid_timestamps_raises(
-    mock_registry: MagicMock, mock_db: MagicMock
-) -> None:
-    """Weekend-only range on weekday calendar raises NoValidTimestampsError."""
-    mock_registry.get_config.return_value = _cfg(calendar=WeekdayCalendar())
-
-    # 2024-01-06 (Sat) and 2024-01-07 (Sun) — no weekday timestamps
-    with pytest.raises(NoValidTimestampsError, match="no valid calendar timestamps"):
-        build_dataset("ds", V010, datetime(2024, 1, 6), datetime(2024, 1, 7))
-
-    mock_db.get_existing_timestamps.assert_not_called()
-
-
-@patch("service.builder.db.datasets")
-@patch("service.builder.registry")
-def test_build_dataset_valid_range_all_built_does_not_raise(
-    mock_registry: MagicMock, mock_db: MagicMock
-) -> None:
-    """Valid weekday range with all timestamps already built does not raise."""
-    mock_registry.get_config.return_value = _cfg(calendar=WeekdayCalendar())
-    # 2024-01-08 (Mon) and 2024-01-09 (Tue) — both weekdays, both already built
-    mock_db.get_existing_timestamps.return_value = [
-        datetime(2024, 1, 8),
-        datetime(2024, 1, 9),
-    ]
-
-    # should not raise
-    build_dataset("ds", V010, datetime(2024, 1, 8), datetime(2024, 1, 9))
-
-
-# --- lookback tests ---
-
-
-@patch("service.builder.validator")
-@patch("service.builder.runner")
-@patch("service.builder.db.datasets")
-@patch("service.builder.registry")
-def test_build_dataset_lookback_expands_dep_build_range(
-    mock_registry: MagicMock,
-    mock_db: MagicMock,
-    mock_runner: MagicMock,
-    mock_validator: MagicMock,
-) -> None:
-    """Lookback dep build range is expanded by the lookback duration."""
-
-    def fake_get_config(name, version):
-        if name == "ds":
-            return _cfg(
-                dependencies={
-                    "dep": DependencyInfo(
-                        version=V010,
-                        lookback_subtract=timedelta(days=4),
-                    ),
-                },
-            )
-        return _cfg(name="dep")
-
-    mock_registry.get_config.side_effect = fake_get_config
-    # everything already exists so we just check build range
-    mock_db.get_existing_timestamps.return_value = [
-        datetime(2024, 1, 1),
-        datetime(2024, 1, 2),
-        datetime(2024, 1, 3),
-    ]
-
-    build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 3))
-
-    # dep's get_existing_timestamps should be called with expanded range
-    dep_call = mock_db.get_existing_timestamps.call_args_list[0]
-    # dep start should be 2024-01-01 - 5d + 1d = 2023-12-28
-    assert dep_call[0][2] == datetime(2023, 12, 28)
-    assert dep_call[0][3] == datetime(2024, 1, 3)
-
-
-@patch("service.builder.validator")
-@patch("service.builder.runner")
-@patch("service.builder.db.datasets")
-@patch("service.builder.registry")
-def test_build_dataset_lookback_fetches_range(
-    mock_registry: MagicMock,
-    mock_db: MagicMock,
-    mock_runner: MagicMock,
-    mock_validator: MagicMock,
-) -> None:
-    """With lookback, get_rows_range is used and passes dict to builder."""
-
-    def fake_get_config(name, version):
-        if name == "ds":
-            return _cfg(
-                dependencies={
-                    "dep": DependencyInfo(
-                        version=V010,
-                        lookback_subtract=timedelta(days=1),
-                    ),
-                },
-            )
-        return _cfg(name="dep")
-
-    mock_registry.get_config.side_effect = fake_get_config
-    mock_db.get_existing_timestamps.side_effect = [
-        # dep: all timestamps exist (expanded range)
-        [datetime(2024, 1, 1), datetime(2024, 1, 2), datetime(2024, 1, 3)],
-        # ds: needs to build Jan 3
-        [datetime(2024, 1, 1), datetime(2024, 1, 2)],
-    ]
-    # lookback range query returns multiple timestamps
-    range_data = {
-        datetime(2024, 1, 2): [{"val": 20}],
-        datetime(2024, 1, 3): [{"val": 30}],
-    }
-    mock_db.get_rows_range.return_value = range_data
-    mock_runner.run_builder.return_value = [{"avg": 25}]
-
-    build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 3))
-
-    # get_rows_range should be called (not get_rows_timestamps)
-    mock_db.get_rows_range.assert_called_once()
-    call_args = mock_db.get_rows_range.call_args[0]
-    assert call_args[0] == "dep"
-    # range should be [Jan 3 - 2d + 1d, Jan 3] = [Jan 2, Jan 3]
-    assert call_args[2] == datetime(2024, 1, 2)
-    assert call_args[3] == datetime(2024, 1, 3)
-
-    # verify the dict was passed to runner
-    runner_call = mock_runner.run_builder.call_args
-    passed_deps = runner_call[0][2]
-    assert passed_deps["dep"] == range_data
-
-
-@patch("service.builder.validator")
-@patch("service.builder.runner")
-@patch("service.builder.db.datasets")
-@patch("service.builder.registry")
-def test_build_dataset_no_lookback_uses_get_rows_timestamps(
-    mock_registry: MagicMock,
-    mock_db: MagicMock,
-    mock_runner: MagicMock,
-    mock_validator: MagicMock,
-) -> None:
-    """Without lookback, get_rows_timestamps is used (not get_rows_range)."""
-
-    def fake_get_config(name, version):
-        if name == "ds":
-            return _cfg(
-                dependencies={"dep": DependencyInfo(version=V010)},
-            )
-        return _cfg(name="dep")
-
-    mock_registry.get_config.side_effect = fake_get_config
-    mock_db.get_existing_timestamps.side_effect = [
-        [datetime(2024, 1, 1)],  # dep
-        [],  # ds
-    ]
-    ts = datetime(2024, 1, 1)
-    mock_db.get_rows_timestamps.return_value = {ts: [{"val": 1}]}
-    mock_runner.run_builder.return_value = [{"val": 1}]
-
-    build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 1))
-
-    mock_db.get_rows_timestamps.assert_called_once()
-    mock_db.get_rows_range.assert_not_called()
+    with pytest.raises(RuntimeError, match="build failed"):
+        build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 5))
 
 
 # --- get_data tests ---

--- a/builders/server/tests/service/test_concurrent_builds.py
+++ b/builders/server/tests/service/test_concurrent_builds.py
@@ -9,20 +9,32 @@ from service.builder import build_dataset
 from .conftest import V010, _cfg
 
 
+def _mock_both_registries(mock_sched_reg, mock_worker_reg, configs):
+    """Helper to set up both scheduler and worker registry mocks."""
+    if callable(configs):
+        mock_sched_reg.get_config.side_effect = configs
+        mock_worker_reg.get_config.side_effect = configs
+    else:
+        mock_sched_reg.get_config.return_value = configs
+        mock_worker_reg.get_config.return_value = configs
+
+
 @pytest.mark.parametrize("n_threads", [3, 5, 10, 15])
-@patch("service.builder.validator")
-@patch("service.builder.runner")
-@patch("service.builder.db.datasets")
-@patch("service.builder.registry")
+@patch("service.worker.validator")
+@patch("service.worker.runner")
+@patch("service.worker.db.datasets")
+@patch("service.worker.registry")
+@patch("service.scheduler.registry")
 def test_concurrent_builds_same_dataset_no_duplicates(
-    mock_registry: MagicMock,
+    mock_sched_reg: MagicMock,
+    mock_worker_reg: MagicMock,
     mock_db: MagicMock,
     mock_runner: MagicMock,
     mock_validator: MagicMock,
     n_threads: int,
 ) -> None:
     """N threads build same (name, version, range); rows inserted exactly once."""
-    mock_registry.get_config.return_value = _cfg()
+    _mock_both_registries(mock_sched_reg, mock_worker_reg, _cfg())
     mock_runner.run_builder.return_value = [{"val": 1}]
 
     # track how many times insert_rows is called
@@ -65,18 +77,20 @@ def test_concurrent_builds_same_dataset_no_duplicates(
     assert insert_call_count == 1
 
 
-@patch("service.builder.validator")
-@patch("service.builder.runner")
-@patch("service.builder.db.datasets")
-@patch("service.builder.registry")
+@patch("service.worker.validator")
+@patch("service.worker.runner")
+@patch("service.worker.db.datasets")
+@patch("service.worker.registry")
+@patch("service.scheduler.registry")
 def test_concurrent_builds_overlapping_ranges(
-    mock_registry: MagicMock,
+    mock_sched_reg: MagicMock,
+    mock_worker_reg: MagicMock,
     mock_db: MagicMock,
     mock_runner: MagicMock,
     mock_validator: MagicMock,
 ) -> None:
     """Two threads build overlapping ranges; each timestamp built exactly once."""
-    mock_registry.get_config.return_value = _cfg()
+    _mock_both_registries(mock_sched_reg, mock_worker_reg, _cfg())
     mock_runner.run_builder.return_value = [{"val": 1}]
 
     # track which timestamps get inserted
@@ -124,12 +138,14 @@ def test_concurrent_builds_overlapping_ranges(
         assert count == 1, f"Jan {d} inserted {count} times, expected 1"
 
 
-@patch("service.builder.validator")
-@patch("service.builder.runner")
-@patch("service.builder.db.datasets")
-@patch("service.builder.registry")
+@patch("service.worker.validator")
+@patch("service.worker.runner")
+@patch("service.worker.db.datasets")
+@patch("service.worker.registry")
+@patch("service.scheduler.registry")
 def test_concurrent_builds_shared_dependency(
-    mock_registry: MagicMock,
+    mock_sched_reg: MagicMock,
+    mock_worker_reg: MagicMock,
     mock_db: MagicMock,
     mock_runner: MagicMock,
     mock_validator: MagicMock,
@@ -146,7 +162,9 @@ def test_concurrent_builds_shared_dependency(
         ),
         "shared-dep": _cfg(name="shared-dep"),
     }
-    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+    _mock_both_registries(
+        mock_sched_reg, mock_worker_reg, lambda name, version: configs[name]
+    )
     mock_runner.run_builder.return_value = [{"val": 1}]
 
     # track inserts per dataset
@@ -189,12 +207,14 @@ def test_concurrent_builds_shared_dependency(
     assert insert_counts.get("shared-dep", 0) == 1
 
 
-@patch("service.builder.validator")
-@patch("service.builder.runner")
-@patch("service.builder.db.datasets")
-@patch("service.builder.registry")
+@patch("service.worker.validator")
+@patch("service.worker.runner")
+@patch("service.worker.db.datasets")
+@patch("service.worker.registry")
+@patch("service.scheduler.registry")
 def test_concurrent_builds_deep_dependency_chain(
-    mock_registry: MagicMock,
+    mock_sched_reg: MagicMock,
+    mock_worker_reg: MagicMock,
     mock_db: MagicMock,
     mock_runner: MagicMock,
     mock_validator: MagicMock,
@@ -211,7 +231,9 @@ def test_concurrent_builds_deep_dependency_chain(
         ),
         "ds-c": _cfg(name="ds-c"),
     }
-    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+    _mock_both_registries(
+        mock_sched_reg, mock_worker_reg, lambda name, version: configs[name]
+    )
     mock_runner.run_builder.return_value = [{"val": 1}]
 
     insert_counts: dict[str, int] = {}
@@ -257,18 +279,20 @@ def test_concurrent_builds_deep_dependency_chain(
         )
 
 
-@patch("service.builder.validator")
-@patch("service.builder.runner")
-@patch("service.builder.db.datasets")
-@patch("service.builder.registry")
+@patch("service.worker.validator")
+@patch("service.worker.runner")
+@patch("service.worker.db.datasets")
+@patch("service.worker.registry")
+@patch("service.scheduler.registry")
 def test_lock_released_on_builder_failure(
-    mock_registry: MagicMock,
+    mock_sched_reg: MagicMock,
+    mock_worker_reg: MagicMock,
     mock_db: MagicMock,
     mock_runner: MagicMock,
     mock_validator: MagicMock,
 ) -> None:
     """Builder crash releases the lock so a subsequent build can proceed."""
-    mock_registry.get_config.return_value = _cfg()
+    _mock_both_registries(mock_sched_reg, mock_worker_reg, _cfg())
     mock_db.get_existing_timestamps.return_value = []
 
     call_count = 0
@@ -282,7 +306,7 @@ def test_lock_released_on_builder_failure(
 
     mock_runner.run_builder.side_effect = fake_run_builder
 
-    # first build should fail
+    # first build should fail (orchestrator wraps worker failure in RuntimeError)
     with pytest.raises(RuntimeError, match="builder crashed"):
         build_dataset("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 1))
 
@@ -292,18 +316,20 @@ def test_lock_released_on_builder_failure(
     assert mock_runner.run_builder.call_count == 2
 
 
-@patch("service.builder.validator")
-@patch("service.builder.runner")
-@patch("service.builder.db.datasets")
-@patch("service.builder.registry")
+@patch("service.worker.validator")
+@patch("service.worker.runner")
+@patch("service.worker.db.datasets")
+@patch("service.worker.registry")
+@patch("service.scheduler.registry")
 def test_second_request_skips_after_first_completes(
-    mock_registry: MagicMock,
+    mock_sched_reg: MagicMock,
+    mock_worker_reg: MagicMock,
     mock_db: MagicMock,
     mock_runner: MagicMock,
     mock_validator: MagicMock,
 ) -> None:
     """Second request re-checks missing after lock, finds nothing, skips building."""
-    mock_registry.get_config.return_value = _cfg()
+    _mock_both_registries(mock_sched_reg, mock_worker_reg, _cfg())
     mock_runner.run_builder.return_value = [{"val": 1}]
 
     # first call sees empty, second sees data (simulating first thread's insert)

--- a/builders/server/tests/service/test_orchestrator.py
+++ b/builders/server/tests/service/test_orchestrator.py
@@ -1,0 +1,155 @@
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from runtime.config import DependencyInfo
+from service.orchestrator import run_build
+
+from .conftest import V010, _cfg
+
+JAN1 = datetime(2024, 1, 1)
+JAN5 = datetime(2024, 1, 5)
+
+
+# --- single root dataset works ---
+
+
+@patch("service.orchestrator.execute_job")
+@patch("service.scheduler.registry")
+def test_single_root(mock_registry, mock_execute) -> None:
+    """Root with no deps -> schedule + execute 1 job successfully."""
+    mock_registry.get_config.return_value = _cfg(name="root")
+    mock_execute.return_value = MagicMock(success=True)
+
+    run_build("root", V010, JAN1, JAN5)
+
+    assert mock_execute.call_count == 1
+    job = mock_execute.call_args[0][0]
+    assert job.dataset_name == "root"
+
+
+# --- level-by-level execution order ---
+
+
+@patch("service.orchestrator.execute_job")
+@patch("service.scheduler.registry")
+def test_level_order_execution(mock_registry, mock_execute) -> None:
+    """A -> B -> C: C built first, then B, then A."""
+    configs = {
+        "A": _cfg(name="A", dependencies={"B": DependencyInfo(version=V010)}),
+        "B": _cfg(name="B", dependencies={"C": DependencyInfo(version=V010)}),
+        "C": _cfg(name="C"),
+    }
+    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+    mock_execute.return_value = MagicMock(success=True)
+
+    run_build("A", V010, JAN1, JAN5)
+
+    assert mock_execute.call_count == 3
+    executed_names = [c[0][0].dataset_name for c in mock_execute.call_args_list]
+    # C at level 0, B at level 1, A at level 2
+    assert executed_names == ["C", "B", "A"]
+
+
+# --- failure at level N prevents level N+1 ---
+
+
+@patch("service.orchestrator.execute_job")
+@patch("service.scheduler.registry")
+def test_failure_stops_subsequent_levels(mock_registry, mock_execute) -> None:
+    """If B fails at level 1, A at level 2 never executes."""
+    configs = {
+        "A": _cfg(name="A", dependencies={"B": DependencyInfo(version=V010)}),
+        "B": _cfg(name="B", dependencies={"C": DependencyInfo(version=V010)}),
+        "C": _cfg(name="C"),
+    }
+    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+
+    # C succeeds, B fails
+    def mock_exec(job, cancelled):
+        if job.dataset_name == "B":
+            return MagicMock(success=False, error="B crashed")
+        return MagicMock(success=True)
+
+    mock_execute.side_effect = mock_exec
+
+    with pytest.raises(RuntimeError, match="B crashed"):
+        run_build("A", V010, JAN1, JAN5)
+
+    # only C and B were attempted, A was never reached
+    executed_names = [c[0][0].dataset_name for c in mock_execute.call_args_list]
+    assert "C" in executed_names
+    assert "B" in executed_names
+    assert "A" not in executed_names
+
+
+# --- NoValidTimestampsError propagates ---
+
+
+@patch("service.orchestrator.execute_job")
+@patch("service.scheduler.registry")
+def test_no_valid_timestamps_propagates(mock_registry, mock_execute) -> None:
+    """Worker failure with no-valid-timestamps error propagates as RuntimeError."""
+    mock_registry.get_config.return_value = _cfg(name="ds")
+    mock_execute.return_value = MagicMock(
+        success=False, error="no valid calendar timestamps"
+    )
+
+    with pytest.raises(RuntimeError, match="no valid calendar timestamps"):
+        run_build("ds", V010, JAN1, JAN5)
+
+
+# --- diamond graph executes correctly ---
+
+
+@patch("service.orchestrator.execute_job")
+@patch("service.scheduler.registry")
+def test_diamond_graph(mock_registry, mock_execute) -> None:
+    """Diamond A -> {B, C}, B -> D, C -> D: D once at level 0, {B,C} at 1, A at 2."""
+    configs = {
+        "A": _cfg(
+            name="A",
+            dependencies={
+                "B": DependencyInfo(version=V010),
+                "C": DependencyInfo(version=V010),
+            },
+        ),
+        "B": _cfg(name="B", dependencies={"D": DependencyInfo(version=V010)}),
+        "C": _cfg(name="C", dependencies={"D": DependencyInfo(version=V010)}),
+        "D": _cfg(name="D"),
+    }
+    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+    mock_execute.return_value = MagicMock(success=True)
+
+    run_build("A", V010, JAN1, JAN5)
+
+    # 4 jobs total, D appears exactly once
+    assert mock_execute.call_count == 4
+    executed_names = [c[0][0].dataset_name for c in mock_execute.call_args_list]
+    assert executed_names.count("D") == 1
+
+    # D first, A last
+    assert executed_names[0] == "D"
+    assert executed_names[-1] == "A"
+
+    # B and C in the middle (level 1, order doesn't matter)
+    middle = set(executed_names[1:3])
+    assert middle == {"B", "C"}
+
+
+# --- cancelled event is set on failure ---
+
+
+@patch("service.orchestrator.execute_job")
+@patch("service.scheduler.registry")
+def test_cancelled_event_set_on_failure(mock_registry, mock_execute) -> None:
+    """When a job fails, the cancelled event passed to execute_job is set."""
+    mock_registry.get_config.return_value = _cfg(name="ds")
+    mock_execute.return_value = MagicMock(success=False, error="boom")
+
+    with pytest.raises(RuntimeError):
+        run_build("ds", V010, JAN1, JAN5)
+
+    # verify the cancelled event passed to execute_job was set
+    cancelled = mock_execute.call_args[0][1]
+    assert cancelled.is_set()

--- a/builders/server/tests/service/test_scheduler.py
+++ b/builders/server/tests/service/test_scheduler.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 from runtime.config import DependencyInfo
-from service.scheduler import collect_graph
+from service.scheduler import collect_graph, schedule_build
 
 from .conftest import V010, _cfg
 
@@ -321,3 +321,146 @@ def test_diamond_reexpansion_propagates_to_grandchildren(mock_registry) -> None:
         datetime(2024, 1, 4),
         datetime(2024, 1, 20),
     )
+
+
+# ============================================================
+# schedule_build tests
+# ============================================================
+
+
+def _job_names_by_level(plan) -> list[set[str]]:
+    """Extract dataset names per level for easier assertions."""
+    return [{j.dataset_name for j in level} for level in plan.levels]
+
+
+@patch("service.scheduler.registry")
+def test_schedule_single_root(mock_registry) -> None:
+    """Root with no deps -> 1 level, 1 job."""
+    mock_registry.get_config.return_value = _cfg(name="root")
+
+    plan = schedule_build("root", V010, datetime(2024, 1, 1), datetime(2024, 1, 5))
+
+    assert len(plan.levels) == 1
+    assert len(plan.levels[0]) == 1
+    job = plan.levels[0][0]
+    assert job.dataset_name == "root"
+    assert job.start == datetime(2024, 1, 1)
+    assert job.end == datetime(2024, 1, 5)
+
+
+@patch("service.scheduler.registry")
+def test_schedule_linear_chain_order(mock_registry) -> None:
+    """A -> B -> C produces 3 levels: C first, A last."""
+    configs = {
+        "A": _cfg(
+            name="A",
+            dependencies={"B": DependencyInfo(version=V010)},
+        ),
+        "B": _cfg(
+            name="B",
+            dependencies={"C": DependencyInfo(version=V010)},
+        ),
+        "C": _cfg(name="C"),
+    }
+    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+
+    plan = schedule_build("A", V010, datetime(2024, 1, 1), datetime(2024, 1, 5))
+
+    names = _job_names_by_level(plan)
+    assert len(names) == 3
+    assert names[0] == {"C"}  # root, level 0
+    assert names[1] == {"B"}  # level 1
+    assert names[2] == {"A"}  # level 2, requested dataset
+
+
+@patch("service.scheduler.registry")
+def test_schedule_diamond_levels(mock_registry) -> None:
+    """Diamond produces 3 levels: D at 0, {B, C} at 1, A at 2."""
+    configs = {
+        "A": _cfg(
+            name="A",
+            dependencies={
+                "B": DependencyInfo(version=V010),
+                "C": DependencyInfo(version=V010),
+            },
+        ),
+        "B": _cfg(
+            name="B",
+            dependencies={"D": DependencyInfo(version=V010)},
+        ),
+        "C": _cfg(
+            name="C",
+            dependencies={"D": DependencyInfo(version=V010)},
+        ),
+        "D": _cfg(name="D"),
+    }
+    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+
+    plan = schedule_build("A", V010, datetime(2024, 1, 1), datetime(2024, 1, 5))
+
+    names = _job_names_by_level(plan)
+    assert len(names) == 3
+    assert names[0] == {"D"}
+    assert names[1] == {"B", "C"}
+    assert names[2] == {"A"}
+
+
+@patch("service.scheduler.registry")
+def test_schedule_lookback_ranges_in_jobs(mock_registry) -> None:
+    """Lookback-expanded ranges are reflected in the JobDescriptor start/end."""
+    configs = {
+        "parent": _cfg(
+            name="parent",
+            dependencies={
+                "dep": DependencyInfo(
+                    version=V010, lookback_subtract=timedelta(days=4)
+                ),
+            },
+        ),
+        "dep": _cfg(name="dep"),
+    }
+    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+
+    plan = schedule_build("parent", V010, datetime(2024, 1, 10), datetime(2024, 1, 20))
+
+    # level 0 = dep (expanded range), level 1 = parent
+    dep_job = plan.levels[0][0]
+    parent_job = plan.levels[1][0]
+
+    assert dep_job.dataset_name == "dep"
+    assert dep_job.start == datetime(2024, 1, 6)  # Jan 10 - 4d
+    assert dep_job.end == datetime(2024, 1, 20)
+
+    assert parent_job.dataset_name == "parent"
+    assert parent_job.start == datetime(2024, 1, 10)
+    assert parent_job.end == datetime(2024, 1, 20)
+
+
+@patch("service.scheduler.registry")
+def test_schedule_jobs_within_level_are_independent(mock_registry) -> None:
+    """Jobs within the same level have no dependency edges between them."""
+    configs = {
+        "A": _cfg(
+            name="A",
+            dependencies={
+                "B": DependencyInfo(version=V010),
+                "C": DependencyInfo(version=V010),
+            },
+        ),
+        "B": _cfg(name="B"),
+        "C": _cfg(name="C"),
+    }
+    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+
+    plan = schedule_build("A", V010, datetime(2024, 1, 1), datetime(2024, 1, 5))
+
+    # level 0 should have B and C (both roots)
+    level0_names = {j.dataset_name for j in plan.levels[0]}
+    assert level0_names == {"B", "C"}
+
+    # verify no edges between B and C in the underlying graph
+    graph = collect_graph("A", V010, datetime(2024, 1, 1), datetime(2024, 1, 5))
+    b_deps = graph.edges.get(("B", V010), set())
+    c_deps = graph.edges.get(("C", V010), set())
+    assert ("C", V010) not in b_deps
+    assert ("B", V010) not in c_deps

--- a/builders/server/tests/service/test_scheduler.py
+++ b/builders/server/tests/service/test_scheduler.py
@@ -1,0 +1,323 @@
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+from runtime.config import DependencyInfo
+from service.scheduler import collect_graph
+
+from .conftest import V010, _cfg
+
+V020 = V010  # alias for readability in multi-version tests
+
+
+# --- single root, no deps ---
+
+
+@patch("service.scheduler.registry")
+def test_single_root_no_deps(mock_registry) -> None:
+    """Root dataset with no dependencies produces 1 node, no edges."""
+    mock_registry.get_config.return_value = _cfg(name="root")
+
+    graph = collect_graph("root", V010, datetime(2024, 1, 1), datetime(2024, 1, 5))
+
+    assert len(graph.ranges) == 1
+    assert ("root", V010) in graph.ranges
+    assert graph.ranges[("root", V010)] == (datetime(2024, 1, 1), datetime(2024, 1, 5))
+    assert graph.edges == {}
+
+
+# --- linear chain ---
+
+
+@patch("service.scheduler.registry")
+def test_linear_chain(mock_registry) -> None:
+    """A -> B -> C produces 3 nodes with correct edges and identical ranges."""
+    configs = {
+        "A": _cfg(
+            name="A",
+            dependencies={"B": DependencyInfo(version=V010)},
+        ),
+        "B": _cfg(
+            name="B",
+            dependencies={"C": DependencyInfo(version=V010)},
+        ),
+        "C": _cfg(name="C"),
+    }
+    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+
+    graph = collect_graph("A", V010, datetime(2024, 1, 1), datetime(2024, 1, 5))
+
+    assert len(graph.ranges) == 3
+    for name in ["A", "B", "C"]:
+        assert (name, V010) in graph.ranges
+        assert graph.ranges[(name, V010)] == (
+            datetime(2024, 1, 1),
+            datetime(2024, 1, 5),
+        )
+
+    assert graph.edges[("A", V010)] == {("B", V010)}
+    assert graph.edges[("B", V010)] == {("C", V010)}
+    assert ("C", V010) not in graph.edges
+
+
+# --- diamond dependency ---
+
+
+@patch("service.scheduler.registry")
+def test_diamond_deduplication(mock_registry) -> None:
+    """Diamond: A -> {B, C}, B -> D, C -> D. D appears once in ranges."""
+    configs = {
+        "A": _cfg(
+            name="A",
+            dependencies={
+                "B": DependencyInfo(version=V010),
+                "C": DependencyInfo(version=V010),
+            },
+        ),
+        "B": _cfg(
+            name="B",
+            dependencies={"D": DependencyInfo(version=V010)},
+        ),
+        "C": _cfg(
+            name="C",
+            dependencies={"D": DependencyInfo(version=V010)},
+        ),
+        "D": _cfg(name="D"),
+    }
+    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+
+    graph = collect_graph("A", V010, datetime(2024, 1, 1), datetime(2024, 1, 5))
+
+    assert len(graph.ranges) == 4
+    # D appears exactly once
+    assert ("D", V010) in graph.ranges
+    assert graph.ranges[("D", V010)] == (datetime(2024, 1, 1), datetime(2024, 1, 5))
+
+    # edges
+    assert graph.edges[("A", V010)] == {("B", V010), ("C", V010)}
+    assert graph.edges[("B", V010)] == {("D", V010)}
+    assert graph.edges[("C", V010)] == {("D", V010)}
+
+
+# --- lookback expansion ---
+
+
+@patch("service.scheduler.registry")
+def test_lookback_expands_dep_range(mock_registry) -> None:
+    """Lookback on a dependency widens its build range backwards."""
+    configs = {
+        "parent": _cfg(
+            name="parent",
+            dependencies={
+                "dep": DependencyInfo(
+                    version=V010,
+                    lookback_subtract=timedelta(days=4),
+                ),
+            },
+        ),
+        "dep": _cfg(name="dep"),
+    }
+    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+
+    graph = collect_graph("parent", V010, datetime(2024, 1, 10), datetime(2024, 1, 20))
+
+    # parent range unchanged
+    assert graph.ranges[("parent", V010)] == (
+        datetime(2024, 1, 10),
+        datetime(2024, 1, 20),
+    )
+    # dep range expanded: Jan 10 - 4d = Jan 6
+    assert graph.ranges[("dep", V010)] == (
+        datetime(2024, 1, 6),
+        datetime(2024, 1, 20),
+    )
+
+
+@patch("service.scheduler.registry")
+def test_lookback_propagates_through_chain(mock_registry) -> None:
+    """Lookback expansion propagates: A (lookback=5d on B) -> B -> C.
+    C's range should be expanded by A's lookback on B."""
+    configs = {
+        "A": _cfg(
+            name="A",
+            dependencies={
+                "B": DependencyInfo(
+                    version=V010,
+                    lookback_subtract=timedelta(days=4),
+                ),
+            },
+        ),
+        "B": _cfg(
+            name="B",
+            dependencies={"C": DependencyInfo(version=V010)},
+        ),
+        "C": _cfg(name="C"),
+    }
+    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+
+    graph = collect_graph("A", V010, datetime(2024, 1, 10), datetime(2024, 1, 20))
+
+    # A: unchanged
+    assert graph.ranges[("A", V010)] == (
+        datetime(2024, 1, 10),
+        datetime(2024, 1, 20),
+    )
+    # B: expanded by A's lookback
+    assert graph.ranges[("B", V010)] == (
+        datetime(2024, 1, 6),
+        datetime(2024, 1, 20),
+    )
+    # C: inherits B's expanded range (no additional lookback)
+    assert graph.ranges[("C", V010)] == (
+        datetime(2024, 1, 6),
+        datetime(2024, 1, 20),
+    )
+
+
+# --- diamond with different lookbacks ---
+
+
+@patch("service.scheduler.registry")
+def test_diamond_different_lookbacks_union(mock_registry) -> None:
+    """Diamond where B and C both depend on D with different lookbacks.
+    D's range should be the union of both expanded ranges."""
+    configs = {
+        "A": _cfg(
+            name="A",
+            dependencies={
+                "B": DependencyInfo(version=V010),
+                "C": DependencyInfo(version=V010),
+            },
+        ),
+        "B": _cfg(
+            name="B",
+            dependencies={
+                # B needs D with 3d lookback -> dep_start = Jan 10 - 2d = Jan 8
+                "D": DependencyInfo(version=V010, lookback_subtract=timedelta(days=2)),
+            },
+        ),
+        "C": _cfg(
+            name="C",
+            dependencies={
+                # C needs D with 7d lookback -> dep_start = Jan 10 - 6d = Jan 4
+                "D": DependencyInfo(version=V010, lookback_subtract=timedelta(days=6)),
+            },
+        ),
+        "D": _cfg(name="D"),
+    }
+    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+
+    graph = collect_graph("A", V010, datetime(2024, 1, 10), datetime(2024, 1, 20))
+
+    # D's range should be union: min(Jan 8, Jan 4)=Jan 4, max(Jan 20, Jan 20)=Jan 20
+    assert graph.ranges[("D", V010)] == (
+        datetime(2024, 1, 4),
+        datetime(2024, 1, 20),
+    )
+
+
+# --- start-date clamping ---
+
+
+@patch("service.scheduler.registry")
+def test_start_date_clamping(mock_registry) -> None:
+    """Start before dataset start-date gets clamped forward."""
+    mock_registry.get_config.return_value = _cfg(
+        name="ds", start_date=datetime(2024, 1, 5)
+    )
+
+    graph = collect_graph("ds", V010, datetime(2024, 1, 1), datetime(2024, 1, 10))
+
+    # start clamped to Jan 5
+    assert graph.ranges[("ds", V010)] == (
+        datetime(2024, 1, 5),
+        datetime(2024, 1, 10),
+    )
+
+
+@patch("service.scheduler.registry")
+def test_end_before_start_date_raises(mock_registry) -> None:
+    """End before dataset start-date raises ValueError."""
+    mock_registry.get_config.return_value = _cfg(
+        name="ds", start_date=datetime(2024, 6, 1)
+    )
+
+    with pytest.raises(ValueError, match="before.*start-date"):
+        collect_graph("ds", V010, datetime(2024, 5, 1), datetime(2024, 5, 15))
+
+
+@patch("service.scheduler.registry")
+def test_lookback_clamped_by_dep_start_date(mock_registry) -> None:
+    """Lookback expansion that pushes start before dep's start-date gets clamped."""
+    configs = {
+        "parent": _cfg(
+            name="parent",
+            dependencies={
+                "dep": DependencyInfo(
+                    version=V010,
+                    lookback_subtract=timedelta(days=30),
+                ),
+            },
+        ),
+        # dep has start-date Jan 1, lookback would push to Dec 2023
+        "dep": _cfg(name="dep", start_date=datetime(2024, 1, 1)),
+    }
+    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+
+    graph = collect_graph("parent", V010, datetime(2024, 1, 10), datetime(2024, 1, 20))
+
+    # dep start clamped to its start-date, not pushed before it
+    assert graph.ranges[("dep", V010)][0] == datetime(2024, 1, 1)
+
+
+# --- diamond re-expansion propagation ---
+
+
+@patch("service.scheduler.registry")
+def test_diamond_reexpansion_propagates_to_grandchildren(mock_registry) -> None:
+    """When a diamond dep's range expands on second visit, the expansion
+    propagates to its children.
+
+    Graph: A -> {B, C}. B -> D -> E. C -> D (with lookback).
+    B is visited first, giving D range [Jan 10, Jan 20].
+    C is visited second with lookback, giving D range [Jan 4, Jan 20].
+    D's range expands, so E must also get the expanded range.
+    """
+    configs = {
+        "A": _cfg(
+            name="A",
+            dependencies={
+                "B": DependencyInfo(version=V010),
+                "C": DependencyInfo(version=V010),
+            },
+        ),
+        "B": _cfg(
+            name="B",
+            dependencies={"D": DependencyInfo(version=V010)},
+        ),
+        "C": _cfg(
+            name="C",
+            dependencies={
+                "D": DependencyInfo(version=V010, lookback_subtract=timedelta(days=6)),
+            },
+        ),
+        "D": _cfg(
+            name="D",
+            dependencies={"E": DependencyInfo(version=V010)},
+        ),
+        "E": _cfg(name="E"),
+    }
+    mock_registry.get_config.side_effect = lambda name, version: configs[name]
+
+    graph = collect_graph("A", V010, datetime(2024, 1, 10), datetime(2024, 1, 20))
+
+    # D expanded to Jan 4 via C's lookback
+    assert graph.ranges[("D", V010)] == (
+        datetime(2024, 1, 4),
+        datetime(2024, 1, 20),
+    )
+    # E must also have the expanded range from D's re-walk
+    assert graph.ranges[("E", V010)] == (
+        datetime(2024, 1, 4),
+        datetime(2024, 1, 20),
+    )

--- a/builders/server/tests/service/test_worker.py
+++ b/builders/server/tests/service/test_worker.py
@@ -1,0 +1,236 @@
+import threading
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+from runtime.config import DependencyInfo, SchemaType
+from service.models import JobDescriptor
+from service.worker import execute_job
+
+from .conftest import V010, _cfg
+
+JAN1 = datetime(2024, 1, 1)
+JAN5 = datetime(2024, 1, 5)
+
+
+def _job(
+    name: str = "ds", start: datetime = JAN1, end: datetime = JAN5
+) -> JobDescriptor:
+    return JobDescriptor(dataset_name=name, dataset_version=V010, start=start, end=end)
+
+
+def _never_cancelled() -> threading.Event:
+    return threading.Event()
+
+
+# --- all timestamps exist -> success, no insert ---
+
+
+@patch("service.worker.db.datasets")
+@patch("service.worker.registry")
+def test_all_timestamps_exist_skips_build(mock_registry, mock_db) -> None:
+    """When all timestamps already exist, no builder runs and no insert."""
+    mock_registry.get_config.return_value = _cfg(name="ds")
+    # 5 days = 5 timestamps for everyday calendar
+    mock_db.get_existing_timestamps.return_value = [
+        JAN1 + timedelta(days=i) for i in range(5)
+    ]
+
+    result = execute_job(_job(), _never_cancelled())
+
+    assert result.success is True
+    assert result.error is None
+    mock_db.insert_rows.assert_not_called()
+
+
+# --- missing timestamps built, validated, and inserted ---
+
+
+@patch("service.worker.validator")
+@patch("service.worker.runner")
+@patch("service.worker.db.datasets")
+@patch("service.worker.registry")
+def test_missing_timestamps_built_and_inserted(
+    mock_registry, mock_db, mock_runner, mock_validator
+) -> None:
+    """Missing timestamps trigger builder + validate + bulk insert."""
+    mock_registry.get_config.return_value = _cfg(
+        name="ds", schema={"price": SchemaType.INT}
+    )
+    mock_db.get_existing_timestamps.return_value = [JAN1]  # only first exists
+    mock_runner.run_builder.return_value = [{"price": 100}]
+
+    result = execute_job(_job(), _never_cancelled())
+
+    assert result.success is True
+    # builder called for each missing timestamp (Jan 2-5 = 4 calls)
+    assert mock_runner.run_builder.call_count == 4
+    # validator called for each missing timestamp
+    assert mock_validator.validate_rows.call_count == 4
+    # single bulk insert
+    mock_db.insert_rows.assert_called_once()
+    args = mock_db.insert_rows.call_args
+    assert args[0][0] == "ds"
+    assert len(args[0][2]) == 4  # 4 rows inserted
+
+
+# --- builder failure mid-range -> no rows inserted ---
+
+
+@patch("service.worker.runner")
+@patch("service.worker.db.datasets")
+@patch("service.worker.registry")
+def test_builder_failure_no_partial_insert(mock_registry, mock_db, mock_runner) -> None:
+    """If builder fails on timestamp 3 of 5, no rows are inserted."""
+    mock_registry.get_config.return_value = _cfg(name="ds")
+    mock_db.get_existing_timestamps.return_value = []  # all missing
+
+    call_count = 0
+
+    def fail_on_third(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 3:
+            raise RuntimeError("builder crashed")
+        return [{"val": 1}]
+
+    mock_runner.run_builder.side_effect = fail_on_third
+
+    result = execute_job(_job(), _never_cancelled())
+
+    assert result.success is False
+    assert result.error is not None
+    assert "builder crashed" in result.error
+    mock_db.insert_rows.assert_not_called()
+
+
+# --- cancelled event stops early ---
+
+
+@patch("service.worker.runner")
+@patch("service.worker.db.datasets")
+@patch("service.worker.registry")
+def test_cancelled_event_stops_early(mock_registry, mock_db, mock_runner) -> None:
+    """When cancelled is set, worker stops before building remaining timestamps."""
+    mock_registry.get_config.return_value = _cfg(name="ds")
+    mock_db.get_existing_timestamps.return_value = []
+    mock_runner.run_builder.return_value = [{"val": 1}]
+
+    cancelled = threading.Event()
+
+    # set cancelled after first builder call
+    def cancel_after_first(*args, **kwargs):
+        result = [{"val": 1}]
+        cancelled.set()
+        return result
+
+    mock_runner.run_builder.side_effect = cancel_after_first
+
+    result = execute_job(_job(), cancelled)
+
+    assert result.success is False
+    assert result.error is not None
+    assert "cancelled" in result.error
+    # builder ran once, then cancelled before second
+    assert mock_runner.run_builder.call_count == 1
+    mock_db.insert_rows.assert_not_called()
+
+
+# --- lookback dep data uses get_rows_range ---
+
+
+@patch("service.worker.runner")
+@patch("service.worker.db.datasets")
+@patch("service.worker.registry")
+def test_lookback_dep_uses_get_rows_range(mock_registry, mock_db, mock_runner) -> None:
+    """Dependency with lookback fetches data via get_rows_range."""
+    mock_registry.get_config.return_value = _cfg(
+        name="ds",
+        dependencies={
+            "dep": DependencyInfo(version=V010, lookback_subtract=timedelta(days=4)),
+        },
+    )
+    mock_db.get_existing_timestamps.return_value = []
+    mock_db.get_rows_range.return_value = {JAN1: [{"val": 1}]}
+    mock_runner.run_builder.return_value = [{"val": 2}]
+
+    # single day range so only one timestamp
+    result = execute_job(_job(start=JAN1, end=JAN1), _never_cancelled())
+
+    assert result.success is True
+    mock_db.get_rows_range.assert_called_once()
+    mock_db.get_rows_timestamps.assert_not_called()
+
+
+# --- no-lookback dep data uses get_rows_timestamps ---
+
+
+@patch("service.worker.runner")
+@patch("service.worker.db.datasets")
+@patch("service.worker.registry")
+def test_no_lookback_dep_uses_get_rows_timestamps(
+    mock_registry, mock_db, mock_runner
+) -> None:
+    """Dependency without lookback fetches data via get_rows_timestamps."""
+    mock_registry.get_config.return_value = _cfg(
+        name="ds",
+        dependencies={
+            "dep": DependencyInfo(version=V010),
+        },
+    )
+    mock_db.get_existing_timestamps.return_value = []
+    mock_db.get_rows_timestamps.return_value = {JAN1: [{"val": 1}]}
+    mock_runner.run_builder.return_value = [{"val": 2}]
+
+    result = execute_job(_job(start=JAN1, end=JAN1), _never_cancelled())
+
+    assert result.success is True
+    mock_db.get_rows_timestamps.assert_called_once()
+    mock_db.get_rows_range.assert_not_called()
+
+
+# --- missing dep data raises RuntimeError ---
+
+
+@patch("service.worker.db.datasets")
+@patch("service.worker.registry")
+def test_missing_dep_data_returns_failure(mock_registry, mock_db) -> None:
+    """When dependency data is missing, worker returns failure."""
+    mock_registry.get_config.return_value = _cfg(
+        name="ds",
+        dependencies={
+            "dep": DependencyInfo(version=V010),
+        },
+    )
+    mock_db.get_existing_timestamps.return_value = []
+    mock_db.get_rows_timestamps.return_value = {}  # no data
+
+    result = execute_job(_job(start=JAN1, end=JAN1), _never_cancelled())
+
+    assert result.success is False
+    assert result.error is not None
+    assert "missing data" in result.error.lower()
+    mock_db.insert_rows.assert_not_called()
+
+
+# --- no valid timestamps raises NoValidTimestampsError ---
+
+
+@patch("service.worker.db.datasets")
+@patch("service.worker.registry")
+def test_no_valid_timestamps_raises(mock_registry, mock_db) -> None:
+    """When no valid calendar timestamps exist, NoValidTimestampsError propagates."""
+    from calendars.registry import CALENDARS_MAP
+    from service.builder import NoValidTimestampsError
+
+    mock_registry.get_config.return_value = _cfg(
+        name="ds",
+        calendar=CALENDARS_MAP["weekday"],
+    )
+
+    # Saturday to Sunday
+    with pytest.raises(NoValidTimestampsError, match="no valid calendar timestamps"):
+        execute_job(
+            _job(start=datetime(2024, 1, 6), end=datetime(2024, 1, 7)),
+            _never_cancelled(),
+        )

--- a/dev-docs/SPEC-backend.md
+++ b/dev-docs/SPEC-backend.md
@@ -101,10 +101,93 @@ Each entry in `rows` contains all data dicts for that timestamp (matching the DB
     - But we must not trust that builder scripts will not crash, so each builder invocation runs in an isolated subprocess.
     - Each builder runs in its own `subprocess.Popen` process, communicating via JSON over stdin/stdout. A standalone worker script (`isolated_worker.py`) handles deserialization, builder import, and result serialization. It uses only stdlib so it works in any venv.
     - If the subprocess crashes, the main process catches the failure cleanly without going down.
-- Builders **never** have direct access to the database — all reads and writes are handled by the server. For now, this is enforced by convention. TODO: add a runtime guard to enforce this.
+- Builders **never** have direct access to the database -- all reads and writes are handled by the server. For now, this is enforced by convention. TODO: add a runtime guard to enforce this.
 - After builder scripts are run, we upload the data to the Postgres database (see below).
-- Builds are recursive: before building a dataset, the server will automatically build any dependencies that are missing data for the requested range.
+- Builds use a scheduler/worker/orchestrator architecture (see below). The scheduler computes a topological build plan, the orchestrator executes it level by level, and the worker handles building a single dataset.
 - The service is the only public-facing security boundary (auth, rate limiting, input validation).
+
+### Build architecture: scheduler / worker / orchestrator
+
+Build execution is split into three layers:
+
+1. **Scheduler** (`service/scheduler.py`): computes a topological build plan
+2. **Worker** (`service/worker.py`): executes a single build job (one dataset, one time range)
+3. **Orchestrator** (`service/orchestrator.py`): coordinates level-by-level execution of the plan
+
+The public entry point is `build_dataset()` in `service/builder.py`, which delegates to `run_build()` in the orchestrator.
+
+#### Scheduler: dependency graph and topological ordering
+
+The scheduler has two phases:
+
+**Graph collection** (`collect_graph()`): DFS walk from the root dataset through its dependencies via `registry.get_config()`. For each node `(name, version)`, it:
+- Validates `end >= start_date`, clamps `start` to `start_date`
+- Records the required `[start, end]` build range
+- Expands dependency ranges by `lookback_subtract` when applicable
+- Handles diamond dependencies by taking the union of required ranges. If a second visit widens a node's range, its subtree is re-walked so the expansion propagates to grandchildren. Since ranges only ever widen (never shrink), convergence is guaranteed for any DAG.
+
+Returns a `DependencyGraph` containing:
+- `ranges: dict[Node, tuple[datetime, datetime]]` -- required range per node
+- `edges: dict[Node, set[Node]]` -- parent -> set of dependencies
+
+**Topological scheduling** (`schedule_build()`): Kahn's algorithm (BFS-based topological sort) on the collected graph. Chosen over Tarjan's DFS-based sort because it naturally produces level-order grouping -- nodes are processed in waves by their distance from roots, which directly maps to the barrier model.
+
+Algorithm:
+1. Compute `in_degree[node]` = number of dependencies for each node
+2. Seed level 0 with all zero-in-degree nodes (roots)
+3. For each level: remove those nodes, decrement in-degrees of their dependents, collect newly zero-in-degree nodes as the next level
+4. Convert each node + range into a `JobDescriptor`, grouped by level
+
+Returns a `BuildPlan` where `levels[0]` = root datasets (build first), `levels[-1]` = the requested dataset (build last).
+
+#### Data types (`service/models.py`)
+
+```python
+@dataclass(frozen=True)
+class JobDescriptor:
+    dataset_name: str
+    dataset_version: SemVer
+    start: datetime
+    end: datetime
+
+@dataclass(frozen=True)
+class JobResult:
+    job: JobDescriptor
+    success: bool
+    error: str | None = None
+
+@dataclass
+class BuildPlan:
+    levels: list[list[JobDescriptor]]
+```
+
+`JobDescriptor` is frozen and hashable for use as dict keys. `JobResult` is lightweight -- the worker handles its own DB insert, so no need to carry rows back.
+
+#### Worker: single-job execution
+
+`execute_job(job, cancelled)` builds one dataset over one time range:
+1. Generate valid calendar timestamps via `generate_timestamps()`
+2. Acquire per-dataset lock (`get_build_lock`)
+3. Check which timestamps already exist in the DB
+4. For each missing timestamp: fetch dependency data, run builder subprocess, validate output against schema
+5. Bulk-insert all rows on success (atomicity: no partial inserts)
+6. Check `cancelled` event between timestamps for early termination
+
+The worker does NOT handle dependency graph walking or start-date clamping -- those are the scheduler's responsibility.
+
+#### Orchestrator: level-by-level execution
+
+`run_build(dataset_name, version, start, end)`:
+1. Calls `schedule_build()` to get a `BuildPlan`
+2. Iterates levels sequentially (barrier model: all level N jobs must complete before level N+1 starts)
+3. Within each level, executes jobs sequentially via `execute_job()` (MVP single worker -- future: parallelize within levels)
+4. On any job failure: sets `cancelled` event, raises `RuntimeError`
+
+#### Commit model
+
+Data is committed per-level. Each level's data is inserted to DB before the next level starts. Workers read dependency data from DB. If level N fails, levels 0 through N-1 remain committed.
+
+Within each job, atomicity is preserved: rows are accumulated in memory and bulk-inserted only if all timestamps succeed. If any timestamp fails, no rows are inserted for that job.
 
 ### Build error responses
 
@@ -124,12 +207,18 @@ builders/server/
 ├── log_config.py   # central structlog configuration
 ├── api/            # endpoint handlers using APIRouter
 │   └── routes.py
-├── service/      # build orchestration (dependency resolution, timestamp generation)
-│   └── builder.py
-├── db/           # database connection management and queries
+├── service/        # build orchestration, scheduling, and execution
+│   ├── builder.py        # public API: build_dataset(), get_data()
+│   ├── orchestrator.py   # level-by-level plan execution via run_build()
+│   ├── scheduler.py      # dependency graph collection + Kahn's algorithm
+│   ├── worker.py         # single-job execution via execute_job()
+│   ├── models.py         # JobDescriptor, JobResult, BuildPlan data types
+│   ├── timestamps.py     # generate_timestamps(), NoValidTimestampsError
+│   └── locks.py          # per-dataset threading.Lock registry
+├── db/             # database connection management and queries
 │   ├── connection.py
 │   └── datasets.py
-├── runtime/      # config loading, subprocess isolation, schema validation, venv management
+├── runtime/        # config loading, subprocess isolation, schema validation, venv management
 │   ├── config.py
 │   ├── registry.py         # startup preload + in-memory config registry
 │   ├── isolated_worker.py  # standalone worker script (stdlib-only, runs in builder subprocesses)
@@ -138,10 +227,10 @@ builders/server/
 │   ├── serialization.py    # JSON serialization for subprocess IPC
 │   ├── validator.py
 │   └── venv_management.py  # per-builder venv creation and caching
-├── utils/        # shared utilities
+├── utils/          # shared utilities
 │   ├── retry.py            # generic retry with exponential backoff
 │   └── semver.py
-└── tests/        # mirrors the layer structure
+└── tests/          # mirrors the layer structure
     ├── api/
     ├── service/
     ├── db/
@@ -165,7 +254,9 @@ The server uses `structlog` for structured logging. Configuration lives in `log_
 
 **What is logged**:
 - `api/routes.py`: build failures (exception)
-- `service/builder.py`: start-date clamping (warning), skipped builds (info), build progress (info), insert counts (info)
+- `service/scheduler.py`: start-date clamping (warning)
+- `service/orchestrator.py`: build plan summary (info), level start/complete (info)
+- `service/worker.py`: skipped builds (info), build progress (info), insert counts (info)
 - `db/connection.py`: new connections (debug)
 - `db/datasets.py`: query execution (debug), rows inserted (info)
 - `runtime/runner.py`: subprocess start/complete (info), stderr output (warning), timeouts and crashes (error)
@@ -273,24 +364,25 @@ The `start-date` field is required and validated when loading the config.
 
 ### Atomicity
 
-Builds are atomic at the request level. If any single timestamp in the requested range fails to build, no data from that request is committed to the database — not even the timestamps that succeeded. This is enforced by batching all inserts for the range into a single database transaction and rolling back on any failure.
+Builds are atomic at the per-job level. Each job (one dataset, one time range) accumulates rows in memory and bulk-inserts only if all timestamps succeed. If any timestamp fails, no rows are inserted for that job.
+
+Data is committed per-level: all jobs in level N insert before level N+1 starts. If a job in level N fails, levels 0 through N-1 remain committed.
 
 ### Build concurrency
 
 The service runs a single uvicorn worker. FastAPI dispatches sync endpoint handlers to a thread pool, so concurrent requests for the same dataset can race between the "check what's missing" DB read and the "insert rows" DB write, producing duplicate rows.
 
-**Per-dataset locking**: a `threading.Lock` per `(dataset_name, dataset_version)` pair serializes the critical section of `_build_recursive` (steps: check existing timestamps, compute missing, build, validate, insert). Different datasets build concurrently; the same dataset serializes. Locks are created lazily and stored in a module-level registry (`service/locks.py`).
+**Per-dataset locking**: a `threading.Lock` per `(dataset_name, dataset_version)` pair serializes the critical section of `execute_job()` in the worker (steps: check existing timestamps, compute missing, build, validate, insert). Different datasets build concurrently; the same dataset serializes. Locks are created lazily and stored in a module-level registry (`service/locks.py`).
 
-**Lock scope in `_build_recursive`**:
-1. Load config, clamp start date, build dependencies recursively (all **outside** the lock)
-2. Generate valid timestamps (outside the lock, deterministic)
-3. **Acquire lock**
-4. Check existing timestamps in DB, compute missing, build each missing timestamp, validate + insert atomically
-5. **Release lock**
+**Lock scope in `execute_job()`**:
+1. Generate valid timestamps (outside the lock, deterministic)
+2. **Acquire lock**
+3. Check existing timestamps in DB, compute missing, build each missing timestamp, validate + insert atomically
+4. **Release lock**
 
-Dependencies are built before the parent's lock is acquired, so each dataset only holds its own lock during its own build phase. This minimizes lock hold time and avoids unnecessary serialization of the dependency tree.
+The scheduler and orchestrator run outside the lock. Each dataset only holds its own lock during its own build phase. This minimizes lock hold time and avoids unnecessary serialization of the dependency tree.
 
-**Deadlock safety**: requires the dependency graph to be acyclic. A cycle (X -> Y -> X) would deadlock because a thread building X acquires `lock(X)`, recurses into Y, acquires `lock(Y)`, recurses back into X, and blocks on `lock(X)`. Currently `validate_dependency_graph` does not detect cycles. Cycle detection is a follow-up.
+**Deadlock safety**: the dependency graph is validated as acyclic at startup by `registry.load_all_configs()`. Since the orchestrator executes levels sequentially (dependencies before dependents), lock ordering follows the topological sort and cannot deadlock.
 
 **Scaling assumption**: this design assumes a single uvicorn worker (single process). Multi-worker deployments would require Postgres advisory locks or a similar distributed locking mechanism.
 
@@ -527,7 +619,7 @@ All calendars are registered in `CALENDARS_MAP` (a `dict[str, Calendar]`) in `bu
 
 ### Integration with timestamp generation
 
-`generate_timestamps()` in `service/builder.py` accepts an optional `Calendar`. When provided, each candidate timestamp is checked via `calendar.is_open()` and excluded if not open. `_build_recursive()` passes `cfg.calendar` automatically.
+`generate_timestamps()` in `service/timestamps.py` accepts a `Calendar`. Each candidate timestamp is checked via `calendar.is_open()` and excluded if not open. The worker passes `cfg.calendar` automatically when building each job.
 
 ### Config integration
 


### PR DESCRIPTION
Updates SPEC-backend.md to document the new scheduler/worker/orchestrator build architecture.

## What changed

- New "Build architecture: scheduler / worker / orchestrator" section documenting:
  - Scheduler: DFS graph collection + Kahn's algorithm for topological ordering
  - Worker: single-job execution with per-dataset locking and atomicity
  - Orchestrator: level-by-level plan execution with barrier model
  - Data types: \`JobDescriptor\`, \`JobResult\`, \`BuildPlan\`
  - Commit-per-level model
- Updated directory layout to include new service modules (\`scheduler.py\`, \`worker.py\`, \`orchestrator.py\`, \`models.py\`, \`timestamps.py\`, \`locks.py\`)
- Updated atomicity section: per-job atomicity with per-level commit
- Updated build concurrency section: lock scope now in \`execute_job()\`, deadlock safety guaranteed by startup DAG validation + topological execution order
- Updated logging section: split across scheduler, orchestrator, worker
- Updated calendar integration: \`generate_timestamps()\` now in \`service/timestamps.py\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)