### PR TITLE
fix: validate_rows now raises a ValidationError for non-list inputs

### DIFF
--- a/builders/server/runtime/validator.py
+++ b/builders/server/runtime/validator.py
@@ -25,5 +25,8 @@ def validate(data: dict, schema: dict[str, SchemaType]) -> None:
 
 def validate_rows(data_list: list[dict], schema: dict[str, SchemaType]) -> None:
     """Validate each dict in a list against the declared schema."""
-    for data in data_list:
-        validate(data, schema)
+    if type(data_list) is not list:
+        raise ValidationError(f"Data received is of type: '{type(data_list).__name__}', however a list is expected")
+    else:
+        for data in data_list:
+            validate(data, schema)


### PR DESCRIPTION
I identified what the actual problem was, which was that the validate_rows function assumes that the data_list type is always a list, but never checked so when it wasn't the function wouldn't raise a ValidationError. The fix that I implemented was just adding a type check at the top of the function. If the type of data_list isn't a list the function now raises a validation error, if it is a list then it will continue like normal. I chose to use type() over isinstance, because the types we are checking for (None and dict) are not subclasses of list, so both will have the same behaviour and type() is a little clearer on the intent.