### PR TITLE
ci: add git-town stack visualization action

### DIFF
--- a/.github/workflows/git-town-stack.yml
+++ b/.github/workflows/git-town-stack.yml
@@ -1,0 +1,24 @@
+name: Git Town Stack
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  display-stack:
+    name: Display the branch stack
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: git-town/action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          skip-single-stacks: true
+          location: comment


### PR DESCRIPTION
adds `git-town/action` to post a stack graph as a bot comment on every PR in a stack. gives graphite-style stack visibility without any paid tooling.

config choices:
- `location: comment` — stack graph stays out of the PR body
- `skip-single-stacks: true` — no comment noise on solo PRs
- `branches: ['**']` — triggers on PRs targeting any branch, required for stacked PRs where the target is a feature branch rather than main