### PR TITLE
fix: let NoValidTimestampsError propagate from worker for 422 response

### DIFF
--- a/builders/server/service/worker.py
+++ b/builders/server/service/worker.py
@@ -58,6 +58,9 @@ def execute_job(
     try:
         _execute(job, cancelled)
         return JobResult(job=job, success=True)
+    except NoValidTimestampsError:
+        # let NoValidTimestampsError propagate so routes.py can return 422
+        raise
     except Exception as exc:
         return JobResult(job=job, success=False, error=str(exc))
 

--- a/builders/server/tests/service/test_worker.py
+++ b/builders/server/tests/service/test_worker.py
@@ -2,6 +2,7 @@ import threading
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
+import pytest
 from runtime.config import DependencyInfo, SchemaType
 from service.models import JobDescriptor
 from service.worker import execute_job
@@ -217,10 +218,10 @@ def test_missing_dep_data_returns_failure(mock_registry, mock_db) -> None:
 
 @patch("service.worker.db.datasets")
 @patch("service.worker.registry")
-def test_no_valid_timestamps_returns_failure(mock_registry, mock_db) -> None:
-    """When no valid calendar timestamps exist, worker returns failure."""
-    # use a calendar that rejects all days -- weekday calendar with a weekend range
+def test_no_valid_timestamps_raises(mock_registry, mock_db) -> None:
+    """When no valid calendar timestamps exist, NoValidTimestampsError propagates."""
     from calendars.registry import CALENDARS_MAP
+    from service.timestamps import NoValidTimestampsError
 
     mock_registry.get_config.return_value = _cfg(
         name="ds",
@@ -228,11 +229,8 @@ def test_no_valid_timestamps_returns_failure(mock_registry, mock_db) -> None:
     )
 
     # Saturday to Sunday
-    result = execute_job(
-        _job(start=datetime(2024, 1, 6), end=datetime(2024, 1, 7)),
-        _never_cancelled(),
-    )
-
-    assert result.success is False
-    assert result.error is not None
-    assert "no valid calendar timestamps" in result.error.lower()
+    with pytest.raises(NoValidTimestampsError, match="no valid calendar timestamps"):
+        execute_job(
+            _job(start=datetime(2024, 1, 6), end=datetime(2024, 1, 7)),
+            _never_cancelled(),
+        )


### PR DESCRIPTION
Fixes integration test \`test_weekend_only_range\` returning 500 instead of 422.

## What changed

- \`execute_job()\` in \`service/worker.py\` now re-raises \`NoValidTimestampsError\` instead of catching it into a \`JobResult\`
- Updated \`test_no_valid_timestamps_raises\` to expect the exception to propagate via \`pytest.raises\`

## Why

The orchestrator was wrapping \`NoValidTimestampsError\` in \`RuntimeError\`, so \`routes.py\` never saw the original exception type and returned 500 instead of 422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)