### PR TITLE
ci: add merge_group trigger to all required-check workflows

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -14,6 +14,8 @@ on:
       - 'pyproject.toml'
       - 'uv.lock'
       - '.github/workflows/backend-ci.yml'
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   backend-lint:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -12,6 +12,8 @@ on:
       - 'frontend/**'
       - '.pre-commit-config.yaml'
       - '.github/workflows/frontend-ci.yml'
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   frontend-precommit:


### PR DESCRIPTION
adds `merge_group` trigger to both CI workflows so GitHub's merge queue can run checks on temporary queue branches (`gh-readonly-queue/...`). without this, queued PRs stall indefinitely with no error.

path filters are intentionally omitted from the `merge_group` trigger — queue branches won't match path patterns, so omitting them ensures CI always runs for queued PRs.