### PR TITLE
docs: document subprocess_worker as single blocking worker

### DIFF
--- a/builders/server/workers/subprocess_worker.py
+++ b/builders/server/workers/subprocess_worker.py
@@ -12,6 +12,11 @@
 #                                                                         #
 #  Reason: the builder venv will not have server packages installed, so    #
 #  any non-stdlib import will fail at runtime.                             #
+#                                                                         #
+#  Design note: currently there is a single worker subprocess per build   #
+#  timestamp. Execution is blocking; the orchestrator waits for each      #
+#  subprocess to complete before spawning the next. Future work may       #
+#  parallelize within a dependency level.                                 #
 ###########################################################################
 """
 


### PR DESCRIPTION
## What changed

Added a design note to the module docstring in `workers/subprocess_worker.py` clarifying that there is currently a single worker subprocess per build timestamp and that execution is blocking.

## Why

The file was renamed from `isolated_worker` to `subprocess_worker`, which no longer conveys the single/blocking nature of the current design. A docstring note captures this intent without encoding it in the filename (which would become a misnomer if parallelism is added later).

## Benefit

Future readers understand the current design constraints and where future parallelism work would plug in.